### PR TITLE
Support elevation on machines other than x86_64

### DIFF
--- a/files/almalinux/repomap.json.el8.in
+++ b/files/almalinux/repomap.json.el8.in
@@ -192,7 +192,7 @@
                     "major_version": "7",
                     "repo_type": "rpm",
                     "repoid": "base",
-                    "arch": "x86_64",
+                    "arch": "{arch}",
                     "channel": "ga"
                 }
             ]
@@ -204,7 +204,7 @@
                     "repoid": "almalinux8-baseos",
                     "major_version": "8",
                     "repo_type": "rpm",
-                    "arch": "x86_64",
+                    "arch": "{arch}",
                     "channel": "ga"
                 }
             ]
@@ -216,7 +216,7 @@
                     "major_version": "8",
                     "repo_type": "rpm",
                     "repoid": "almalinux8-appstream",
-                    "arch": "x86_64",
+                    "arch": "{arch}",
                     "channel": "ga"
                 }
             ]
@@ -228,7 +228,7 @@
                     "major_version": "8",
                     "repoid": "almalinux8-powertools",
                     "repo_type": "rpm",
-                    "arch": "x86_64",
+                    "arch": "{arch}",
                     "channel": "ga"
                 }
             ]
@@ -240,7 +240,7 @@
                     "major_version": "8",
                     "repo_type": "rpm",
                     "repoid": "almalinux8-ha",
-                    "arch": "x86_64",
+                    "arch": "{arch}",
                     "channel": "ga"
                 }
             ]
@@ -252,7 +252,7 @@
                     "major_version": "8",
                     "repo_type": "rpm",
                     "repoid": "almalinux8-resilientstorage",
-                    "arch": "x86_64",
+                    "arch": "{arch}",
                     "channel": "ga"
                 }
             ]
@@ -264,7 +264,7 @@
                     "major_version": "7",
                     "repo_type": "rpm",
                     "repoid": "updates",
-                    "arch": "x86_64",
+                    "arch": "{arch}",
                     "channel": "ga"
                 }
             ]
@@ -276,7 +276,7 @@
                     "major_version": "7",
                     "repo_type": "rpm",
                     "repoid": "extras",
-                    "arch": "x86_64",
+                    "arch": "{arch}",
                     "channel": "ga"
                 }
             ]
@@ -288,7 +288,7 @@
                     "major_version": "8",
                     "repo_type": "rpm",
                     "repoid": "almalinux8-extras",
-                    "arch": "x86_64",
+                    "arch": "{arch}",
                     "channel": "ga"
                 }
             ]
@@ -300,7 +300,7 @@
                     "major_version": "8",
                     "repo_type": "rpm",
                     "repoid": "almalinux8-nfv",
-                    "arch": "x86_64",
+                    "arch": "{arch}",
                     "channel": "ga"
                 }
             ]
@@ -312,7 +312,7 @@
                     "major_version": "8",
                     "repo_type": "rpm",
                     "repoid": "almalinux8-sap",
-                    "arch": "x86_64",
+                    "arch": "{arch}",
                     "channel": "ga"
                 }
             ]
@@ -324,7 +324,7 @@
                     "major_version": "8",
                     "repo_type": "rpm",
                     "repoid": "almalinux8-saphana",
-                    "arch": "x86_64",
+                    "arch": "{arch}",
                     "channel": "ga"
                 }
             ]
@@ -336,7 +336,7 @@
                     "major_version": "7",
                     "repo_type": "rpm",
                     "repoid": "centos7-els",
-                    "arch": "x86_64",
+                    "arch": "{arch}",
                     "channel": "ga"
                 }
             ]
@@ -348,7 +348,7 @@
                     "major_version": "7",
                     "repo_type": "rpm",
                     "repoid": "centos7-els-testing",
-                    "arch": "x86_64",
+                    "arch": "{arch}",
                     "channel": "ga"
                 }
             ]
@@ -360,7 +360,7 @@
                     "major_version": "7",
                     "repo_type": "rpm",
                     "repoid": "centos7els-rollout-1",
-                    "arch": "x86_64",
+                    "arch": "{arch}",
                     "channel": "ga"
                 }
             ]
@@ -372,7 +372,7 @@
                     "major_version": "7",
                     "repo_type": "rpm",
                     "repoid": "centos7els-rollout-1-bypass",
-                    "arch": "x86_64",
+                    "arch": "{arch}",
                     "channel": "ga"
                 }
             ]
@@ -384,7 +384,7 @@
                     "major_version": "7",
                     "repo_type": "rpm",
                     "repoid": "centos7els-rollout-2",
-                    "arch": "x86_64",
+                    "arch": "{arch}",
                     "channel": "ga"
                 }
             ]
@@ -396,7 +396,7 @@
                     "major_version": "7",
                     "repo_type": "rpm",
                     "repoid": "centos7els-rollout-2-bypass",
-                    "arch": "x86_64",
+                    "arch": "{arch}",
                     "channel": "ga"
                 }
             ]
@@ -408,7 +408,7 @@
                     "major_version": "7",
                     "repo_type": "rpm",
                     "repoid": "centos7els-rollout-3",
-                    "arch": "x86_64",
+                    "arch": "{arch}",
                     "channel": "ga"
                 }
             ]
@@ -420,7 +420,7 @@
                     "major_version": "7",
                     "repo_type": "rpm",
                     "repoid": "centos7els-rollout-3-bypass",
-                    "arch": "x86_64",
+                    "arch": "{arch}",
                     "channel": "ga"
                 }
             ]
@@ -432,7 +432,7 @@
                     "major_version": "7",
                     "repo_type": "rpm",
                     "repoid": "centos7els-rollout-4",
-                    "arch": "x86_64",
+                    "arch": "{arch}",
                     "channel": "ga"
                 }
             ]
