### PR TITLE
Replace libunwind package imunify360 vendor is enabled

### DIFF
--- a/leapp-data.spec
+++ b/leapp-data.spec
@@ -46,7 +46,7 @@
 
 Name:		leapp-data-%{dist_name}
 Version:	0.4
-Release:	6%{?dist}.%{pes_events_build_date}
+Release:	7%{?dist}.%{pes_events_build_date}
 Summary:	data for migrating tool
 Group:		Applications/Databases
 License:	ASL 2.0
@@ -153,6 +153,9 @@ python3 tests/check_debranding.py %{buildroot}%{_sysconfdir}/leapp/files/pes-eve
 
 
 %changelog
+* Tue Sep 17 2024 Yuriy Kohut <ykohut@almalinux.org> - 0.4-7.20240827
+ - Replace libunwind package if imunify360 vendor is enabled
+
 * Fri Sep 06 2024 Yuriy Kohut <ykohut@almalinux.org> - 0.4-6.20240827
 - Switch CentOS Stream9 repositories from mirrorlist into baseurl at mirror.stream.centos.org
 

--- a/vendors.d/imunify_pes.json
+++ b/vendors.d/imunify_pes.json
@@ -1,10 +1,53 @@
 {
     "legal_notice": "Copyright (c) 2022 CloudLinux Inc.",
-    "packageinfo": [],
+    "packageinfo": [
+        {
+            "action": 3,
+            "architectures": [
+                "x86_64",
+                "aarch64",
+                "ppc64le",
+                "s390x"
+            ],
+            "id": 32998,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "libunwind",
+                        "repository": "base"
+                    }
+                ],
+                "set_id": 32999
+            },
+            "initial_release": {
+                "major_version": 7,
+                "minor_version": 7,
+                "os_name": "CentOS"
+            },
+            "out_packageset": {
+                "package": [
+                    {
+                        "module_stream": null,
+                        "name": "libunwind",
+                        "repository": "cloudlinux8-imunify360"
+                    }
+                ],
+                "set_id": 33001
+            },
+            "release": {
+                "major_version": 8,
+                "minor_version": 9,
+                "os_name": "AlmaLinux"
+            }
+        }
+    ],
     "provided_data_streams": [
         "2.0",
         "3.0",
         "3.1"
     ],
-    "timestamp": "202207130941Z"
+    "timestamp": "202409170900Z"
 }


### PR DESCRIPTION
- If imunify360 vendor is enabled, replace the package. Otherwise, the package is removed according to distros' PES instructions
- Fix duplicate "set_id"
- Bump the package version: 0.4-7