### PR TITLE
Provide vendor for WP Toolkit software

### DIFF
--- a/vendors.d/wp-toolkit.repo
+++ b/vendors.d/wp-toolkit.repo
@@ -1,0 +1,11 @@
+[wp-toolkit-cpanel-el8]
+name=WordPress Toolkit for cPanel
+baseurl=https://wp-toolkit.plesk.com/cPanel/CentOS-8-x86_64/$wptkversion/wp-toolkit/
+enabled=1
+gpgcheck=1
+
+[wp-toolkit-thirdparties-el8]
+name=WordPress Toolkit third parties
+baseurl=https://wp-toolkit.plesk.com/cPanel/CentOS-8-x86_64/$wptkversion/thirdparty/
+enabled=1
+gpgcheck=1

--- a/vendors.d/wp-toolkit.sigs
+++ b/vendors.d/wp-toolkit.sigs
@@ -1,0 +1,2 @@
+bd11a6aa914bdf7e
+ba338aa6d9170f80

--- a/vendors.d/wp-toolkit_map.json
+++ b/vendors.d/wp-toolkit_map.json
@@ -1,0 +1,69 @@
+{
+	"version_format" : "1.0.0",
+	"mapping" : [
+		{
+			"source_major_version" : "7",
+			"target_major_version" : "8",
+			"entries" : [
+				{
+					"source" : "wp-toolkit-cpanel-el7",
+					"target" : [ "wp-toolkit-cpanel-el8" ]
+				},
+				{
+					"source" : "wp-toolkit-thirdparties-el7",
+					"target" : [ "wp-toolkit-thirdparties-el8" ]
+				}
+			]
+		}
+	],
+	"repositories" : [
+		{
+			"pesid" : "wp-toolkit-cpanel-el7",
+			"entries" : [
+				{
+					"major_version" : "7",
+					"repo_type" : "rpm",
+					"repoid" : "wp-toolkit-cpanel",
+					"arch" : "x86_64",
+					"channel" : "ga"
+				}
+			]
+		},
+		{
+			"pesid" : "wp-toolkit-cpanel-el8",
+			"entries" : [
+				{
+					"major_version" : "8",
+					"repo_type" : "rpm",
+					"repoid" : "wp-toolkit-cpanel-el8",
+					"arch" : "x86_64",
+					"channel" : "ga"
+				}
+			]
+		},
+		{
+			"pesid" : "wp-toolkit-thirdparties-el7",
+			"entries" : [
+				{
+					"major_version" : "7",
+					"repo_type" : "rpm",
+					"repoid" : "wp-toolkit-thirdparties",
+					"arch" : "x86_64",
+					"channel" : "ga"
+				}
+			]
+		},
+		{
+			"pesid" : "wp-toolkit-thirdparties-el8",
+			"entries" : [
+				{
+					"major_version" : "8",
+					"repo_type" : "rpm",
+					"repoid" : "wp-toolkit-thirdparties-el8",
+					"arch" : "x86_64",
+					"channel" : "ga"
+				}
+			]
+		}
+	]
+}

--- a/vendors.d/wp-toolkit_pes.json
+++ b/vendors.d/wp-toolkit_pes.json
@@ -1,0 +1,79 @@
+{
+	"packageinfo" : [
+		{
+			"action" : 8,
+			"arches" : [ "x86_64" ],
+			"id" : 9001,
+			"initial_release": {
+				"major_version": 7,
+				"minor_version": 7,
+				"os_name": "CentOS"
+			},
+			"release": {
+				"major_version": 8,
+				"minor_version": 0,
+				"os_name": "AlmaLinux"
+			},
+			"in_packageset" : {
+				"packages" : [
+					{
+						"module_stream" : null,
+						"name" : "wp-toolkit-cpanel",
+						"repository" : "wp-toolkit-cpanel-el8"
+					}
+				],
+				"set_id" : 1
+			}
+		},
+		{
+			"action": 1,
+			"arches" : [ "x86_64" ],
+			"id" : 9002,
+			"initial_release": {
+				"major_version": 7,
+				"minor_version": 7,
+				"os_name": "CentOS"
+			},
+			"release": {
+				"major_version": 8,
+				"minor_version": 0,
+				"os_name": "AlmaLinux"
+			},
+			"in_packageset" : {
+				"packages" : [
+					{
+						"name" : "plesk-libboost-chrono1.65",
+						"repository": "wp-toolkit-thirdparties-el7",
+						"module_stream" : null
+					}
+				],
+				"set_id" : 2
+			}
+		},
+		{
+			"action": 1,
+			"arches" : [ "x86_64" ],
+			"id" : 9003,
+			"initial_release": {
+				"major_version": 7,
+				"minor_version": 7,
+				"os_name": "CentOS"
+			},
+			"release": {
+				"major_version": 8,
+				"minor_version": 0,
+				"os_name": "AlmaLinux"
+			},
+			"in_packageset" : {
+				"packages" : [
+					{
+						"name" : "plesk-libboost-log1.65",
+						"repository": "wp-toolkit-thirdparties-el7",
+						"module_stream" : null
+					}
+				],
+				"set_id" : 3
+			}
+		}
+	]
+}


### PR DESCRIPTION
Provide a PES vendor to upgrade the WP Toolkit software package.

Due to pecularities with the way the WP Toolkit repository is structured and operated, a DNF variable is needed in order for the .repo file provided here to function. That and other miscellaneous fixups are handled by the leapp repository submitted as AlmaLinux/leapp-repository#72.