@@ -444,7 +444,7 @@
                     "major_version": "7",
                     "repo_type": "rpm",
                     "repoid": "centos7els-rollout-4-bypass",
-                    "arch": "x86_64",
+                    "arch": "{arch}",
                     "channel": "ga"
                 }
             ]
@@ -456,7 +456,7 @@
                     "major_version": "7",
                     "repo_type": "rpm",
                     "repoid": "centos7els-rollout-5",
-                    "arch": "x86_64",
+                    "arch": "{arch}",
                     "channel": "ga"
                 }
             ]
@@ -468,7 +468,7 @@
                     "major_version": "7",
                     "repo_type": "rpm",
                     "repoid": "centos7els-rollout-5-bypass",
-                    "arch": "x86_64",
+                    "arch": "{arch}",
                     "channel": "ga"
                 }
             ]
@@ -480,7 +480,7 @@
                     "major_version": "7",
                     "repo_type": "rpm",
                     "repoid": "centos7els-rollout-6",
-                    "arch": "x86_64",
+                    "arch": "{arch}",
                     "channel": "ga"
                 }
             ]
@@ -492,7 +492,7 @@
                     "major_version": "7",
                     "repo_type": "rpm",
                     "repoid": "centos7els-rollout-6-bypass",
-                    "arch": "x86_64",
+                    "arch": "{arch}",
                     "channel": "ga"
                 }
             ]

--- a/files/almalinux/repomap.json.el9.in
+++ b/files/almalinux/repomap.json.el9.in
@@ -12,43 +12,61 @@
                 {
                     "source": "baseos",
                     "target": [
-                        "centos9-baseos"
+                        "almalinux9-baseos"
                     ]
                 },
                 {
                     "source": "appstream",
                     "target": [
-                        "centos9-appstream"
+                        "almalinux9-appstream"
                     ]
                 },
                 {
                     "source": "powertools",
                     "target": [
-                        "centos9-crb"
+                        "almalinux9-crb"
                     ]
                 },
                 {
                     "source": "ha",
                     "target": [
-                        "centos9-ha"
+                        "almalinux9-highavailability"
+                    ]
+                },
+                {
+                    "source": "resilientstorage",
+                    "target": [
+                        "almalinux9-resilientstorage"
                     ]
                 },
                 {
                     "source": "extras",
                     "target": [
-                        "centos9-extras"
+                        "almalinux9-extras"
                     ]
                 },
                 {
                     "source": "rt",
                     "target": [
-                        "centos9-rt"
+                        "almalinux9-rt"
                     ]
                 },
                 {
                     "source": "nfv",
                     "target": [
-                        "centos9-extras"
+                        "almalinux9-nfv"
+                    ]
+                },
+                {
+                    "source": "sap",
+                    "target": [
+                        "almalinux9-sap"
+                    ]
+                },
+                {
+                    "source": "saphana",
+                    "target": [
+                        "almalinux9-saphana"
                     ]
                 }
             ]
@@ -62,7 +80,7 @@
                     "repoid": "baseos",
                     "major_version": "8",
                     "repo_type": "rpm",
-                    "arch": "x86_64",
+                    "arch": "{arch}",
                     "channel": "ga"
                 }
             ]
@@ -74,7 +92,7 @@
                     "major_version": "8",
                     "repo_type": "rpm",
                     "repoid": "appstream",
-                    "arch": "x86_64",
+                    "arch": "{arch}",
                     "channel": "ga"
                 }
             ]
@@ -86,7 +104,7 @@
                     "major_version": "8",
                     "repoid": "powertools",
                     "repo_type": "rpm",
-                    "arch": "x86_64",
+                    "arch": "{arch}",
                     "channel": "ga"
                 }
             ]
@@ -98,7 +116,19 @@
                     "major_version": "8",
                     "repo_type": "rpm",
                     "repoid": "ha",
-                    "arch": "x86_64",
+                    "arch": "{arch}",
+                    "channel": "ga"
+                }
+            ]
+        },
+        {
+            "pesid": "resilientstorage",
+            "entries": [
+                {
+                    "major_version": "8",
+                    "repo_type": "rpm",
+                    "repoid": "resilientstorage",
+                    "arch": "{arch}",
                     "channel": "ga"
                 }
             ]
@@ -110,7 +140,7 @@
                     "major_version": "8",
                     "repo_type": "rpm",
                     "repoid": "extras",
-                    "arch": "x86_64",
+                    "arch": "{arch}",
                     "channel": "ga"
                 }
             ]
@@ -122,7 +152,7 @@
                     "major_version": "8",
                     "repo_type": "rpm",
                     "repoid": "rt",
-                    "arch": "x86_64",
+                    "arch": "{arch}",
                     "channel": "ga"
                 }
             ]
@@ -134,91 +164,151 @@
                     "major_version": "8",
                     "repo_type": "rpm",
                     "repoid": "nfv",
