### PR TITLE
Revert "Temporary force 9.3 version due to RHEL-36249"

### DIFF
--- a/files/almalinux/leapp_upgrade_repositories.repo.el9
+++ b/files/almalinux/leapp_upgrade_repositories.repo.el9
@@ -1,47 +1,47 @@
 [almalinux9-baseos]
 name=AlmaLinux 9 - BaseOS
-mirrorlist=https://mirrors.almalinux.org/mirrorlist/9.3/baseos
-# baseurl=https://vault.almalinux.org/9.3/BaseOS/$basearch/os/
+mirrorlist=https://mirrors.almalinux.org/mirrorlist/9/baseos
+# baseurl=https://repo.almalinux.org/almalinux/9/BaseOS/$basearch/os/
 enabled=1
 gpgcheck=1
 gpgkey=file:///etc/leapp/repos.d/system_upgrade/common/files/rpm-gpg/9/RPM-GPG-KEY-AlmaLinux-9
 
 [almalinux9-appstream]
 name=AlmaLinux 9 - AppStream
-mirrorlist=https://mirrors.almalinux.org/mirrorlist/9.3/appstream
-# baseurl=https://vault.almalinux.org/9.3/AppStream/$basearch/os/
+mirrorlist=https://mirrors.almalinux.org/mirrorlist/9/appstream
+# baseurl=https://repo.almalinux.org/almalinux/9/AppStream/$basearch/os/
 enabled=1
 gpgcheck=1
 gpgkey=file:///etc/leapp/repos.d/system_upgrade/common/files/rpm-gpg/9/RPM-GPG-KEY-AlmaLinux-9
 
 [almalinux9-crb]
 name=AlmaLinux 9 - CRB
-mirrorlist=https://mirrors.almalinux.org/mirrorlist/9.3/crb
-# baseurl=https://vault.almalinux.org/9.3/CRB/$basearch/os/
+mirrorlist=https://mirrors.almalinux.org/mirrorlist/9/crb
+# baseurl=https://repo.almalinux.org/almalinux/9/CRB/$basearch/os/
 enabled=1
 gpgcheck=1
 gpgkey=file:///etc/leapp/repos.d/system_upgrade/common/files/rpm-gpg/9/RPM-GPG-KEY-AlmaLinux-9
 
 [almalinux9-highavailability]
 name=AlmaLinux 9 - HighAvailability
-mirrorlist=https://mirrors.almalinux.org/mirrorlist/9.3/ha
-# baseurl=https://vault.almalinux.org/9.3/HighAvailability/$basearch/os/
+mirrorlist=https://mirrors.almalinux.org/mirrorlist/9/ha
+# baseurl=https://repo.almalinux.org/almalinux/9/HighAvailability/$basearch/os/
 enabled=1
 gpgcheck=1
 gpgkey=file:///etc/leapp/repos.d/system_upgrade/common/files/rpm-gpg/9/RPM-GPG-KEY-AlmaLinux-9
 
 [almalinux9-resilientstorage]
 name=AlmaLinux 9 - ResilientStorage
-mirrorlist=https://mirrors.almalinux.org/mirrorlist/9.3/resilientstorage
-# baseurl=https://vault.almalinux.org/9.3/ResilientStorage/$basearch/os/
+mirrorlist=https://mirrors.almalinux.org/mirrorlist/9/resilientstorage
+# baseurl=https://repo.almalinux.org/almalinux/9/ResilientStorage/$basearch/os/
 enabled=1
 gpgcheck=1
 gpgkey=file:///etc/leapp/repos.d/system_upgrade/common/files/rpm-gpg/9/RPM-GPG-KEY-AlmaLinux-9
 
 [almalinux9-extras]
 name=AlmaLinux 9 - Extras
-mirrorlist=https://mirrors.almalinux.org/mirrorlist/9.3/extras
-# baseurl=https://vault.almalinux.org/9.3/extras/$basearch/os/
+mirrorlist=https://mirrors.almalinux.org/mirrorlist/9/extras
+# baseurl=https://repo.almalinux.org/almalinux/9/extras/$basearch/os/
 enabled=1
 gpgcheck=1
 gpgkey=file:///etc/leapp/repos.d/system_upgrade/common/files/rpm-gpg/9/RPM-GPG-KEY-AlmaLinux-9

--- a/files/eurolinux/leapp_upgrade_repositories.repo.el9
+++ b/files/eurolinux/leapp_upgrade_repositories.repo.el9
@@ -1,6 +1,6 @@
 [certify-baseos-9]
 name = EuroLinux certify BaseOS
