### PR TITLE
Add per-distro leapp.conf packaging

### DIFF
--- a/files/cloudlinux/leapp.conf
+++ b/files/cloudlinux/leapp.conf
@@ -1,0 +1,8 @@
+[repositories]
+repo_path=/etc/leapp/repos.d/
+
+[database]
+path=/var/lib/leapp/leapp.db
+
+[sentry]
+dsn=https://0386afd87f3744debeec61a60cbf6961@cl.sentry.cloudlinux.com/31

--- a/files/cloudlinux/leapp.conf
+++ b/files/cloudlinux/leapp.conf
@@ -5,4 +5,4 @@ repo_path=/etc/leapp/repos.d/
 path=/var/lib/leapp/leapp.db
 
 [sentry]
-dsn=https://0386afd87f3744debeec61a60cbf6961@cl.sentry.cloudlinux.com/31
+dsn=https://0386afd87f3744debeec61a60cbf6961:b149477239984bd38f4637561cf767bf@cl.sentry.cloudlinux.com/31

--- a/leapp-data.spec
+++ b/leapp-data.spec
@@ -3,7 +3,7 @@
 
 Name:		leapp-data-%{dist_name}
 Version:	0.2
-Release:	3%{?dist}
+Release:	4%{?dist}
 Summary:	data for migrating tool
 Group:		Applications/Databases
 License:	ASL 2.0