-                    "arch": "x86_64",
-                    "channel": "ga"
-                }
-            ]
-        },
-	{
-            "pesid": "centos9-baseos",
-            "entries": [
-                {
-                    "repoid": "centos9-baseos",
-                    "major_version": "9",
-                    "repo_type": "rpm",
-                    "arch": "x86_64",
+                    "arch": "{arch}",
                     "channel": "ga"
                 }
             ]
         },
         {
-            "pesid": "centos9-appstream",
+            "pesid": "sap",
             "entries": [
                 {
-                    "major_version": "9",
+                    "major_version": "8",
                     "repo_type": "rpm",
-                    "repoid": "centos9-appstream",
-                    "arch": "x86_64",
+                    "repoid": "sap",
+                    "arch": "{arch}",
                     "channel": "ga"
                 }
             ]
         },
         {
-            "pesid": "centos9-crb",
+            "pesid": "saphana",
             "entries": [
                 {
-                    "major_version": "9",
-                    "repoid": "centos9-crb",
+                    "major_version": "8",
                     "repo_type": "rpm",
-                    "arch": "x86_64",
+                    "repoid": "saphana",
+                    "arch": "{arch}",
                     "channel": "ga"
                 }
             ]
         },
         {
-            "pesid": "centos9-ha",
+            "pesid": "almalinux9-baseos",
             "entries": [
                 {
+                    "repoid": "almalinux9-baseos",
                     "major_version": "9",
                     "repo_type": "rpm",
-                    "repoid": "centos9-ha",
-                    "arch": "x86_64",
+                    "arch": "{arch}",
                     "channel": "ga"
                 }
             ]
         },
         {
-            "pesid": "centos9-extras",
+            "pesid": "almalinux9-appstream",
             "entries": [
                 {
                     "major_version": "9",
                     "repo_type": "rpm",
-                    "repoid": "centos9-extras",
-                    "arch": "x86_64",
+                    "repoid": "almalinux9-appstream",
+                    "arch": "{arch}",
                     "channel": "ga"
                 }
             ]
         },
         {
-            "pesid": "centos9-rt",
+            "pesid": "almalinux9-crb",
             "entries": [
                 {
                     "major_version": "9",
+                    "repoid": "almalinux9-crb",
                     "repo_type": "rpm",
-                    "repoid": "centos9-rt",
-                    "arch": "x86_64",
+                    "arch": "{arch}",
                     "channel": "ga"
                 }
             ]
         },
         {
-            "pesid": "centos9-nfv",
+            "pesid": "almalinux9-highavailability",
             "entries": [
                 {
                     "major_version": "9",
                     "repo_type": "rpm",
-                    "repoid": "centos9-nfv",
-                    "arch": "x86_64",
+                    "repoid": "almalinux9-highavailability",
+                    "arch": "{arch}",
+                    "channel": "ga"
+                }
+            ]
+        },
+        {
+            "pesid": "almalinux9-resilientstorage",
+            "entries": [
+                {
+                    "major_version": "9",
+                    "repo_type": "rpm",
+                    "repoid": "almalinux9-resilientstorage",
+                    "arch": "{arch}",
+                    "channel": "ga"
+                }
+            ]
+        },
+        {
+            "pesid": "almalinux9-extras",
+            "entries": [
+                {
+                    "major_version": "9",
+                    "repo_type": "rpm",
+                    "repoid": "almalinux9-extras",
+                    "arch": "{arch}",
+                    "channel": "ga"
+                }
+            ]
+        },
+        {
+            "pesid": "almalinux9-rt",
+            "entries": [
+                {
+                    "major_version": "9",
+                    "repo_type": "rpm",
+                    "repoid": "almalinux9-rt",
+                    "arch": "{arch}",
+                    "channel": "ga"
+                }
+            ]
+        },
+        {
+            "pesid": "almalinux9-nfv",
+            "entries": [
+                {
+                    "major_version": "9",
+                    "repo_type": "rpm",
+                    "repoid": "almalinux9-nfv",
+                    "arch": "{arch}",
+                    "channel": "ga"
+                }
+            ]
+        },
+        {
+            "pesid": "almalinux9-sap",
+            "entries": [
+                {
+                    "major_version": "9",
+                    "repo_type": "rpm",
+                    "repoid": "almalinux9-sap",
+                    "arch": "{arch}",
+                    "channel": "ga"
+                }
+            ]
+        },
+        {
+            "pesid": "almalinux9-saphana",
+            "entries": [
+                {
+                    "major_version": "9",
+                    "repo_type": "rpm",
+                    "repoid": "almalinux9-saphana",
+                    "arch": "{arch}",
                     "channel": "ga"
                 }
             ]

--- a/files/centos/repomap.json.el8.in
+++ b/files/centos/repomap.json.el8.in
@@ -46,7 +46,7 @@
             "entries": [
                 {
                     "repo_type": "rpm",
-                    "arch": "x86_64",
+                    "arch": "{arch}",
                     "major_version": "7",
                     "repoid": "base",
                     "channel": "ga"
@@ -60,7 +60,7 @@
                     "repo_type": "rpm",
                     "repoid": "centos8-baseos",
                     "major_version": "8",
-                    "arch": "x86_64",
+                    "arch": "{arch}",
                     "channel": "ga"
                 }
             ]
@@ -71,7 +71,7 @@
                 {
                     "repo_type": "rpm",
                     "major_version": "8",
-                    "arch": "x86_64",
+                    "arch": "{arch}",
                     "repoid": "centos8-appstream",
                     "channel": "ga"
                 }
@@ -84,7 +84,7 @@
                     "repoid": "centos8-powertools",
                     "repo_type": "rpm",
                     "major_version": "8",
-                    "arch": "x86_64",
+                    "arch": "{arch}",
                     "channel": "ga"
                 }
             ]
@@ -95,7 +95,7 @@
                 {
                     "repo_type": "rpm",
                     "major_version": "8",
-                    "arch": "x86_64",
+                    "arch": "{arch}",
                     "repoid": "centos8-ha",
                     "channel": "ga"
                 }
@@ -106,7 +106,7 @@
             "entries": [
                 {
                     "repo_type": "rpm",
-                    "arch": "x86_64",
+                    "arch": "{arch}",
                     "major_version": "7",
                     "repoid": "updates",
                     "channel": "ga"
@@ -119,7 +119,7 @@
                 {
                     "repo_type": "rpm",
                     "repoid": "extras",
-                    "arch": "x86_64",
+                    "arch": "{arch}",
                     "major_version": "7",
                     "channel": "ga"
                 }
@@ -132,7 +132,7 @@
                     "repo_type": "rpm",
                     "repoid": "centos8-extras",
                     "major_version": "8",
-                    "arch": "x86_64",
+                    "arch": "{arch}",
                     "channel": "ga"
                 }
             ]