-baseurl=https://vault.cdn.euro-linux.com/legacy/eurolinux/9/9.3/BaseOS/$basearch/os/
+baseurl=https://fbi.cdn.euro-linux.com/dist/eurolinux/server/9/$basearch/certify-BaseOS/os
 enabled=1
 gpgcheck=1
 gpgkey=file:///etc/leapp/repos.d/system_upgrade/common/files/rpm-gpg/9/RPM-GPG-KEY-eurolinux9
@@ -8,7 +8,7 @@ skip_if_unavailable=1
 
 [certify-appstream-9]
 name = EuroLinux certify AppStream
-baseurl=https://vault.cdn.euro-linux.com/legacy/eurolinux/9/9.3/AppStream/$basearch/os/
+baseurl=https://fbi.cdn.euro-linux.com/dist/eurolinux/server/9/$basearch/certify-AppStream/os
 enabled=1
 gpgcheck=1
 gpgkey=file:///etc/leapp/repos.d/system_upgrade/common/files/rpm-gpg/9/RPM-GPG-KEY-eurolinux9
@@ -16,7 +16,7 @@ skip_if_unavailable=1
 
 [certify-powertools-9]
 name = EuroLinux certify PowerTools
-baseurl=https://vault.cdn.euro-linux.com/legacy/eurolinux/9/9.3/PowerTools/$basearch/os/
+baseurl=https://fbi.cdn.euro-linux.com/dist/eurolinux/server/9/$basearch/certify-PowerTools/os
 enabled=1
 gpgcheck=1
 gpgkey=file:///etc/leapp/repos.d/system_upgrade/common/files/rpm-gpg/9/RPM-GPG-KEY-eurolinux9
@@ -24,14 +24,14 @@ skip_if_unavailable=1
 
 [high-availability-9]
 name = EuroLinux High Availability
-baseurl=https://vault.cdn.euro-linux.com/legacy/eurolinux/9/9.3/HighAvailability/$basearch/os/
+baseurl=https://fbi.cdn.euro-linux.com/dist/eurolinux/server/9/$basearch/certify-HighAvailability/os
 enabled=0
 gpgcheck=1
 gpgkey=file:///etc/leapp/repos.d/system_upgrade/common/files/rpm-gpg/9/RPM-GPG-KEY-eurolinux9
 
 [resilient-storage-9]
 name = EuroLinux Resilient Storage
-baseurl=https://vault.cdn.euro-linux.com/legacy/eurolinux/9/9.3/ResilientStorage/$basearch/os/
+baseurl=https://fbi.cdn.euro-linux.com/dist/eurolinux/server/9/$basearch/certify-ResilientStorage/os
 enabled=0
 gpgcheck=1
 gpgkey=file:///etc/leapp/repos.d/system_upgrade/common/files/rpm-gpg/9/RPM-GPG-KEY-eurolinux9

--- a/files/rocky/leapp_upgrade_repositories.repo.el9
+++ b/files/rocky/leapp_upgrade_repositories.repo.el9
@@ -1,79 +1,79 @@
 [rocky9-baseos]
 name=Rocky Linux 9 - BaseOS
-#mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=BaseOS-9.3
-baseurl=http://dl.rockylinux.org/vault/rocky/9.3/BaseOS/$basearch/os/
+mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=BaseOS-9.3
+#baseurl=http://dl.rockylinux.org/vault/rocky/9.3/BaseOS/$basearch/os/
 gpgcheck=1
 enabled=1
 gpgkey=file:///etc/leapp/repos.d/system_upgrade/common/files/rpm-gpg/9/RPM-GPG-KEY-Rocky-9
 
 [rocky9-appstream]
 name=Rocky Linux 9 - AppStream
-#mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=AppStream-9.3
-baseurl=http://dl.rockylinux.org/vault/rocky/9.3/AppStream/$basearch/os/
+mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=AppStream-9.3
+#baseurl=http://dl.rockylinux.org/vault/rocky/9.3/AppStream/$basearch/os/
 gpgcheck=1
 enabled=1
 gpgkey=file:///etc/leapp/repos.d/system_upgrade/common/files/rpm-gpg/9/RPM-GPG-KEY-Rocky-9
 
 [rocky9-crb]
 name=Rocky Linux 9 - CRB
