### PR TITLE
Change major release number into $releasever in AlmaLinux repositories

### DIFF
--- a/files/almalinux/leapp_upgrade_repositories.repo.el8
+++ b/files/almalinux/leapp_upgrade_repositories.repo.el8
@@ -1,71 +1,71 @@
 [almalinux8-baseos]
-name=AlmaLinux 8 - BaseOS
-mirrorlist=https://mirrors.almalinux.org/mirrorlist/8/baseos
-# baseurl=https://repo.almalinux.org/almalinux/8/BaseOS/$basearch/os/
+name=AlmaLinux $releasever - BaseOS
+mirrorlist=https://mirrors.almalinux.org/mirrorlist/$releasever/baseos
+# baseurl=https://repo.almalinux.org/almalinux/$releasever/BaseOS/$basearch/os/
 enabled=1
 gpgcheck=0
 gpgkey=file:///etc/leapp/repos.d/system_upgrade/common/files/rpm-gpg/8/RPM-GPG-KEY-AlmaLinux-8
 
 [almalinux8-appstream]
-name=AlmaLinux 8 - AppStream
-mirrorlist=https://mirrors.almalinux.org/mirrorlist/8/appstream
-# baseurl=https://repo.almalinux.org/almalinux/8/AppStream/$basearch/os/
+name=AlmaLinux $releasever - AppStream
+mirrorlist=https://mirrors.almalinux.org/mirrorlist/$releasever/appstream
+# baseurl=https://repo.almalinux.org/almalinux/$releasever/AppStream/$basearch/os/
 enabled=1
 gpgcheck=0
 gpgkey=file:///etc/leapp/repos.d/system_upgrade/common/files/rpm-gpg/8/RPM-GPG-KEY-AlmaLinux-8
 
 [almalinux8-powertools]
-name=AlmaLinux 8 - PowerTools
-mirrorlist=https://mirrors.almalinux.org/mirrorlist/8/powertools
-# baseurl=https://repo.almalinux.org/almalinux/8/PowerTools/$basearch/os/
+name=AlmaLinux $releasever - PowerTools
+mirrorlist=https://mirrors.almalinux.org/mirrorlist/$releasever/powertools
+# baseurl=https://repo.almalinux.org/almalinux/$releasever/PowerTools/$basearch/os/
 enabled=1
 gpgcheck=0
 gpgkey=file:///etc/leapp/repos.d/system_upgrade/common/files/rpm-gpg/8/RPM-GPG-KEY-AlmaLinux-8
 
 [almalinux8-ha]
-name=AlmaLinux 8 - HighAvailability
-mirrorlist=https://mirrors.almalinux.org/mirrorlist/8/ha
-# baseurl=https://repo.almalinux.org/almalinux/8/HighAvailability/$basearch/os/
+name=AlmaLinux $releasever - HighAvailability
+mirrorlist=https://mirrors.almalinux.org/mirrorlist/$releasever/ha
+# baseurl=https://repo.almalinux.org/almalinux/$releasever/HighAvailability/$basearch/os/
 enabled=1
 gpgcheck=0
 gpgkey=file:///etc/leapp/repos.d/system_upgrade/common/files/rpm-gpg/8/RPM-GPG-KEY-AlmaLinux-8
 
 [almalinux8-resilientstorage]
-name=AlmaLinux 8 - ResilientStorage
-mirrorlist=https://mirrors.almalinux.org/mirrorlist/8/resilientstorage
-# baseurl=https://repo.almalinux.org/almalinux/8/ResilientStorage/$basearch/os/
+name=AlmaLinux $releasever - ResilientStorage
+mirrorlist=https://mirrors.almalinux.org/mirrorlist/$releasever/resilientstorage
+# baseurl=https://repo.almalinux.org/almalinux/$releasever/ResilientStorage/$basearch/os/
 enabled=1
 gpgcheck=0
 gpgkey=file:///etc/leapp/repos.d/system_upgrade/common/files/rpm-gpg/8/RPM-GPG-KEY-AlmaLinux-8
 
 [almalinux8-extras]