@@ -47,7 +47,7 @@ cp -rf files/%{dist_name}/* %{buildroot}%{_sysconfdir}/leapp/files/
 %endif
 
 %global dist_leapp_conf %( if [ -f files/%{dist_name}/leapp.conf ]; then echo "1" ; else echo "0"; fi )
-if %dist_leapp_conf
+%if %dist_leapp_conf
 	cp -f files/%{dist_name}/leapp.conf %{buildroot}%{_sysconfdir}/leapp/leapp.conf
 %endif
 
@@ -55,12 +55,15 @@ if %dist_leapp_conf
 %files
 %doc LICENSE NOTICE README.md
 %{_sysconfdir}/leapp/files/*
-if %dist_leapp_conf
+%if %dist_leapp_conf
 	%{_sysconfdir}/leapp/leapp.conf
 %endif
 
 
 %changelog
+* Thu May 11 2023 Roman Prilipskii <rprilpskii@cloudlinux.com> - 0.2-4
+- Add the option to provide separate leapp.conf files for different distributions
+
 * Mon Mar 27 2023 Andrew Lukoshko <alukoshko@almalinux.org> - 0.2-3
 - Add 8 to 9 migration support for Rocky Linux, EuroLinux, CentOS Stream
 

--- a/leapp-data.spec
+++ b/leapp-data.spec
@@ -27,24 +27,27 @@ Conflicts: %{conflict_dists}
 %install
 mkdir -p %{buildroot}%{_sysconfdir}/leapp/files/vendors.d
 %if 0%{?rhel} < 8
-cp -f vendors.d/* %{buildroot}%{_sysconfdir}/leapp/files/vendors.d/
+      cp -f vendors.d/* %{buildroot}%{_sysconfdir}/leapp/files/vendors.d/
 %endif
 cp -rf files/%{dist_name}/* %{buildroot}%{_sysconfdir}/leapp/files/
 
 %if 0%{?rhel} == 7
-mv -f %{buildroot}%{_sysconfdir}/leapp/files/leapp_upgrade_repositories.repo.el8 \
-      %{buildroot}%{_sysconfdir}/leapp/files/leapp_upgrade_repositories.repo
-mv -f %{buildroot}%{_sysconfdir}/leapp/files/repomap.json.el8 \
-      %{buildroot}%{_sysconfdir}/leapp/files/repomap.json
-rm -f %{buildroot}%{_sysconfdir}/leapp/files/*.el9
+      mv -f %{buildroot}%{_sysconfdir}/leapp/files/leapp_upgrade_repositories.repo.el8 \
+            %{buildroot}%{_sysconfdir}/leapp/files/leapp_upgrade_repositories.repo
+      mv -f %{buildroot}%{_sysconfdir}/leapp/files/repomap.json.el8 \
+            %{buildroot}%{_sysconfdir}/leapp/files/repomap.json
+      rm -f %{buildroot}%{_sysconfdir}/leapp/files/*.el9
 %endif
 %if 0%{?rhel} == 8
-mv -f %{buildroot}%{_sysconfdir}/leapp/files/leapp_upgrade_repositories.repo.el9 \
-      %{buildroot}%{_sysconfdir}/leapp/files/leapp_upgrade_repositories.repo
-mv -f %{buildroot}%{_sysconfdir}/leapp/files/repomap.json.el9 \
-      %{buildroot}%{_sysconfdir}/leapp/files/repomap.json
-rm -f %{buildroot}%{_sysconfdir}/leapp/files/*.el8
+      mv -f %{buildroot}%{_sysconfdir}/leapp/files/leapp_upgrade_repositories.repo.el9 \
+            %{buildroot}%{_sysconfdir}/leapp/files/leapp_upgrade_repositories.repo
+      mv -f %{buildroot}%{_sysconfdir}/leapp/files/repomap.json.el9 \
+            %{buildroot}%{_sysconfdir}/leapp/files/repomap.json
+      rm -f %{buildroot}%{_sysconfdir}/leapp/files/*.el8
 %endif
+
+cp -f files/%{dist_name}/leapp.conf %{buildroot}%{_sysconfdir}/leapp/leapp.conf
+
 
 %files
 %doc LICENSE NOTICE README.md

--- a/leapp-data.spec
+++ b/leapp-data.spec
@@ -27,28 +27,28 @@ Conflicts: %{conflict_dists}
 %install
 mkdir -p %{buildroot}%{_sysconfdir}/leapp/files/vendors.d
 %if 0%{?rhel} < 8
-	cp -f vendors.d/* %{buildroot}%{_sysconfdir}/leapp/files/vendors.d/
+    cp -f vendors.d/* %{buildroot}%{_sysconfdir}/leapp/files/vendors.d/
 %endif
 cp -rf files/%{dist_name}/* %{buildroot}%{_sysconfdir}/leapp/files/
 
 %if 0%{?rhel} == 7
-	mv -f %{buildroot}%{_sysconfdir}/leapp/files/leapp_upgrade_repositories.repo.el8 \
-		%{buildroot}%{_sysconfdir}/leapp/files/leapp_upgrade_repositories.repo
-	mv -f %{buildroot}%{_sysconfdir}/leapp/files/repomap.json.el8 \
-		%{buildroot}%{_sysconfdir}/leapp/files/repomap.json
-	rm -f %{buildroot}%{_sysconfdir}/leapp/files/*.el9
+    mv -f %{buildroot}%{_sysconfdir}/leapp/files/leapp_upgrade_repositories.repo.el8 \
+        %{buildroot}%{_sysconfdir}/leapp/files/leapp_upgrade_repositories.repo
+    mv -f %{buildroot}%{_sysconfdir}/leapp/files/repomap.json.el8 \
+        %{buildroot}%{_sysconfdir}/leapp/files/repomap.json
+    rm -f %{buildroot}%{_sysconfdir}/leapp/files/*.el9
 %endif
 %if 0%{?rhel} == 8
-	mv -f %{buildroot}%{_sysconfdir}/leapp/files/leapp_upgrade_repositories.repo.el9 \
-		%{buildroot}%{_sysconfdir}/leapp/files/leapp_upgrade_repositories.repo
-	mv -f %{buildroot}%{_sysconfdir}/leapp/files/repomap.json.el9 \
-		%{buildroot}%{_sysconfdir}/leapp/files/repomap.json
-	rm -f %{buildroot}%{_sysconfdir}/leapp/files/*.el8
+    mv -f %{buildroot}%{_sysconfdir}/leapp/files/leapp_upgrade_repositories.repo.el9 \
+        %{buildroot}%{_sysconfdir}/leapp/files/leapp_upgrade_repositories.repo
+    mv -f %{buildroot}%{_sysconfdir}/leapp/files/repomap.json.el9 \
+        %{buildroot}%{_sysconfdir}/leapp/files/repomap.json
+    rm -f %{buildroot}%{_sysconfdir}/leapp/files/*.el8
 %endif
 
 %global dist_leapp_conf %( if [ -f files/%{dist_name}/leapp.conf ]; then echo "1" ; else echo "0"; fi )
 %if %dist_leapp_conf
-	cp -f files/%{dist_name}/leapp.conf %{buildroot}%{_sysconfdir}/leapp/leapp.conf
+    cp -f files/%{dist_name}/leapp.conf %{buildroot}%{_sysconfdir}/leapp/leapp.conf
 %endif
 
 
@@ -56,7 +56,7 @@ cp -rf files/%{dist_name}/* %{buildroot}%{_sysconfdir}/leapp/files/
 %doc LICENSE NOTICE README.md
 %{_sysconfdir}/leapp/files/*
 %if %dist_leapp_conf
-	%{_sysconfdir}/leapp/leapp.conf
+    %{_sysconfdir}/leapp/leapp.conf
 %endif
 
 

--- a/leapp-data.spec
+++ b/leapp-data.spec
@@ -46,12 +46,18 @@ cp -rf files/%{dist_name}/* %{buildroot}%{_sysconfdir}/leapp/files/
 	rm -f %{buildroot}%{_sysconfdir}/leapp/files/*.el8
 %endif
 
-cp -f files/%{dist_name}/leapp.conf %{buildroot}%{_sysconfdir}/leapp/leapp.conf
+%global dist_leapp_conf %( if [ -f files/%{dist_name}/leapp.conf ]; then echo "1" ; else echo "0"; fi )
+if %dist_leapp_conf
+	cp -f files/%{dist_name}/leapp.conf %{buildroot}%{_sysconfdir}/leapp/leapp.conf
+%endif
 
 
 %files
 %doc LICENSE NOTICE README.md
 %{_sysconfdir}/leapp/files/*
+if %dist_leapp_conf
+	%{_sysconfdir}/leapp/leapp.conf
+%endif
 
 
 %changelog

--- a/leapp-data.spec
+++ b/leapp-data.spec
@@ -27,23 +27,23 @@ Conflicts: %{conflict_dists}
 %install
 mkdir -p %{buildroot}%{_sysconfdir}/leapp/files/vendors.d
 %if 0%{?rhel} < 8
-      cp -f vendors.d/* %{buildroot}%{_sysconfdir}/leapp/files/vendors.d/
+	cp -f vendors.d/* %{buildroot}%{_sysconfdir}/leapp/files/vendors.d/
 %endif
 cp -rf files/%{dist_name}/* %{buildroot}%{_sysconfdir}/leapp/files/
 
 %if 0%{?rhel} == 7
-      mv -f %{buildroot}%{_sysconfdir}/leapp/files/leapp_upgrade_repositories.repo.el8 \
-            %{buildroot}%{_sysconfdir}/leapp/files/leapp_upgrade_repositories.repo
-      mv -f %{buildroot}%{_sysconfdir}/leapp/files/repomap.json.el8 \
-            %{buildroot}%{_sysconfdir}/leapp/files/repomap.json
-      rm -f %{buildroot}%{_sysconfdir}/leapp/files/*.el9
+	mv -f %{buildroot}%{_sysconfdir}/leapp/files/leapp_upgrade_repositories.repo.el8 \
+		%{buildroot}%{_sysconfdir}/leapp/files/leapp_upgrade_repositories.repo
+	mv -f %{buildroot}%{_sysconfdir}/leapp/files/repomap.json.el8 \
+		%{buildroot}%{_sysconfdir}/leapp/files/repomap.json
+	rm -f %{buildroot}%{_sysconfdir}/leapp/files/*.el9
 %endif
 %if 0%{?rhel} == 8
-      mv -f %{buildroot}%{_sysconfdir}/leapp/files/leapp_upgrade_repositories.repo.el9 \
-            %{buildroot}%{_sysconfdir}/leapp/files/leapp_upgrade_repositories.repo
-      mv -f %{buildroot}%{_sysconfdir}/leapp/files/repomap.json.el9 \
-            %{buildroot}%{_sysconfdir}/leapp/files/repomap.json
-      rm -f %{buildroot}%{_sysconfdir}/leapp/files/*.el8
+	mv -f %{buildroot}%{_sysconfdir}/leapp/files/leapp_upgrade_repositories.repo.el9 \
+		%{buildroot}%{_sysconfdir}/leapp/files/leapp_upgrade_repositories.repo
+	mv -f %{buildroot}%{_sysconfdir}/leapp/files/repomap.json.el9 \
+		%{buildroot}%{_sysconfdir}/leapp/files/repomap.json
+	rm -f %{buildroot}%{_sysconfdir}/leapp/files/*.el8
 %endif
 
 cp -f files/%{dist_name}/leapp.conf %{buildroot}%{_sysconfdir}/leapp/leapp.conf


### PR DESCRIPTION
`leapp.conf` files can be used for passing parameters to the Leapp upgrade commands, like paths to Leapp repos or the database.
At the moment, there's only one default `leapp.conf` for all variants of the leapp-data packages.
This patch allows providing separate `leapp.conf` files for different target OS leapp-data packages, and one such file (with new conf section from https://github.com/AlmaLinux/leapp-repository/pull/73) is provided.