-#mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=CRB-9.3
-baseurl=http://dl.rockylinux.org/vault/rocky/9.3/CRB/$basearch/os/
+mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=CRB-9.3
+#baseurl=http://dl.rockylinux.org/vault/rocky/9.3/CRB/$basearch/os/
 gpgcheck=1
 enabled=0
 gpgkey=file:///etc/leapp/repos.d/system_upgrade/common/files/rpm-gpg/9/RPM-GPG-KEY-Rocky-9
 
 [rocky9-ha]
 name=Rocky Linux 9 - HighAvailability
-#mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=HighAvailability-9.3
-baseurl=http://dl.rockylinux.org/vault/rocky/9.3/HighAvailability/$basearch/os/
+mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=HighAvailability-9.3
+#baseurl=http://dl.rockylinux.org/vault/rocky/9.3/HighAvailability/$basearch/os/
 gpgcheck=1
 enabled=0
 gpgkey=file:///etc/leapp/repos.d/system_upgrade/common/files/rpm-gpg/9/RPM-GPG-KEY-Rocky-9
 
 [rocky9-resilient-storage]
 name=Rocky Linux 9 - ResilientStorage
-#mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=ResilientStorage-9.3
-baseurl=http://dl.rockylinux.org/vault/rocky/9.3/ResilientStorage/$basearch/os/
+mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=ResilientStorage-9.3
+#baseurl=http://dl.rockylinux.org/vault/rocky/9.3/ResilientStorage/$basearch/os/
 gpgcheck=1
 enabled=0
 gpgkey=file:///etc/leapp/repos.d/system_upgrade/common/files/rpm-gpg/9/RPM-GPG-KEY-Rocky-9
 
 [rocky9-extras]
 name=Rocky Linux 9 - Extras
-#mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=extras-9.3
-baseurl=http://dl.rockylinux.org/vault/rocky/9.3/extras/$basearch/os/
+mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=extras-9.3
+#baseurl=http://dl.rockylinux.org/vault/rocky/9.3/extras/$basearch/os/
 gpgcheck=1
 enabled=1
 gpgkey=file:///etc/leapp/repos.d/system_upgrade/common/files/rpm-gpg/9/RPM-GPG-KEY-Rocky-9
 
 [rocky9-rt]
 name=Rocky Linux 9 - RT
-#mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=RT-9
-baseurl=http://dl.rockylinux.org/pub/rocky/9/RT/$basearch/os/
+mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=RT-9
+#baseurl=http://dl.rockylinux.org/pub/rocky/9/RT/$basearch/os/
 gpgcheck=1
 enabled=1
 gpgkey=file:///etc/leapp/repos.d/system_upgrade/common/files/rpm-gpg/9/RPM-GPG-KEY-Rocky-9
 
 [rocky9-nfv]
 name=Rocky Linux 9 - NFV
-#mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=NFV-9
-baseurl=http://dl.rockylinux.org/pub/rocky/9/NFV/$basearch/os/
+mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=NFV-9
+#baseurl=http://dl.rockylinux.org/pub/rocky/9/NFV/$basearch/os/
 gpgcheck=1
 enabled=1
 gpgkey=file:///etc/leapp/repos.d/system_upgrade/common/files/rpm-gpg/9/RPM-GPG-KEY-Rocky-9
 
 [rocky9-sap]
 name=Rocky Linux 9 - SAP
-#mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=SAP-9
-baseurl=http://dl.rockylinux.org/pub/rocky/9/SAP/$basearch/os/
+mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=SAP-9
+#baseurl=http://dl.rockylinux.org/pub/rocky/9/SAP/$basearch/os/
 gpgcheck=1
 enabled=1
 gpgkey=file:///etc/leapp/repos.d/system_upgrade/common/files/rpm-gpg/9/RPM-GPG-KEY-Rocky-9
 
 [rocky9-saphana]
 name=Rocky Linux 9 - SAPHANA
-#mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=SAPHANA-9
-baseurl=http://dl.rockylinux.org/pub/rocky/9/SAPHANA/$basearch/os/
+mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=SAPHANA-9
+#baseurl=http://dl.rockylinux.org/pub/rocky/9/SAPHANA/$basearch/os/
 gpgcheck=1
 enabled=1
 gpgkey=file:///etc/leapp/repos.d/system_upgrade/common/files/rpm-gpg/9/RPM-GPG-KEY-Rocky-9

--- a/files/rocky/leapp_upgrade_repositories.repo.el9
+++ b/files/rocky/leapp_upgrade_repositories.repo.el9
@@ -1,47 +1,47 @@
 [rocky9-baseos]
 name=Rocky Linux 9 - BaseOS
-mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=BaseOS-9.3
-#baseurl=http://dl.rockylinux.org/vault/rocky/9.3/BaseOS/$basearch/os/
+mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=BaseOS-9
+#baseurl=http://dl.rockylinux.org/pub/rocky/9/BaseOS/$basearch/os/
 gpgcheck=1
 enabled=1
 gpgkey=file:///etc/leapp/repos.d/system_upgrade/common/files/rpm-gpg/9/RPM-GPG-KEY-Rocky-9
 
 [rocky9-appstream]
 name=Rocky Linux 9 - AppStream
-mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=AppStream-9.3
-#baseurl=http://dl.rockylinux.org/vault/rocky/9.3/AppStream/$basearch/os/
+mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=AppStream-9
+#baseurl=http://dl.rockylinux.org/pub/rocky/9/AppStream/$basearch/os/
 gpgcheck=1
 enabled=1
 gpgkey=file:///etc/leapp/repos.d/system_upgrade/common/files/rpm-gpg/9/RPM-GPG-KEY-Rocky-9
 
 [rocky9-crb]
 name=Rocky Linux 9 - CRB
-mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=CRB-9.3
-#baseurl=http://dl.rockylinux.org/vault/rocky/9.3/CRB/$basearch/os/
+mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=CRB-9
+#baseurl=http://dl.rockylinux.org/pub/rocky/9/CRB/$basearch/os/
 gpgcheck=1
 enabled=0
 gpgkey=file:///etc/leapp/repos.d/system_upgrade/common/files/rpm-gpg/9/RPM-GPG-KEY-Rocky-9
 
 [rocky9-ha]
 name=Rocky Linux 9 - HighAvailability
-mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=HighAvailability-9.3
-#baseurl=http://dl.rockylinux.org/vault/rocky/9.3/HighAvailability/$basearch/os/
+mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=HighAvailability-9
+#baseurl=http://dl.rockylinux.org/pub/rocky/9/HighAvailability/$basearch/os/
 gpgcheck=1
 enabled=0
 gpgkey=file:///etc/leapp/repos.d/system_upgrade/common/files/rpm-gpg/9/RPM-GPG-KEY-Rocky-9
 
 [rocky9-resilient-storage]
 name=Rocky Linux 9 - ResilientStorage
-mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=ResilientStorage-9.3
-#baseurl=http://dl.rockylinux.org/vault/rocky/9.3/ResilientStorage/$basearch/os/
+mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=ResilientStorage-9
+#baseurl=http://dl.rockylinux.org/pub/rocky/9/ResilientStorage/$basearch/os/
 gpgcheck=1
 enabled=0
 gpgkey=file:///etc/leapp/repos.d/system_upgrade/common/files/rpm-gpg/9/RPM-GPG-KEY-Rocky-9
 
 [rocky9-extras]
 name=Rocky Linux 9 - Extras
-mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=extras-9.3
-#baseurl=http://dl.rockylinux.org/vault/rocky/9.3/extras/$basearch/os/
+mirrorlist=https://mirrors.rockylinux.org/mirrorlist?arch=$basearch&repo=extras-9
+#baseurl=http://dl.rockylinux.org/pub/rocky/9/extras/$basearch/os/
 gpgcheck=1
 enabled=1
 gpgkey=file:///etc/leapp/repos.d/system_upgrade/common/files/rpm-gpg/9/RPM-GPG-KEY-Rocky-9

--- a/leapp-data.spec
+++ b/leapp-data.spec
@@ -47,7 +47,7 @@
 
 Name:		leapp-data-%{dist_name}
 Version:	0.2
-Release:	15%{?dist}.%{pes_events_build_date}
+Release:	16%{?dist}.%{pes_events_build_date}
 Summary:	data for migrating tool
 Group:		Applications/Databases
 License:	ASL 2.0
@@ -154,6 +154,9 @@ python3 tests/check_debranding.py %{buildroot}%{_sysconfdir}/leapp/files/pes-eve
 
 
 %changelog
+* Tue Sep 03 2024 Yuriy Kohut <ykohut@almalinux.org> - 0.2-16.20230823
+- Revert "Temporary force 9.3 version due to RHEL-36249"
+
 * Wed Jul 24 2024 Yuriy Kohut <ykohut@almalinux.org> - 0.2-15.20230823
 - Add device driver deprecation data for all distros
 - Update the data for AlmaLinux with devices which support were added in its specific release (as of 20240724090818)


### PR DESCRIPTION
The https://issues.redhat.com/browse/RHEL-36249 resolved on upstream and distros provide updated packages.