### PR TITLE
Add Cloudlinux into the list of distributions to build data packages for

### DIFF
--- a/leapp-data.spec
+++ b/leapp-data.spec
@@ -1,5 +1,5 @@
-%define dist_list almalinux centos eurolinux oraclelinux rocky
-%define conflict_dists() %(for i in almalinux centos eurolinux oraclelinux rocky; do if [ "${i}" != "%{dist_name}" ]; then echo -n "leapp-data-${i} "; fi; done)
+%define dist_list almalinux centos eurolinux oraclelinux rocky cloudlinux
+%define conflict_dists() %(for i in almalinux centos eurolinux oraclelinux rocky cloudlinux; do if [ "${i}" != "%{dist_name}" ]; then echo -n "leapp-data-${i} "; fi; done)
 
 Name:		leapp-data-%{dist_name}
 Version:	0.2


### PR DESCRIPTION
Data files for CloudLinux distributions were present but weren't used while building the leapp-data-* packages. The .spec file was missing a matching entry in the distribution list.