### PR TITLE
Add CL-EasyApache4 to list of CL repositories

### DIFF
--- a/files/cloudlinux/leapp_upgrade_repositories.repo.el8
+++ b/files/cloudlinux/leapp_upgrade_repositories.repo.el8
@@ -82,3 +82,17 @@ mirrorlist=https://mirrors.almalinux.org/mirrorlist/8.6/powertools
 enabled=1
 gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-AlmaLinux
+
+[cl8-ea4]
+name=CloudLinux 8 EasyApache4
+baseurl=https://repo.cloudlinux.com/cloudlinux/EA4/8/updates/$basearch/
+enabled=1
+gpgcheck=1
+gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CloudLinux
+
+[cl8-ea4-testing]
+name=CloudLinux 8 EasyApache4 - testing
+baseurl=https://repo.cloudlinux.com/cloudlinux/EA4/8/updates-testing/$basearch/
+gpgcheck=1
+enabled=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CloudLinux

--- a/files/cloudlinux/repomap.json.el8
+++ b/files/cloudlinux/repomap.json.el8
@@ -154,7 +154,7 @@
                     "major_version": "7",
                     "repo_type": "rpm",
                     "arch": "x86_64",
-                    "channel": "ga"
+                    "channel": "beta"
                 }
             ]
         },

--- a/files/cloudlinux/repomap.json.el8
+++ b/files/cloudlinux/repomap.json.el8
@@ -45,6 +45,18 @@
                 {
                     "source": "extras",
                     "target": ["almalinux8-extras"]
+                },
+                {
+                    "source": "cl-ea4",
+                    "target": [
+                        "cl8-ea4"
+                    ]
+                },
+                {
+                    "source": "cl-ea4-testing",
+                    "target": [
+                        "cl8-ea4-testing"
+                    ]
                 }
             ]
         }
@@ -107,6 +119,54 @@
                     "repo_type": "rpm",
                     "arch": "x86_64",
                     "channel": "ga"
+                }
+            ]
+        },
+        {
+            "pesid": "cl-ea4",
+            "entries": [
+                {
+                    "repoid": "cl-ea4",
+                    "major_version": "7",
+                    "repo_type": "rpm",
+                    "arch": "x86_64",
+                    "channel": "ga"
+                }
+            ]
+        },
+        {
+            "pesid": "cl8-ea4",
+            "entries": [
+                {
+                    "repoid": "cl8-ea4",
+                    "major_version": "8",
+                    "repo_type": "rpm",
+                    "arch": "x86_64",
+                    "channel": "ga"
+                }
+            ]
+        },
+        {
+            "pesid": "cl-ea4-testing",
+            "entries": [
+                {
+                    "repoid": "cl-ea4-testing",
+                    "major_version": "7",
+                    "repo_type": "rpm",
+                    "arch": "x86_64",
+                    "channel": "ga"
+                }
+            ]
+        },
+        {
+            "pesid": "cl8-ea4-testing",
+            "entries": [
+                {
+                    "repoid": "cl8-ea4-testing",
+                    "major_version": "8",
+                    "repo_type": "rpm",
+                    "arch": "x86_64",
+                    "channel": "beta"
                 }
             ]
         },


### PR DESCRIPTION
CloudLinux repodata files were missing the cl-ea4 repositories.