-name=AlmaLinux 8 - Extras
-mirrorlist=https://mirrors.almalinux.org/mirrorlist/8/extras
-# baseurl=https://repo.almalinux.org/almalinux/8/extras/$basearch/os/
+name=AlmaLinux $releasever - Extras
+mirrorlist=https://mirrors.almalinux.org/mirrorlist/$releasever/extras
+# baseurl=https://repo.almalinux.org/almalinux/$releasever/extras/$basearch/os/
 enabled=1
 gpgcheck=0
 gpgkey=file:///etc/leapp/repos.d/system_upgrade/common/files/rpm-gpg/8/RPM-GPG-KEY-AlmaLinux-8
 
 [almalinux8-sap]
-name=AlmaLinux 8 - SAP
-mirrorlist=https://mirrors.almalinux.org/mirrorlist/8/sap
-# baseurl=https://repo.almalinux.org/almalinux/8/SAP/$basearch/os/
+name=AlmaLinux $releasever - SAP
+mirrorlist=https://mirrors.almalinux.org/mirrorlist/$releasever/sap
+# baseurl=https://repo.almalinux.org/almalinux/$releasever/SAP/$basearch/os/
 enabled=1
 gpgcheck=1
 gpgkey=file:///etc/leapp/repos.d/system_upgrade/common/files/rpm-gpg/8/RPM-GPG-KEY-AlmaLinux-8
 
 [almalinux8-saphana]
-name=AlmaLinux 8 - SAPHANA
-mirrorlist=https://mirrors.almalinux.org/mirrorlist/8/saphana
-# baseurl=https://repo.almalinux.org/almalinux/8/SAPHANA/$basearch/os/
+name=AlmaLinux $releasever - SAPHANA
+mirrorlist=https://mirrors.almalinux.org/mirrorlist/$releasever/saphana
+# baseurl=https://repo.almalinux.org/almalinux/$releasever/SAPHANA/$basearch/os/
 enabled=1
 gpgcheck=1
 gpgkey=file:///etc/leapp/repos.d/system_upgrade/common/files/rpm-gpg/8/RPM-GPG-KEY-AlmaLinux-8
 
 [almalinux8-nfv]
-name=AlmaLinux 8 - NFV
-mirrorlist=https://mirrors.almalinux.org/mirrorlist/8/nfv
-# baseurl=https://repo.almalinux.org/almalinux/8/NFV/$basearch/os/
+name=AlmaLinux $releasever - NFV
+mirrorlist=https://mirrors.almalinux.org/mirrorlist/$releasever/nfv
+# baseurl=https://repo.almalinux.org/almalinux/$releasever/NFV/$basearch/os/
 enabled=1
 gpgcheck=1
 gpgkey=file:///etc/leapp/repos.d/system_upgrade/common/files/rpm-gpg/8/RPM-GPG-KEY-AlmaLinux-8

--- a/files/almalinux/leapp_upgrade_repositories.repo.el9
+++ b/files/almalinux/leapp_upgrade_repositories.repo.el9
@@ -1,79 +1,79 @@
 [almalinux9-baseos]
-name=AlmaLinux 9 - BaseOS
-mirrorlist=https://mirrors.almalinux.org/mirrorlist/9/baseos
-# baseurl=https://repo.almalinux.org/almalinux/9/BaseOS/$basearch/os/
+name=AlmaLinux $releasever - BaseOS
+mirrorlist=https://mirrors.almalinux.org/mirrorlist/$releasever/baseos
+# baseurl=https://repo.almalinux.org/almalinux/$releasever/BaseOS/$basearch/os/
 enabled=1
 gpgcheck=1
 gpgkey=file:///etc/leapp/repos.d/system_upgrade/common/files/rpm-gpg/9/RPM-GPG-KEY-AlmaLinux-9
 
 [almalinux9-appstream]
