### PR TITLE
Add mappings to CloudLinux and Imunify360 repository data

### DIFF
--- a/files/cloudlinux/pes-events.json
+++ b/files/cloudlinux/pes-events.json
@@ -69078,11 +69078,6 @@
           },
           {
             "module_stream": null,
-            "name": "kernel-uek",
-            "repository": "ol8-uek"
-          },
-          {
-            "module_stream": null,
             "name": "kernel-core",
             "repository": "almalinux8-baseos"
           },

--- a/files/cloudlinux/repomap.json.el8
+++ b/files/cloudlinux/repomap.json.el8
@@ -90,6 +90,18 @@
             ]
         },
         {
+            "pesid": "cloudlinux-extras",
+            "entries": [
+                {
+                    "major_version": "7",
+                    "repo_type": "rpm",
+                    "repoid": "cloudlinux-extras",
+                    "arch": "x86_64",
+                    "channel": "ga"
+                }
+            ]
+        },
+        {
             "pesid": "cloudlinux8-baseos",
             "entries": [
                 {

--- a/files/cloudlinux/vendors.d/cloudlinux_testing.repo
+++ b/files/cloudlinux/vendors.d/cloudlinux_testing.repo
@@ -6,7 +6,7 @@ enabled = 1
 gpgcheck = 1
 gpgkey = file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CloudLinux
 
-[cl-ea4-testing]
+[cl8-ea4-testing]
 name=CloudLinux 8 EasyApache4 - testing
 baseurl=https://repo.cloudlinux.com/cloudlinux/EA4/8/updates-testing/$basearch/
 gpgcheck=1

--- a/leapp-data.spec
+++ b/leapp-data.spec
@@ -26,10 +26,10 @@ Conflicts: %{conflict_dists}
 
 %install
 mkdir -p %{buildroot}%{_sysconfdir}/leapp/files/vendors.d
-install -t %{buildroot}%{_sysconfdir}/leapp/files files/%{dist_name}/*
 %if 0%{?rhel} < 8
 install -t %{buildroot}%{_sysconfdir}/leapp/files/vendors.d vendors.d/*
 %endif
+install -t %{buildroot}%{_sysconfdir}/leapp/files files/%{dist_name}/*
 
 %if 0%{?rhel} == 7
 mv -f %{buildroot}%{_sysconfdir}/leapp/files/leapp_upgrade_repositories.repo.el8 \

--- a/leapp-data.spec
+++ b/leapp-data.spec
@@ -26,10 +26,10 @@ Conflicts: %{conflict_dists}
 
 %install
 mkdir -p %{buildroot}%{_sysconfdir}/leapp/files/vendors.d
+install -t %{buildroot}%{_sysconfdir}/leapp/files files/%{dist_name}/*
 %if 0%{?rhel} < 8
 install -t %{buildroot}%{_sysconfdir}/leapp/files/vendors.d vendors.d/*
 %endif
-install -t %{buildroot}%{_sysconfdir}/leapp/files files/%{dist_name}/*
 
 %if 0%{?rhel} == 7
 mv -f %{buildroot}%{_sysconfdir}/leapp/files/leapp_upgrade_repositories.repo.el8 \

--- a/vendors.d/imunify_map.json
+++ b/vendors.d/imunify_map.json
@@ -13,6 +13,14 @@
                 {
                     "source": "cloudlinux-imunify360",
                     "target": ["cloudlinux8-imunify360"]
+                },
+                {
+                    "source": "imunify360-testing",
+                    "target": ["cloudlinux8-imunify360-testing"]
+                },
+                {
+                    "source": "cloudlinux-imunify360-testing",
+                    "target": ["cloudlinux8-imunify360-testing"]
                 }
             ]
         }
@@ -51,6 +59,42 @@
                     "repo_type": "rpm",
                     "arch": "x86_64",
                     "channel": "ga"
+                }
+            ]
+        },
+        {
+            "pesid": "imunify360-testing",
+            "entries": [
+                {
+                    "repoid": "imunify360-testing",
+                    "major_version": "7",
+                    "repo_type": "rpm",
+                    "arch": "x86_64",
+                    "channel": "beta"
+                }
+            ]
+        },
+        {
+            "pesid": "cloudlinux-imunify360-testing",
+            "entries": [
+                {
+                    "repoid": "cloudlinux-imunify360-testing",
+                    "major_version": "7",
+                    "repo_type": "rpm",
+                    "arch": "x86_64",
+                    "channel": "beta"
+                }
+            ]
+        },
+        {
+            "pesid": "cloudlinux8-imunify360-testing",
+            "entries": [
+                {
+                    "repoid": "cloudlinux8-imunify360-testing",
+                    "major_version": "8",
+                    "repo_type": "rpm",
+                    "arch": "x86_64",
+                    "channel": "beta"
                 }
             ]
         }


### PR DESCRIPTION
Some mappings that could be encountered on CL systems or ones with Imunify have been missing from the configuration.
This change adds them into the corresponding files.