### PR TITLE
Fix pes-events.json for CentOS and Eurolinux

### DIFF
--- a/files/centos/pes-events.json
+++ b/files/centos/pes-events.json
@@ -90116,7 +90116,8 @@
     {
       "action": 7,
       "architectures": [
-        "noarch"
+        "x86_64",
+        "aarch64"
       ],
       "description": "Python package from EPEL was renamed in Alma8 System repos. ",
       "id": 2224,
@@ -90156,7 +90157,8 @@
     {
       "action": 7,
       "architectures": [
-        "noarch"
+        "x86_64",
+        "aarch64"
       ],
       "description": "EPEL Package is renamed in Alma8 Repo",
       "id": 2225,

--- a/files/eurolinux/pes-events.json
+++ b/files/eurolinux/pes-events.json
@@ -90116,7 +90116,8 @@
     {
       "action": 7,
       "architectures": [
-        "noarch"
+        "x86_64",
+        "aarch64"
       ],
       "description": "Python package from EPEL was renamed in Alma8 System repos. ",
       "id": 2224,
@@ -90156,7 +90157,8 @@
     {
       "action": 7,
       "architectures": [
-        "noarch"
+        "x86_64",
+        "aarch64"
       ],
       "description": "EPEL Package is renamed in Alma8 Repo",
       "id": 2225,


### PR DESCRIPTION
Set correct 'architectures' for python36-ply and python36-six packages.