### PR TITLE
Make per-target OS vendor files take priority over common ones

### DIFF
--- a/leapp-data.spec
+++ b/leapp-data.spec
@@ -26,10 +26,10 @@ Conflicts: %{conflict_dists}
 
 %install
 mkdir -p %{buildroot}%{_sysconfdir}/leapp/files/vendors.d
-install -t %{buildroot}%{_sysconfdir}/leapp/files files/%{dist_name}/*
 %if 0%{?rhel} < 8
 install -t %{buildroot}%{_sysconfdir}/leapp/files/vendors.d vendors.d/*
 %endif
+install -t %{buildroot}%{_sysconfdir}/leapp/files files/%{dist_name}/*
 
 %if 0%{?rhel} == 7
 mv -f %{buildroot}%{_sysconfdir}/leapp/files/leapp_upgrade_repositories.repo.el8 \


### PR DESCRIPTION
At the moment, any commonly available vendor files will override vendor files specific for the target OS.
Logically, this behaviour should be reversed, with per-OS configuration files having priority over common ones for better granularity.