### PR TITLE
Mariadb - generic repo,

### DIFF
--- a/vendors.d/mariadb.repo
+++ b/vendors.d/mariadb.repo
@@ -1,4 +1,4 @@
-[el8-mariadb-main]
+[all-mariadb-main]
 name = MariaDB Server
 baseurl = https://dlm.mariadb.com/repo/mariadb-server/11.1/yum/rhel/8/x86_64
 gpgkey = file:///etc/pki/rpm-gpg/MariaDB-Server-GPG-KEY
@@ -6,7 +6,7 @@ gpgcheck = 1
 enabled = 1
 module_hotfixes = true
 
-[el8-mariadb-maxscale]
+[all-mariadb-maxscale]
 # To use the latest stable release of MaxScale, use "latest" as the version
 # To use the latest beta (or stable if no current beta) release of MaxScale, use "beta" as the version
 name = MariaDB MaxScale
@@ -16,8 +16,7 @@ gpgcheck = 1
 enabled = 1
 module_hotfixes = true
 
-
-[el8-mariadb-tools]
+[all-mariadb-tools]
 name = MariaDB Tools
 baseurl = https://downloads.mariadb.com/Tools/rhel/8/x86_64
 gpgkey = file:///etc/pki/rpm-gpg/MariaDB-Enterprise-GPG-KEY

--- a/vendors.d/mariadb.repo
+++ b/vendors.d/mariadb.repo
@@ -1,6 +1,6 @@
 [all-mariadb-main]
 name = MariaDB Server
-baseurl = https://dlm.mariadb.com/repo/mariadb-server/11.1/yum/rhel/8/x86_64
+baseurl = https://dlm.mariadb.com/repo/mariadb-server/11.1/yum/rhel/$releasever/$basearch
 gpgkey = file:///etc/pki/rpm-gpg/MariaDB-Server-GPG-KEY
 gpgcheck = 1
 enabled = 1
@@ -10,7 +10,7 @@ module_hotfixes = true
 # To use the latest stable release of MaxScale, use "latest" as the version
 # To use the latest beta (or stable if no current beta) release of MaxScale, use "beta" as the version
 name = MariaDB MaxScale
-baseurl = https://dlm.mariadb.com/repo/maxscale/latest/yum/rhel/8/x86_64
+baseurl = https://dlm.mariadb.com/repo/maxscale/latest/yum/rhel/$releasever/$basearch
 gpgkey = file:///etc/pki/rpm-gpg/MariaDB-MaxScale-GPG-KEY
 gpgcheck = 1
 enabled = 1
@@ -18,7 +18,7 @@ module_hotfixes = true
 
 [all-mariadb-tools]
 name = MariaDB Tools
-baseurl = https://downloads.mariadb.com/Tools/rhel/8/x86_64
+baseurl = https://downloads.mariadb.com/Tools/rhel/$releasever/$basearch
 gpgkey = file:///etc/pki/rpm-gpg/MariaDB-Enterprise-GPG-KEY
 gpgcheck = 1
 enabled = 1

--- a/vendors.d/mariadb_map.json
+++ b/vendors.d/mariadb_map.json
@@ -9,19 +9,19 @@
                 {
                     "source": "mariadb-main",
                     "target": [
-                        "el8-mariadb-main"
+                        "all-mariadb-main"
                     ]
                 },
                 {
                     "source": "mariadb-maxscale",
                     "target": [
-                        "el8-mariadb-maxscale"
+                        "all-mariadb-maxscale"
                     ]
                 },
                 {
                     "source": "mariadb-tools",
                     "target": [
-                        "el8-mariadb-tools"
+                        "all-mariadb-tools"
                     ]
                 }
             ]
@@ -65,11 +65,11 @@
             ]
         },
         {
-            "pesid": "el8-mariadb-main",
+            "pesid": "all-mariadb-main",
             "entries": [
                 {
                     "major_version": "8",
-                    "repoid": "el8-mariadb-main",
+                    "repoid": "all-mariadb-main",
                     "arch": "x86_64",
                     "channel": "ga",
                     "repo_type": "rpm"
@@ -77,11 +77,11 @@
             ]
         },
         {
-            "pesid": "el8-mariadb-maxscale",
+            "pesid": "all-mariadb-maxscale",
             "entries": [
                 {
                     "major_version": "8",
-                    "repoid": "el8-mariadb-maxscale",
+                    "repoid": "all-mariadb-maxscale",
                     "arch": "x86_64",
                     "channel": "ga",
                     "repo_type": "rpm"
@@ -89,11 +89,11 @@
             ]
         },
         {
-            "pesid": "el8-mariadb-tools",
+            "pesid": "all-mariadb-tools",
             "entries": [
                 {
                     "major_version": "8",
-                    "repoid": "el8-mariadb-tools",
+                    "repoid": "all-mariadb-tools",
                     "arch": "x86_64",
                     "channel": "ga",
                     "repo_type": "rpm"

--- a/vendors.d/mariadb_pes.json
+++ b/vendors.d/mariadb_pes.json
@@ -31,8 +31,8 @@
         "package": [
           {
             "module_stream": null,
-            "name": "percona-xtrabackup-24",
-            "repository": "el8-mariadb-tools"
+            "name": "MariaDB-backup",
+            "repository": "all-mariadb-main"
           }
         ], 
         "set_id": 4123

--- a/vendors.d/mariadb_pes.json
+++ b/vendors.d/mariadb_pes.json
@@ -6,7 +6,8 @@
       "arches": [
         "x86_64", 
         "aarch64", 
-        "ppc64le"
+        "ppc64le",
+        "s390x"
       ], 
       "description": "", 
       "id": 2327, 


### PR DESCRIPTION
When repo macros are needed do we need to pin this to el8? I went for `all` by other suggestions welcome. Technically `module_hotfixes` won't apply to 9+.

Replace percona-xtrabackup with the MariaDB fork.