@@ -144,7 +144,7 @@
                     "repo_type": "rpm",
                     "repoid": "centos8-rt",
                     "major_version": "8",
-                    "arch": "x86_64",
+                    "arch": "{arch}",
                     "channel": "ga"
                 }
             ]
@@ -156,7 +156,7 @@
                     "repo_type": "rpm",
                     "repoid": "centos8-nfv",
                     "major_version": "8",
-                    "arch": "x86_64",
+                    "arch": "{arch}",
                     "channel": "ga"
                 }
             ]

--- a/files/centos/repomap.json.el9.in
+++ b/files/centos/repomap.json.el9.in
@@ -12,61 +12,43 @@
                 {
                     "source": "baseos",
                     "target": [
-                        "almalinux9-baseos"
+                        "centos9-baseos"
                     ]
                 },
                 {
                     "source": "appstream",
                     "target": [
-                        "almalinux9-appstream"
+                        "centos9-appstream"
                     ]
                 },
                 {
                     "source": "powertools",
                     "target": [
-                        "almalinux9-crb"
+                        "centos9-crb"
                     ]
                 },
                 {
                     "source": "ha",
                     "target": [
-                        "almalinux9-highavailability"
-                    ]
-                },
-                {
-                    "source": "resilientstorage",
-                    "target": [
-                        "almalinux9-resilientstorage"
+                        "centos9-ha"
                     ]
                 },
                 {
                     "source": "extras",
                     "target": [
-                        "almalinux9-extras"
+                        "centos9-extras"
                     ]
                 },
                 {
                     "source": "rt",
                     "target": [
-                        "almalinux9-rt"
+                        "centos9-rt"
                     ]
                 },
                 {
                     "source": "nfv",
                     "target": [
-                        "almalinux9-nfv"
-                    ]
-                },
-                {
-                    "source": "sap",
-                    "target": [
-                        "almalinux9-sap"
-                    ]
-                },
-                {
-                    "source": "saphana",
-                    "target": [
-                        "almalinux9-saphana"
+                        "centos9-extras"
                     ]
                 }
             ]
@@ -80,7 +62,7 @@
                     "repoid": "baseos",
                     "major_version": "8",
                     "repo_type": "rpm",
-                    "arch": "x86_64",
+                    "arch": "{arch}",
                     "channel": "ga"
                 }
             ]
@@ -92,7 +74,7 @@
                     "major_version": "8",
                     "repo_type": "rpm",
                     "repoid": "appstream",
-                    "arch": "x86_64",
+                    "arch": "{arch}",
                     "channel": "ga"
                 }
             ]
@@ -104,7 +86,7 @@
                     "major_version": "8",
                     "repoid": "powertools",
                     "repo_type": "rpm",
-                    "arch": "x86_64",
+                    "arch": "{arch}",
                     "channel": "ga"
                 }
             ]
@@ -116,19 +98,7 @@
                     "major_version": "8",
                     "repo_type": "rpm",
                     "repoid": "ha",
-                    "arch": "x86_64",
-                    "channel": "ga"
-                }
-            ]
-        },
-        {
-            "pesid": "resilientstorage",
-            "entries": [
-                {
-                    "major_version": "8",
-                    "repo_type": "rpm",
-                    "repoid": "resilientstorage",
-                    "arch": "x86_64",
+                    "arch": "{arch}",
                     "channel": "ga"
                 }
             ]
@@ -140,7 +110,7 @@
                     "major_version": "8",
                     "repo_type": "rpm",
                     "repoid": "extras",
-                    "arch": "x86_64",
+                    "arch": "{arch}",
                     "channel": "ga"
                 }
             ]
@@ -152,7 +122,7 @@
                     "major_version": "8",
                     "repo_type": "rpm",
                     "repoid": "rt",
-                    "arch": "x86_64",
+                    "arch": "{arch}",
                     "channel": "ga"
                 }
             ]
@@ -164,151 +134,91 @@
                     "major_version": "8",
                     "repo_type": "rpm",
                     "repoid": "nfv",
-                    "arch": "x86_64",
+                    "arch": "{arch}",
                     "channel": "ga"
                 }
             ]
         },
