### PR TITLE
Modify repo mapping for CL Hybrid installations

### DIFF
--- a/files/cloudlinux/leapp_upgrade_repositories.repo.el8
+++ b/files/cloudlinux/leapp_upgrade_repositories.repo.el8
@@ -82,10 +82,10 @@ gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CloudLinux
 # Third-party install scripts may pass --enablerepo=cloudlinux-PowerTools
 # to dnf and without this repo a error will occur
 
-[cloudlinux-PowerTools]
-name=AlmaLinux 8.6 - PowerTools
-mirrorlist=https://mirrors.almalinux.org/mirrorlist/8.6/powertools
-# baseurl=https://repo.almalinux.org/almalinux/8.6/PowerTools/$basearch/os/
+[cloudlinux8-PowerTools]
+name=AlmaLinux 8 - PowerTools
+mirrorlist=https://mirrors.almalinux.org/mirrorlist/8/powertools
+# baseurl=https://repo.almalinux.org/almalinux/8/PowerTools/$basearch/os/
 enabled=1
 gpgcheck=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-AlmaLinux

--- a/files/cloudlinux/repomap.json.el8
+++ b/files/cloudlinux/repomap.json.el8
@@ -23,6 +23,14 @@
                     ]
                 },
                 {
+                    "source": "cloudlinux-hybrid-updates",
+                    "target": [
+                        "cloudlinux8-baseos",
+                        "cloudlinux8-appstream",
+                        "cloudlinux8-powertools"
+                    ]
+                },
+                {
                     "source": "base",
                     "target": [
                         "almalinux8-baseos",
@@ -264,6 +272,18 @@
                     "major_version": "8",
                     "repo_type": "rpm",
                     "repoid": "almalinux8-extras",
+                    "arch": "x86_64",
+                    "channel": "ga"
+                }
+            ]
+        },
+        {
+            "pesid": "cloudlinux-hybrid-updates",
+            "entries": [
+                {
+                    "major_version": "7",
+                    "repo_type": "rpm",
+                    "repoid": "cloudlinux-hybrid-updates",
                     "arch": "x86_64",
                     "channel": "ga"
                 }


### PR DESCRIPTION
CloudLinux OS 7 Hybrid has a package repository defined that is different from normal CL7 installations.
In order for it to upgrade packages from it correctly, it should be added to the repository mapping.