-name=AlmaLinux 9 - AppStream
-mirrorlist=https://mirrors.almalinux.org/mirrorlist/9/appstream
-# baseurl=https://repo.almalinux.org/almalinux/9/AppStream/$basearch/os/
+name=AlmaLinux $releasever - AppStream
+mirrorlist=https://mirrors.almalinux.org/mirrorlist/$releasever/appstream
+# baseurl=https://repo.almalinux.org/almalinux/$releasever/AppStream/$basearch/os/
 enabled=1
 gpgcheck=1
 gpgkey=file:///etc/leapp/repos.d/system_upgrade/common/files/rpm-gpg/9/RPM-GPG-KEY-AlmaLinux-9
 
 [almalinux9-crb]
-name=AlmaLinux 9 - CRB
-mirrorlist=https://mirrors.almalinux.org/mirrorlist/9/crb
-# baseurl=https://repo.almalinux.org/almalinux/9/CRB/$basearch/os/
+name=AlmaLinux $releasever - CRB
+mirrorlist=https://mirrors.almalinux.org/mirrorlist/$releasever/crb
+# baseurl=https://repo.almalinux.org/almalinux/$releasever/CRB/$basearch/os/
 enabled=1
 gpgcheck=1
 gpgkey=file:///etc/leapp/repos.d/system_upgrade/common/files/rpm-gpg/9/RPM-GPG-KEY-AlmaLinux-9
 
 [almalinux9-highavailability]
-name=AlmaLinux 9 - HighAvailability
-mirrorlist=https://mirrors.almalinux.org/mirrorlist/9/ha
-# baseurl=https://repo.almalinux.org/almalinux/9/HighAvailability/$basearch/os/
+name=AlmaLinux $releasever - HighAvailability
+mirrorlist=https://mirrors.almalinux.org/mirrorlist/$releasever/ha
+# baseurl=https://repo.almalinux.org/almalinux/$releasever/HighAvailability/$basearch/os/
 enabled=1
 gpgcheck=1
 gpgkey=file:///etc/leapp/repos.d/system_upgrade/common/files/rpm-gpg/9/RPM-GPG-KEY-AlmaLinux-9
 
 [almalinux9-resilientstorage]
-name=AlmaLinux 9 - ResilientStorage
-mirrorlist=https://mirrors.almalinux.org/mirrorlist/9/resilientstorage
-# baseurl=https://repo.almalinux.org/almalinux/9/ResilientStorage/$basearch/os/
+name=AlmaLinux $releasever - ResilientStorage
+mirrorlist=https://mirrors.almalinux.org/mirrorlist/$releasever/resilientstorage
+# baseurl=https://repo.almalinux.org/almalinux/$releasever/ResilientStorage/$basearch/os/
 enabled=1
 gpgcheck=1
 gpgkey=file:///etc/leapp/repos.d/system_upgrade/common/files/rpm-gpg/9/RPM-GPG-KEY-AlmaLinux-9
 
 [almalinux9-extras]
-name=AlmaLinux 9 - Extras
-mirrorlist=https://mirrors.almalinux.org/mirrorlist/9/extras
-# baseurl=https://repo.almalinux.org/almalinux/9/extras/$basearch/os/
+name=AlmaLinux $releasever - Extras
+mirrorlist=https://mirrors.almalinux.org/mirrorlist/$releasever/extras
+# baseurl=https://repo.almalinux.org/almalinux/$releasever/extras/$basearch/os/
 enabled=1
 gpgcheck=1
 gpgkey=file:///etc/leapp/repos.d/system_upgrade/common/files/rpm-gpg/9/RPM-GPG-KEY-AlmaLinux-9
 
 [almalinux9-sap]