-        {
-            "pesid": "sap",
+	{
+            "pesid": "centos9-baseos",
             "entries": [
                 {
-                    "major_version": "8",
-                    "repo_type": "rpm",
-                    "repoid": "sap",
-                    "arch": "x86_64",
-                    "channel": "ga"
-                }
-            ]
-        },
-        {
-            "pesid": "saphana",
-            "entries": [
-                {
-                    "major_version": "8",
-                    "repo_type": "rpm",
-                    "repoid": "saphana",
-                    "arch": "x86_64",
-                    "channel": "ga"
-                }
-            ]
-        },
-        {
-            "pesid": "almalinux9-baseos",
-            "entries": [
-                {
-                    "repoid": "almalinux9-baseos",
+                    "repoid": "centos9-baseos",
                     "major_version": "9",
                     "repo_type": "rpm",
-                    "arch": "x86_64",
+                    "arch": "{arch}",
                     "channel": "ga"
                 }
             ]
         },
         {
-            "pesid": "almalinux9-appstream",
+            "pesid": "centos9-appstream",
             "entries": [
                 {
                     "major_version": "9",
                     "repo_type": "rpm",
-                    "repoid": "almalinux9-appstream",
-                    "arch": "x86_64",
+                    "repoid": "centos9-appstream",
+                    "arch": "{arch}",
                     "channel": "ga"
                 }
             ]
         },
         {
-            "pesid": "almalinux9-crb",
+            "pesid": "centos9-crb",
             "entries": [
                 {
                     "major_version": "9",
-                    "repoid": "almalinux9-crb",
+                    "repoid": "centos9-crb",
                     "repo_type": "rpm",
-                    "arch": "x86_64",
+                    "arch": "{arch}",
                     "channel": "ga"
                 }
             ]
         },
         {
-            "pesid": "almalinux9-highavailability",
+            "pesid": "centos9-ha",
             "entries": [
                 {
                     "major_version": "9",
                     "repo_type": "rpm",
-                    "repoid": "almalinux9-highavailability",
-                    "arch": "x86_64",
+                    "repoid": "centos9-ha",
+                    "arch": "{arch}",
                     "channel": "ga"
                 }
             ]
         },
         {
-            "pesid": "almalinux9-resilientstorage",
+            "pesid": "centos9-extras",
             "entries": [
                 {
                     "major_version": "9",
                     "repo_type": "rpm",
-                    "repoid": "almalinux9-resilientstorage",
-                    "arch": "x86_64",
+                    "repoid": "centos9-extras",
+                    "arch": "{arch}",
                     "channel": "ga"
                 }
             ]
         },
         {
-            "pesid": "almalinux9-extras",
+            "pesid": "centos9-rt",
             "entries": [
                 {
                     "major_version": "9",
                     "repo_type": "rpm",
-                    "repoid": "almalinux9-extras",
-                    "arch": "x86_64",
+                    "repoid": "centos9-rt",
+                    "arch": "{arch}",
                     "channel": "ga"
                 }
             ]
         },
         {
-            "pesid": "almalinux9-rt",
+            "pesid": "centos9-nfv",
             "entries": [
                 {
                     "major_version": "9",
                     "repo_type": "rpm",
-                    "repoid": "almalinux9-rt",
-                    "arch": "x86_64",
-                    "channel": "ga"
-                }
-            ]
-        },
-        {
-            "pesid": "almalinux9-nfv",
-            "entries": [
-                {
-                    "major_version": "9",
-                    "repo_type": "rpm",
-                    "repoid": "almalinux9-nfv",
-                    "arch": "x86_64",
-                    "channel": "ga"
-                }
-            ]
-        },
-        {
-            "pesid": "almalinux9-sap",
-            "entries": [
-                {
-                    "major_version": "9",
-                    "repo_type": "rpm",
-                    "repoid": "almalinux9-sap",
-                    "arch": "x86_64",
-                    "channel": "ga"
-                }
-            ]
-        },
-        {
-            "pesid": "almalinux9-saphana",
-            "entries": [
-                {
-                    "major_version": "9",
-                    "repo_type": "rpm",
-                    "repoid": "almalinux9-saphana",
-                    "arch": "x86_64",
+                    "repoid": "centos9-nfv",
+                    "arch": "{arch}",
                     "channel": "ga"
                 }
             ]

--- a/files/eurolinux/repomap.json.el8.in
+++ b/files/eurolinux/repomap.json.el8.in
@@ -43,7 +43,7 @@
             "pesid": "base",
             "entries": [
                 {
-                    "arch": "x86_64",
+                    "arch": "{arch}",
                     "repo_type": "rpm",
                     "repoid": "base",
                     "major_version": "7",
@@ -55,7 +55,7 @@
             "pesid": "certify-baseos",
             "entries": [
                 {
-                    "arch": "x86_64",
+                    "arch": "{arch}",
                     "repo_type": "rpm",
                     "repoid": "certify-baseos",
                     "channel": "ga",
@@ -67,7 +67,7 @@
             "pesid": "certify-appstream",
             "entries": [
                 {
-                    "arch": "x86_64",
+                    "arch": "{arch}",
                     "repo_type": "rpm",
                     "repoid": "certify-appstream",
                     "channel": "ga",
@@ -79,7 +79,7 @@
             "pesid": "certify-powertools",
             "entries": [
                 {
-                    "arch": "x86_64",
+                    "arch": "{arch}",
                     "repo_type": "rpm",
                     "repoid": "certify-powertools",
                     "channel": "ga",
@@ -91,7 +91,7 @@
             "pesid": "high-availability",
             "entries": [
                 {
-                    "arch": "x86_64",
+                    "arch": "{arch}",
                     "repo_type": "rpm",
                     "repoid": "high-availability",
                     "channel": "ga",
@@ -103,7 +103,7 @@
             "pesid": "resilient-storage",
             "entries": [
                 {
-                    "arch": "x86_64",
+                    "arch": "{arch}",
                     "repoid": "resilient-storage",
                     "repo_type": "rpm",
                     "channel": "ga",
@@ -115,7 +115,7 @@
             "pesid": "updates",
             "entries": [
                 {
-                    "arch": "x86_64",
+                    "arch": "{arch}",
                     "repoid": "updates",
                     "repo_type": "rpm",
                     "major_version": "7",
@@ -127,7 +127,7 @@
             "pesid": "extras",
             "entries": [
                 {
-                    "arch": "x86_64",
+                    "arch": "{arch}",
                     "repo_type": "rpm",
                     "major_version": "7",
                     "repoid": "extras",

--- a/files/eurolinux/repomap.json.el9.in
+++ b/files/eurolinux/repomap.json.el9.in
@@ -50,7 +50,7 @@
                     "repoid": "baseos",
                     "major_version": "8",
                     "repo_type": "rpm",
-                    "arch": "x86_64",
+                    "arch": "{arch}",
                     "channel": "ga"
                 }
             ]
@@ -62,7 +62,7 @@
                     "major_version": "8",
                     "repo_type": "rpm",
                     "repoid": "appstream",
-                    "arch": "x86_64",
+                    "arch": "{arch}",
                     "channel": "ga"
                 }
             ]
@@ -74,7 +74,7 @@
                     "major_version": "8",
                     "repoid": "powertools",
                     "repo_type": "rpm",
-                    "arch": "x86_64",
+                    "arch": "{arch}",
                     "channel": "ga"
                 }
             ]
@@ -86,7 +86,7 @@
                     "major_version": "8",
                     "repo_type": "rpm",
                     "repoid": "high-availability",
-                    "arch": "x86_64",
+                    "arch": "{arch}",
                     "channel": "ga"
                 }
             ]
@@ -98,7 +98,7 @@
                     "major_version": "8",
                     "repo_type": "rpm",
                     "repoid": "resilient-storage",
-                    "arch": "x86_64",
+                    "arch": "{arch}",
                     "channel": "ga"
                 }
             ]
@@ -110,7 +110,7 @@
                     "repoid": "certify-baseos-9",
                     "major_version": "9",
                     "repo_type": "rpm",
-                    "arch": "x86_64",
+                    "arch": "{arch}",
                     "channel": "ga"
                 }
             ]
@@ -122,7 +122,7 @@
                     "major_version": "9",
                     "repo_type": "rpm",
                     "repoid": "certify-appstream-9",
-                    "arch": "x86_64",
+                    "arch": "{arch}",
                     "channel": "ga"
                 }
             ]
@@ -134,7 +134,7 @@
                     "major_version": "9",
                     "repoid": "certify-powertools-9",
                     "repo_type": "rpm",
-                    "arch": "x86_64",
+                    "arch": "{arch}",
                     "channel": "ga"
                 }
             ]
@@ -146,7 +146,7 @@
                     "major_version": "9",
                     "repo_type": "rpm",
                     "repoid": "high-availability-9",
-                    "arch": "x86_64",
+                    "arch": "{arch}",
                     "channel": "ga"
                 }
             ]
