### PR TITLE
Switch CentOS Stream9 repositories from mirrorlist into baseurl

### DIFF
--- a/files/centos/leapp_upgrade_repositories.repo.el9
+++ b/files/centos/leapp_upgrade_repositories.repo.el9
@@ -1,31 +1,31 @@
 [centos9-baseos]
 name=CentOS-9-stream - Base
-mirrorlist=https://mirrors.centos.org/mirrorlist?path=/9-stream/BaseOS/$basearch/os/
-#baseurl=http://mirror.centos.org/$contentdir/9-stream/BaseOS/$basearch/os/
+#mirrorlist=https://mirrors.centos.org/mirrorlist?path=/9-stream/BaseOS/$basearch/os/
+baseurl=http://mirror.stream.centos.org/9-stream/BaseOS/$basearch/os/
 gpgcheck=1
 enabled=1
 gpgkey=file:///etc/leapp/repos.d/system_upgrade/common/files/rpm-gpg/9/RPM-GPG-KEY-CentOS-Official
 
 [centos9-appstream]
 name=CentOS-9-stream - AppStream
-mirrorlist=https://mirrors.centos.org/mirrorlist?path=/9-stream/AppStream/$basearch/os/
-#baseurl=http://mirror.centos.org/$contentdir/9-stream/AppStream/$basearch/os/
+#mirrorlist=https://mirrors.centos.org/mirrorlist?path=/9-stream/AppStream/$basearch/os/
+baseurl=http://mirror.stream.centos.org/9-stream/AppStream/$basearch/os/
 gpgcheck=1
 enabled=1
 gpgkey=file:///etc/leapp/repos.d/system_upgrade/common/files/rpm-gpg/9/RPM-GPG-KEY-CentOS-Official
 
 [centos9-crb]
 name=CentOS-9-stream - CRB
-mirrorlist=https://mirrors.centos.org/mirrorlist?path=/9-stream/CRB/$basearch/os/
-#baseurl=http://mirror.centos.org/$contentdir/9-stream/CRB/$basearch/os/
+#mirrorlist=https://mirrors.centos.org/mirrorlist?path=/9-stream/CRB/$basearch/os/
+baseurl=http://mirror.stream.centos.org/9-stream/CRB/$basearch/os/
 gpgcheck=1
 enabled=0
 gpgkey=file:///etc/leapp/repos.d/system_upgrade/common/files/rpm-gpg/9/RPM-GPG-KEY-CentOS-Official
 
 [centos9-ha]
 name=CentOS-9-stream - HA
-mirrorlist=https://mirrors.centos.org/mirrorlist?path=/9-stream/HighAvailability/$basearch/os/
-#baseurl=http://mirror.centos.org/$contentdir/9-stream/HighAvailability/$basearch/os/
+#mirrorlist=https://mirrors.centos.org/mirrorlist?path=/9-stream/HighAvailability/$basearch/os/
+baseurl=http://mirror.stream.centos.org/9-stream/HighAvailability/$basearch/os/
 gpgcheck=1
 enabled=0
 gpgkey=file:///etc/leapp/repos.d/system_upgrade/common/files/rpm-gpg/9/RPM-GPG-KEY-CentOS-Official
@@ -40,16 +40,16 @@ gpgkey=file:///etc/leapp/repos.d/system_upgrade/common/files/rpm-gpg/9/RPM-GPG-K
 
 [centos9-nfv]
 name=CentOS-9-stream - NFV
-mirrorlist=https://mirrors.centos.org/mirrorlist?path=/9-stream/NFV/$basearch/os/
-#baseurl=http://mirror.centos.org/$contentdir/9-stream/NFV/$basearch/os/
+#mirrorlist=https://mirrors.centos.org/mirrorlist?path=/9-stream/NFV/$basearch/os/
+baseurl=http://mirror.stream.centos.org/9-stream/NFV/$basearch/os/
 gpgcheck=1
 enabled=1
 gpgkey=file:///etc/leapp/repos.d/system_upgrade/common/files/rpm-gpg/9/RPM-GPG-KEY-CentOS-Official
 
 [centos9-rt]
 name=CentOS-9-stream - RT
-mirrorlist=https://mirrors.centos.org/mirrorlist?path=/9-stream/RT/$basearch/os/
-#baseurl=http://mirror.centos.org/$contentdir/9-stream/RT/$basearch/os/
+#mirrorlist=https://mirrors.centos.org/mirrorlist?path=/9-stream/RT/$basearch/os/
+baseurl=http://mirror.stream.centos.org/9-stream/RT/$basearch/os/
 gpgcheck=1
 enabled=1
 gpgkey=file:///etc/leapp/repos.d/system_upgrade/common/files/rpm-gpg/9/RPM-GPG-KEY-CentOS-Official

--- a/leapp-data.spec
+++ b/leapp-data.spec
@@ -47,7 +47,7 @@
 
 Name:		leapp-data-%{dist_name}
 Version:	0.2
-Release:	16%{?dist}.%{pes_events_build_date}
+Release:	17%{?dist}.%{pes_events_build_date}
 Summary:	data for migrating tool
 Group:		Applications/Databases
 License:	ASL 2.0
@@ -154,6 +154,9 @@ python3 tests/check_debranding.py %{buildroot}%{_sysconfdir}/leapp/files/pes-eve
 
 
 %changelog
+* Fri Sep 06 2024 Yuriy Kohut <ykohut@almalinux.org> - 0.2-17.20230823
+- Switch CentOS Stream9 repositories from mirrorlist into baseurl at mirror.stream.centos.org
+
 * Tue Sep 03 2024 Yuriy Kohut <ykohut@almalinux.org> - 0.2-16.20230823
 - Revert "Temporary force 9.3 version due to RHEL-36249"
 


### PR DESCRIPTION
The baseurl at mirror.stream.centos.org

(cherry picked from commit f5106eb9d4d59208397c872d354855f95dba3884)