-name=AlmaLinux 9 - SAP
-mirrorlist=https://mirrors.almalinux.org/mirrorlist/9/sap
-# baseurl=https://repo.almalinux.org/almalinux/9/SAP/$basearch/os/
+name=AlmaLinux $releasever - SAP
+mirrorlist=https://mirrors.almalinux.org/mirrorlist/$releasever/sap
+# baseurl=https://repo.almalinux.org/almalinux/$releasever/SAP/$basearch/os/
 enabled=1
 gpgcheck=1
 gpgkey=file:///etc/leapp/repos.d/system_upgrade/common/files/rpm-gpg/9/RPM-GPG-KEY-AlmaLinux-9
 
 [almalinux9-saphana]
-name=AlmaLinux 9 - SAPHANA
-mirrorlist=https://mirrors.almalinux.org/mirrorlist/9/saphana
-# baseurl=https://repo.almalinux.org/almalinux/9/SAPHANA/$basearch/os/
+name=AlmaLinux $releasever - SAPHANA
+mirrorlist=https://mirrors.almalinux.org/mirrorlist/$releasever/saphana
+# baseurl=https://repo.almalinux.org/almalinux/$releasever/SAPHANA/$basearch/os/
 enabled=1
 gpgcheck=1
 gpgkey=file:///etc/leapp/repos.d/system_upgrade/common/files/rpm-gpg/9/RPM-GPG-KEY-AlmaLinux-9
 
 [almalinux9-rt]
-name=AlmaLinux 9 - RT
-mirrorlist=https://mirrors.almalinux.org/mirrorlist/9/rt
-# baseurl=https://repo.almalinux.org/almalinux/9/RT/$basearch/os/
+name=AlmaLinux $releasever - RT
+mirrorlist=https://mirrors.almalinux.org/mirrorlist/$releasever/rt
+# baseurl=https://repo.almalinux.org/almalinux/$releasever/RT/$basearch/os/
 enabled=1
 gpgcheck=1
 gpgkey=file:///etc/leapp/repos.d/system_upgrade/common/files/rpm-gpg/9/RPM-GPG-KEY-AlmaLinux-9
 
 [almalinux9-nfv]
-name=AlmaLinux 9 - NFV
-mirrorlist=https://mirrors.almalinux.org/mirrorlist/9/nfv
-# baseurl=https://repo.almalinux.org/almalinux/9/NFV/$basearch/os/
+name=AlmaLinux $releasever - NFV
+mirrorlist=https://mirrors.almalinux.org/mirrorlist/$releasever/nfv
+# baseurl=https://repo.almalinux.org/almalinux/$releasever/NFV/$basearch/os/
 enabled=1
 gpgcheck=1
 gpgkey=file:///etc/leapp/repos.d/system_upgrade/common/files/rpm-gpg/9/RPM-GPG-KEY-AlmaLinux-9

--- a/leapp-data.spec
+++ b/leapp-data.spec
@@ -46,7 +46,7 @@
 
 Name:		leapp-data-%{dist_name}
 Version:	0.4
-Release:	7%{?dist}.%{pes_events_build_date}
+Release:	8%{?dist}.%{pes_events_build_date}
 Summary:	data for migrating tool
 Group:		Applications/Databases
 License:	ASL 2.0
@@ -153,6 +153,9 @@ python3 tests/check_debranding.py %{buildroot}%{_sysconfdir}/leapp/files/pes-eve
 
 
 %changelog
+* Mon Oct 07 2024 Yuriy Kohut <ykohut@almalinux.org> - 0.4-8.20240827
+ - Change major release number into $releasever in AlmaLinux repositories configuration
+
 * Fri Sep 27 2024 Yuriy Kohut <ykohut@almalinux.org> - 0.4-7.20240827
  - Replace libunwind package if imunify360 vendor is enabled
  - Move GeoIP package if epel vendor is enabled


### PR DESCRIPTION
These are to enable upgrade path to older releases with `--target` option.