@@ -158,7 +158,7 @@
                     "major_version": "9",
                     "repo_type": "rpm",
                     "repoid": "resilient-storage-9",
-                    "arch": "x86_64",
+                    "arch": "{arch}",
                     "channel": "ga"
                 }
             ]

--- a/files/oraclelinux/repomap.json.el8.in
+++ b/files/oraclelinux/repomap.json.el8.in
@@ -46,7 +46,7 @@
                     "repoid": "base",
                     "major_version": "7",
                     "channel": "ga",
-                    "arch": "x86_64",
+                    "arch": "{arch}",
                     "repo_type": "rpm"
                 },
                 {
@@ -71,7 +71,7 @@
                 {
                     "repoid": "ol8_baseos_latest",
                     "channel": "ga",
-                    "arch": "x86_64",
+                    "arch": "{arch}",
                     "major_version": "8",
                     "repo_type": "rpm"
                 }
@@ -90,7 +90,7 @@
                 {
                     "channel": "ga",
                     "repoid": "ol8_appstream",
-                    "arch": "x86_64",
+                    "arch": "{arch}",
                     "major_version": "8",
                     "repo_type": "rpm"
                 }
@@ -109,7 +109,7 @@
                 {
                     "repoid": "ol8_codeready_builder",
                     "channel": "ga",
-                    "arch": "x86_64",
+                    "arch": "{arch}",
                     "major_version": "8",
                     "repo_type": "rpm"
                 }
@@ -121,7 +121,7 @@
                 {
                     "repoid": "ol8_addons",
                     "channel": "ga",
-                    "arch": "x86_64",
+                    "arch": "{arch}",
                     "major_version": "8",
                     "repo_type": "rpm"
                 },
@@ -140,7 +140,7 @@
                 {
                     "channel": "ga",
                     "repoid": "ol8_UEKR6",
-                    "arch": "x86_64",
+                    "arch": "{arch}",
                     "major_version": "8",
                     "repo_type": "rpm"
                 },
@@ -160,7 +160,7 @@
                     "major_version": "7",
                     "channel": "ga",
                     "repoid": "updates",
-                    "arch": "x86_64",
+                    "arch": "{arch}",
                     "repo_type": "rpm"
                 },
                 {
@@ -186,7 +186,7 @@
                     "major_version": "7",
                     "repoid": "extras",
                     "channel": "ga",
-                    "arch": "x86_64",
+                    "arch": "{arch}",
                     "repo_type": "rpm"
                 }
             ]

--- a/files/rocky/repomap.json.el8.in
+++ b/files/rocky/repomap.json.el8.in
@@ -49,7 +49,7 @@
                     "repoid": "base",
                     "major_version": "7",
                     "repo_type": "rpm",
-                    "arch": "x86_64"
+                    "arch": "{arch}"
                 }
             ]
         },
@@ -61,7 +61,7 @@
                     "repoid": "rocky8-baseos",
                     "major_version": "8",
                     "repo_type": "rpm",
-                    "arch": "x86_64"
+                    "arch": "{arch}"
                 }
             ]
         },
@@ -73,7 +73,7 @@
                     "major_version": "8",
                     "repo_type": "rpm",
                     "repoid": "rocky8-appstream",
-                    "arch": "x86_64"
+                    "arch": "{arch}"
                 }
             ]
         },
@@ -85,7 +85,7 @@
                     "major_version": "8",
                     "repo_type": "rpm",
                     "repoid": "rocky8-powertools",
-                    "arch": "x86_64"
+                    "arch": "{arch}"
                 }
             ]
         },
@@ -97,7 +97,7 @@
                     "channel": "ga",
                     "major_version": "8",
                     "repo_type": "rpm",
-                    "arch": "x86_64"
+                    "arch": "{arch}"
                 }
             ]
         },
@@ -109,7 +109,7 @@
                     "major_version": "8",
                     "repo_type": "rpm",
                     "repoid": "rocky8-resilient-storage",
-                    "arch": "x86_64"
+                    "arch": "{arch}"
                 }
             ]
         },
@@ -121,7 +121,7 @@
                     "major_version": "7",
                     "repo_type": "rpm",
                     "repoid": "updates",
-                    "arch": "x86_64"
+                    "arch": "{arch}"
                 }
             ]
         },
@@ -133,7 +133,7 @@
                     "repoid": "extras",
                     "major_version": "7",
                     "repo_type": "rpm",
-                    "arch": "x86_64"
+                    "arch": "{arch}"
                 }
             ]
         },
@@ -144,7 +144,7 @@
                     "channel": "ga",
                     "major_version": "8",
                     "repo_type": "rpm",
-                    "arch": "x86_64",
+                    "arch": "{arch}",
                     "repoid": "rocky8-extras"
                 }
             ]
@@ -156,7 +156,7 @@
                     "channel": "ga",
                     "major_version": "8",
                     "repo_type": "rpm",
-                    "arch": "x86_64",
+                    "arch": "{arch}",
                     "repoid": "rocky8-rt"
                 }
             ]
@@ -168,7 +168,7 @@
                     "channel": "ga",
                     "major_version": "8",
                     "repo_type": "rpm",
-                    "arch": "x86_64",
+                    "arch": "{arch}",
                     "repoid": "rocky8-nfv"
                 }
             ]

--- a/files/rocky/repomap.json.el9.in
+++ b/files/rocky/repomap.json.el9.in
@@ -80,7 +80,7 @@
                     "repoid": "baseos",
                     "major_version": "8",
                     "repo_type": "rpm",
-                    "arch": "x86_64",
+                    "arch": "{arch}",
                     "channel": "ga"
                 }
             ]
@@ -92,7 +92,7 @@
                     "major_version": "8",
                     "repo_type": "rpm",
                     "repoid": "appstream",
-                    "arch": "x86_64",
+                    "arch": "{arch}",
                     "channel": "ga"
                 }
             ]
@@ -104,7 +104,7 @@
                     "major_version": "8",
                     "repoid": "powertools",
                     "repo_type": "rpm",
-                    "arch": "x86_64",
+                    "arch": "{arch}",
                     "channel": "ga"
                 }
             ]
@@ -116,7 +116,7 @@
                     "major_version": "8",
                     "repo_type": "rpm",
                     "repoid": "ha",
-                    "arch": "x86_64",
+                    "arch": "{arch}",
                     "channel": "ga"
                 }
             ]
@@ -128,7 +128,7 @@
                     "major_version": "8",
                     "repo_type": "rpm",
                     "repoid": "rt",
-                    "arch": "x86_64",
+                    "arch": "{arch}",
                     "channel": "ga"
                 }
             ]
@@ -140,7 +140,7 @@
                     "major_version": "8",
                     "repo_type": "rpm",
                     "repoid": "nfv",
-                    "arch": "x86_64",
+                    "arch": "{arch}",
                     "channel": "ga"
                 }
             ]
@@ -152,7 +152,7 @@
                     "major_version": "8",
                     "repo_type": "rpm",
                     "repoid": "sap",
-                    "arch": "x86_64",
+                    "arch": "{arch}",
                     "channel": "ga"
                 }
             ]
@@ -164,7 +164,7 @@
                     "major_version": "8",
                     "repo_type": "rpm",
                     "repoid": "saphana",
-                    "arch": "x86_64",
+                    "arch": "{arch}",
                     "channel": "ga"
                 }
             ]
@@ -176,7 +176,7 @@
                     "major_version": "8",
                     "repo_type": "rpm",
                     "repoid": "resilient-storage",
-                    "arch": "x86_64",
+                    "arch": "{arch}",
                     "channel": "ga"
                 }
             ]
@@ -188,7 +188,7 @@
                     "major_version": "8",
                     "repo_type": "rpm",
                     "repoid": "extras",
-                    "arch": "x86_64",
+                    "arch": "{arch}",
                     "channel": "ga"
                 }
             ]
@@ -200,7 +200,7 @@
                     "repoid": "rocky9-baseos",
                     "major_version": "9",
                     "repo_type": "rpm",
-                    "arch": "x86_64",
+                    "arch": "{arch}",
                     "channel": "ga"
                 }
             ]
@@ -212,7 +212,7 @@
                     "major_version": "9",
                     "repo_type": "rpm",
                     "repoid": "rocky9-appstream",
-                    "arch": "x86_64",
+                    "arch": "{arch}",
                     "channel": "ga"
                 }
             ]
@@ -224,7 +224,7 @@
                     "major_version": "9",
                     "repoid": "rocky9-crb",
                     "repo_type": "rpm",
-                    "arch": "x86_64",
+                    "arch": "{arch}",
                     "channel": "ga"
                 }
             ]
@@ -236,7 +236,7 @@
                     "major_version": "9",
                     "repo_type": "rpm",
                     "repoid": "rocky9-ha",
-                    "arch": "x86_64",
+                    "arch": "{arch}",
                     "channel": "ga"
                 }
             ]
@@ -248,7 +248,7 @@
                     "major_version": "9",
                     "repo_type": "rpm",
                     "repoid": "rocky9-resilient-storage",
-                    "arch": "x86_64",
+                    "arch": "{arch}",
                     "channel": "ga"
                 }
             ]
@@ -260,7 +260,7 @@
                     "major_version": "9",
                     "repo_type": "rpm",
                     "repoid": "rocky9-extras",
-                    "arch": "x86_64",
+                    "arch": "{arch}",
                     "channel": "ga"
                 }
             ]
@@ -272,7 +272,7 @@
                     "major_version": "9",
                     "repo_type": "rpm",
                     "repoid": "rocky9-rt",
-                    "arch": "x86_64",
+                    "arch": "{arch}",
                     "channel": "ga"
                 }
             ]
@@ -284,7 +284,7 @@
                     "major_version": "9",
                     "repo_type": "rpm",
                     "repoid": "rocky9-nfv",
-                    "arch": "x86_64",
+                    "arch": "{arch}",
                     "channel": "ga"
                 }
             ]
@@ -296,7 +296,7 @@
                     "major_version": "9",
                     "repo_type": "rpm",
                     "repoid": "rocky9-sap",
-                    "arch": "x86_64",
+                    "arch": "{arch}",
                     "channel": "ga"
                 }
             ]
@@ -308,7 +308,7 @@
                     "major_version": "9",
                     "repo_type": "rpm",
                     "repoid": "rocky9-saphana",
-                    "arch": "x86_64",
+                    "arch": "{arch}",
                     "channel": "ga"
                 }
             ]

--- a/leapp-data.spec
+++ b/leapp-data.spec
@@ -1,5 +1,7 @@
 %global pes_events_build_date 20240827
 
+%define debug_package %{nil}
+
 %define dist_list almalinux centos eurolinux oraclelinux rocky
 %define conflict_dists() %(for i in almalinux centos eurolinux oraclelinux rocky; do if [ "${i}" != "%{dist_name}" ]; then echo -n "leapp-data-${i} "; fi; done)
 
@@ -7,18 +9,23 @@
 %define supported_vendors epel imunify kernelcare mariadb nginx-stable nginx-mainline postgresql docker-ce microsoft imunify360-alt-php
 %define target_version 8
 %if %{dist_name} == "almalinux"
+%define exclusivearch x86_64 aarch64 ppc64le
 %define gpg_key RPM-GPG-KEY-AlmaLinux-8
 %endif
 %if %{dist_name} == "centos"
+%define exclusivearch x86_64 aarch64 ppc64le
 %define gpg_key RPM-GPG-KEY-CentOS-Official
 %endif
 %if %{dist_name} == "eurolinux"
+%define exclusivearch x86_64 aarch64
 %define gpg_key RPM-GPG-KEY-eurolinux8
 %endif
 %if %{dist_name} == "oraclelinux"
+%define exclusivearch x86_64 aarch64
 %define gpg_key RPM-GPG-KEY-oracle-ol8
 %endif
 %if %{dist_name} == "rocky"
+%define exclusivearch x86_64 aarch64
 %define gpg_key RPM-GPG-KEY-Rocky-8
 %endif
 %endif
@@ -26,18 +33,23 @@
 %define supported_vendors epel mariadb nginx-stable nginx-mainline postgresql docker-ce microsoft
 %define target_version 9
 %if %{dist_name} == "almalinux"
+%define exclusivearch x86_64 aarch64 ppc64le s390x
 %define gpg_key RPM-GPG-KEY-AlmaLinux-9
 %endif
 %if %{dist_name} == "centos"
+%define exclusivearch x86_64 aarch64 ppc64le
 %define gpg_key RPM-GPG-KEY-CentOS-Official RPM-GPG-KEY-CentOS-SIG-Extras
 %endif
 %if %{dist_name} == "eurolinux"
+%define exclusivearch x86_64 aarch64
 %define gpg_key RPM-GPG-KEY-eurolinux9
 %endif
 %if %{dist_name} == "oraclelinux"
+%define exclusivearch %{nil}
 %define gpg_key RPM-GPG-KEY-oracle-ol9
 %endif
 %if %{dist_name} == "rocky"
+%define exclusivearch x86_64 aarch64
 %define gpg_key RPM-GPG-KEY-Rocky-9
 %endif
 %endif
@@ -46,13 +58,13 @@
 
 Name:		leapp-data-%{dist_name}
 Version:	0.4
-Release:	8%{?dist}.%{pes_events_build_date}
+Release:	9%{?dist}.%{pes_events_build_date}
 Summary:	data for migrating tool
 Group:		Applications/Databases
 License:	ASL 2.0
 URL:		https://github.com/AlmaLinux/leapp-data
 Source0:	leapp-data-%{version}.tar.gz
-BuildArch:  noarch
+ExclusiveArch: %{exclusivearch}
 
 Conflicts: %{conflict_dists}
 
@@ -153,6 +165,9 @@ python3 tests/check_debranding.py %{buildroot}%{_sysconfdir}/leapp/files/pes-eve
 
 
 %changelog
+* Tue Oct 08 2024 Yuriy Kohut <ykohut@almalinux.org> - 0.4-9.20240827
+ - Support elevation on machines other than x86_64
+
 * Mon Oct 07 2024 Yuriy Kohut <ykohut@almalinux.org> - 0.4-8.20240827
  - Change major release number into $releasever in AlmaLinux repositories configuration
 

--- a/tools/generate_map_pes_files.sh
+++ b/tools/generate_map_pes_files.sh
@@ -7,6 +7,7 @@ fi
 
 dist_name=$1
 major_ver=$2
+arch=$(rpm -E %_arch)
 
 declare -A os_repos
 os_repos["almalinux7"]="almalinux8-appstream almalinux8-powertools almalinux8-baseos"
@@ -38,6 +39,12 @@ case $major_ver in
         exit 1;
         ;;
 esac
+
+distro_map_file="files/${dist_name}/repomap.json.el${target_version}"
+if test -e "${distro_map_file}.in"; then
+    sed -i "s/{arch}/${arch}/g" "${distro_map_file}.in" && \
+    mv -f "${distro_map_file}.in" "${distro_map_file}"
+fi
 
 epel_pes_file=vendors.d/epel_pes.json_template
 epel_map_file="vendors.d/epel_map.json_template.el${target_version}"


### PR DESCRIPTION
This is for distro repositories only.

Build the package under the architectures:
#### for CentOS7:
```
leapp-data-almalinux:	x86_64 aarch64 ppc64le
leapp-data-centos:	x86_64 aarch64 ppc64le
leapp-data-eurolinux:	x86_64 aarch64
leapp-data-oraclelinux:	x86_64 aarch64
leapp-data-rocky:	x86_64 aarch64
```
#### for EL8:
```
leapp-data-almalinux:	x86_64 aarch64 ppc64le s390x
leapp-data-centos:	x86_64 aarch64 ppc64le
leapp-data-eurolinux:	x86_64 aarch64
leapp-data-oraclelinux:	-
leapp-data-rocky:	x86_64 aarch64
```