### PR TITLE
Update data to the upstream most recent version 0.22.0

### DIFF
--- a/files/almalinux/config.json
+++ b/files/almalinux/config.json
@@ -307,6 +307,31 @@
             "name": "redhat-cloud-client-configuration",
             "initial_release": 8,
             "target_release": 9
+        },
+        {
+            "name": "libreport-rhel-anaconda-bugzilla",
+            "initial_release": 9,
+            "target_release": 9
+        },
+        {
+            "name": "libreport-rhel-anaconda-bugzilla",
+            "initial_release": 9,
+            "target_release": 10
+        },
+        {
+            "name": "redhat-flatpak-preinstall-firefox",
+            "initial_release": 9,
+            "target_release": 10
+        },
+        {
+            "name": "redhat-flatpak-preinstall-thunderbird",
+            "initial_release": 9,
+            "target_release": 10
+        },
+        {
+            "name": "redhat-flatpak-repo",
+            "initial_release": 9,
+            "target_release": 10
         }
     ],
 

--- a/files/almalinux/device_driver_deprecation_data.json
+++ b/files/almalinux/device_driver_deprecation_data.json
@@ -1557,7 +1557,7 @@
       "device_id": "",
       "device_name": "",
       "device_type": "pci",
-      "driver_name": "3w-9xxx",
+      "driver_name": "3w_9xxx",
       "maintained_in_rhel": []
     },
     {
@@ -1568,7 +1568,7 @@
       "device_id": "",
       "device_name": "",
       "device_type": "pci",
-      "driver_name": "3w-sas",
+      "driver_name": "3w_sas",
       "maintained_in_rhel": []
     },
     {
@@ -2555,7 +2555,7 @@
       "device_id": "",
       "device_name": "",
       "device_type": "pci",
-      "driver_name": "acard-ahci",
+      "driver_name": "acard_ahci",
       "maintained_in_rhel": []
     },
     {
@@ -2570,6 +2570,42 @@
       "device_name": "PF_KEY sockets",
       "device_type": "pci",
       "driver_name": "af_key",
+      "maintained_in_rhel": [
+        7,
+        8,
+        9
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7,
+        8,
+        9,
+        10
+      ],
+      "deprecation_announced": "",
+      "device_id": "",
+      "device_name": "Seattle AHCI SATA platform driver",
+      "device_type": "pci",
+      "driver_name": "ahci_seattle",
+      "maintained_in_rhel": [
+        7,
+        8,
+        9
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7,
+        8,
+        9,
+        10
+      ],
+      "deprecation_announced": "",
+      "device_id": "",
+      "device_name": "APM X-Gene AHCI SATA driver",
+      "device_type": "pci",
+      "driver_name": "ahci_xgene",
       "maintained_in_rhel": [
         7,
         8,
@@ -3029,7 +3065,7 @@
       "device_id": "",
       "device_name": "",
       "device_type": "pci",
-      "driver_name": "firewire-core",
+      "driver_name": "firewire_core",
       "maintained_in_rhel": [
         7,
         8,
@@ -3078,7 +3114,8 @@
       "available_in_rhel": [
         7,
         8,
-        9
+        9,
+        10
       ],
       "deprecation_announced": "",
       "device_id": "",
@@ -3087,7 +3124,27 @@
       "driver_name": "hfi1",
       "maintained_in_rhel": [
         7,
-        8
+        8,
+        9,
+        10
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7,
+        8,
+        9,
+        10
+      ],
+      "deprecation_announced": "",
+      "device_id": "",
+      "device_name": "HISILICON SAS controller driver",
+      "device_type": "pci",
+      "driver_name": "hisi_sas_main",
+      "maintained_in_rhel": [
+        7,
+        8,
+        9
       ]
     },
     {
@@ -4485,6 +4542,30 @@
     },
     {
       "available_in_rhel": [
+        9,
+        10
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x15B3:0x1023",
+      "device_name": "ConnectX-8",
+      "device_type": "pci",
+      "driver_name": "mlx5",
+      "maintained_in_rhel": [
+        9,
+        10
+      ]
+    },
+    {
+      "available_in_rhel": [],
+      "deprecation_announced": "",
+      "device_id": "0x15B3:0x1025",
+      "device_name": "ConnectX-9",
+      "device_type": "pci",
+      "driver_name": "mlx5",
+      "maintained_in_rhel": []
+    },
+    {
+      "available_in_rhel": [
         7,
         8,
         9,
@@ -4496,7 +4577,9 @@
       "device_type": "pci",
       "driver_name": "mlx5",
       "maintained_in_rhel": [
-        7
+        7,
+        9,
+        10
       ]
     },
     {
@@ -5064,7 +5147,7 @@
       "device_id": "",
       "device_name": "",
       "device_type": "pci",
-      "driver_name": "nvmet-fc",
+      "driver_name": "nvmet_fc",
       "maintained_in_rhel": [
         7
       ]
@@ -5080,7 +5163,7 @@
       "device_id": "",
       "device_name": "",
       "device_type": "pci",
-      "driver_name": "nvmet-tcp",
+      "driver_name": "nvmet_tcp",
       "maintained_in_rhel": [
         7
       ]
@@ -6072,5 +6155,5 @@
       "maintained_in_rhel": []
     }
   ],
-  "created_at": "20241127160819"
+  "created_at": "20250228085903"
 }

--- a/files/almalinux/pes-events.json
+++ b/files/almalinux/pes-events.json
@@ -1,5 +1,5 @@
 {
-    "timestamp": "202411121506Z",
+    "timestamp": "202502132105Z",
     "provided_data_streams": [
         "3.0",
         "3.1",
@@ -10024,7 +10024,14 @@
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "postgresql",
+                                "stream": "10"
+                            },
+                            {
+                                "name": "postgresql",
+                                "stream": "9.6"
+                            }
                         ],
                         "name": "postgresql-test-rpm-macros",
                         "repository": "almalinux8-appstream"
@@ -10032,7 +10039,11 @@
                 ],
                 "set_id": 391
             },
-            "initial_release": null,
+            "initial_release": {
+                "major_version": 7,
+                "minor_version": 9,
+                "os_name": "CentOS"
+            },
             "modulestream_maps": [],
             "out_packageset": null,
             "release": {
@@ -10782,7 +10793,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -10818,7 +10828,7 @@
                             null
                         ],
                         "name": "libjpeg-turbo-utils",
-                        "repository": "almalinux8-baseos"
+                        "repository": "almalinux8-appstream"
                     }
                 ],
                 "set_id": 432
@@ -10981,9 +10991,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 337,
@@ -65010,7 +65017,6 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -65044,7 +65050,6 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -65078,7 +65083,6 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -65112,7 +65116,6 @@
         {
             "action": 7,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -65260,9 +65263,6 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 1645,
@@ -65294,9 +65294,6 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 1646,
@@ -65328,9 +65325,6 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 1647,
@@ -65362,9 +65356,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 1648,
@@ -65398,7 +65389,7 @@
                             null
                         ],
                         "name": "libappindicator-gtk3-devel",
-                        "repository": "almalinux8-appstream"
+                        "repository": "almalinux8-powertools"
                     }
                 ],
                 "set_id": 5296
@@ -65412,9 +65403,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 1649,
@@ -65448,7 +65436,7 @@
                             null
                         ],
                         "name": "libdbusmenu-devel",
-                        "repository": "almalinux8-appstream"
+                        "repository": "almalinux8-powertools"
                     }
                 ],
                 "set_id": 5298
@@ -65462,9 +65450,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 1650,
@@ -65512,9 +65497,6 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 1651,
@@ -65546,9 +65528,6 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 1652,
@@ -65580,9 +65559,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 1653,
@@ -65630,9 +65606,6 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 1654,
@@ -65664,9 +65637,6 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 1655,
@@ -65698,9 +65668,6 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 1656,
@@ -65732,9 +65699,6 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 1657,
@@ -65766,9 +65730,6 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 1658,
@@ -65800,9 +65761,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 1659,
@@ -65850,9 +65808,6 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 1660,
@@ -65884,9 +65839,6 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 1661,
@@ -71210,7 +71162,6 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -71230,7 +71181,7 @@
             },
             "initial_release": {
                 "major_version": 7,
-                "minor_version": 7,
+                "minor_version": 9,
                 "os_name": "CentOS"
             },
             "modulestream_maps": [],
@@ -71362,9 +71313,6 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 2136,
@@ -71382,7 +71330,7 @@
             },
             "initial_release": {
                 "major_version": 7,
-                "minor_version": 7,
+                "minor_version": 9,
                 "os_name": "CentOS"
             },
             "modulestream_maps": [],
@@ -83317,7 +83265,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -83353,7 +83300,7 @@
                             null
                         ],
                         "name": "dovecot-devel",
-                        "repository": "almalinux8-appstream"
+                        "repository": "almalinux8-powertools"
                     }
                 ],
                 "set_id": 3995
@@ -83553,7 +83500,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -83589,7 +83535,7 @@
                             null
                         ],
                         "name": "gpgme-devel",
-                        "repository": "almalinux8-baseos"
+                        "repository": "almalinux8-powertools"
                     }
                 ],
                 "set_id": 4007
@@ -85433,7 +85379,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -85469,7 +85414,7 @@
                             null
                         ],
                         "name": "uuid-devel",
-                        "repository": "almalinux8-appstream"
+                        "repository": "almalinux8-powertools"
                     }
                 ],
                 "set_id": 4097
@@ -115861,9 +115806,7 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 3208,
@@ -115897,7 +115840,7 @@
                             null
                         ],
                         "name": "devhelp-devel",
-                        "repository": "almalinux8-appstream"
+                        "repository": "almalinux8-powertools"
                     }
                 ],
                 "set_id": 5300
@@ -115911,9 +115854,6 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 3209,
@@ -115945,9 +115885,7 @@
         {
             "action": 7,
             "architectures": [
-                "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 3210,
@@ -115995,7 +115933,6 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -116029,7 +115966,6 @@
         {
             "action": 7,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -116079,9 +116015,7 @@
         {
             "action": 7,
             "architectures": [
-                "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 3213,
@@ -116129,7 +116063,6 @@
         {
             "action": 7,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -116179,9 +116112,7 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 3215,
@@ -116215,7 +116146,7 @@
                             null
                         ],
                         "name": "yelp-devel",
-                        "repository": "almalinux8-appstream"
+                        "repository": "almalinux8-powertools"
                     }
                 ],
                 "set_id": 5313
@@ -116229,7 +116160,6 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -242269,40 +242199,6 @@
                 "s390x",
                 "x86_64"
             ],
-            "id": 6711,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "librsvg-tools",
-                        "repository": "almalinux8-baseos"
-                    }
-                ],
-                "set_id": 10196
-            },
-            "initial_release": {
-                "major_version": 8,
-                "minor_version": 0,
-                "os_name": "AlmaLinux"
-            },
-            "modulestream_maps": [],
-            "out_packageset": null,
-            "release": {
-                "major_version": 8,
-                "minor_version": 1,
-                "os_name": "AlmaLinux"
-            }
-        },
-        {
-            "action": 0,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
             "id": 6712,
             "in_packageset": {
                 "package": [
@@ -242889,7 +242785,7 @@
                             null
                         ],
                         "name": "dovecot-pigeonhole",
-                        "repository": "almalinux8-baseos"
+                        "repository": "almalinux8-appstream"
                     }
                 ],
                 "set_id": 10219
@@ -242922,7 +242818,7 @@
                         "modulestreams": [
                             null
                         ],
-                        "name": "libxkbfile-1.1.0-1.el8",
+                        "name": "libxkbfile",
                         "repository": "almalinux8-appstream"
                     }
                 ],
@@ -243188,7 +243084,7 @@
                         "modulestreams": [
                             null
                         ],
-                        "name": "pipewire0.2",
+                        "name": "pipewire0.2-libs",
                         "repository": "almalinux8-appstream"
                     }
                 ],
@@ -249100,9 +248996,7 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 6935,
@@ -249169,8 +249063,6 @@
             "action": 1,
             "architectures": [
                 "aarch64",
-                "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 6937,
@@ -249239,9 +249131,7 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 6940,
@@ -249307,9 +249197,7 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 6942,
@@ -249689,7 +249577,6 @@
             "architectures": [
                 "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 6953,
@@ -249700,7 +249587,7 @@
                             null
                         ],
                         "name": "libraw1394",
-                        "repository": "baseos"
+                        "repository": "appstream"
                     }
                 ],
                 "set_id": 10540
@@ -256791,7 +256678,7 @@
                             null
                         ],
                         "name": "jakarta-mail",
-                        "repository": "almalinux9-crb"
+                        "repository": "almalinux9-appstream"
                     }
                 ],
                 "set_id": 10706
@@ -272791,7 +272678,6 @@
             "architectures": [
                 "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 7739,
@@ -272825,7 +272711,6 @@
             "architectures": [
                 "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 7740,
@@ -315481,56 +315366,6 @@
                 "s390x",
                 "x86_64"
             ],
-            "id": 8982,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "python3-gobject-base",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 12693
-            },
-            "initial_release": {
-                "major_version": 8,
-                "minor_version": 6,
-                "os_name": "AlmaLinux"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "python3-gobject-base",
-                        "repository": "almalinux9-crb"
-                    }
-                ],
-                "set_id": 12694
-            },
-            "release": {
-                "major_version": 9,
-                "minor_version": 0,
-                "os_name": "AlmaLinux"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
             "id": 8983,
             "in_packageset": {
                 "package": [
@@ -316202,9 +316037,7 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 9001,
@@ -316236,9 +316069,7 @@
         {
             "action": 2,
             "architectures": [
-                "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 9002,
@@ -316406,9 +316237,7 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 9008,
@@ -316440,9 +316269,7 @@
         {
             "action": 2,
             "architectures": [
-                "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 9009,
@@ -316474,9 +316301,7 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 9010,
@@ -316508,9 +316333,7 @@
         {
             "action": 2,
             "architectures": [
-                "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 9011,
@@ -316542,9 +316365,7 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 9012,
@@ -316576,9 +316397,7 @@
         {
             "action": 2,
             "architectures": [
-                "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 9013,
@@ -316816,7 +316635,6 @@
             "architectures": [
                 "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 9020,
@@ -316850,7 +316668,6 @@
             "architectures": [
                 "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 9021,
@@ -317494,9 +317311,7 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 9040,
@@ -317528,9 +317343,7 @@
         {
             "action": 2,
             "architectures": [
-                "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 9041,
@@ -317562,9 +317375,7 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 9042,
@@ -317596,9 +317407,7 @@
         {
             "action": 2,
             "architectures": [
-                "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 9043,
@@ -318208,9 +318017,7 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 9062,
@@ -318221,7 +318028,7 @@
                             null
                         ],
                         "name": "gtkspell",
-                        "repository": "powertools"
+                        "repository": "appstream"
                     }
                 ],
                 "set_id": 12745
@@ -318582,9 +318389,7 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 9073,
@@ -318701,40 +318506,6 @@
                     }
                 ],
                 "set_id": 12761
-            },
-            "initial_release": {
-                "major_version": 8,
-                "minor_version": 6,
-                "os_name": "AlmaLinux"
-            },
-            "modulestream_maps": [],
-            "out_packageset": null,
-            "release": {
-                "major_version": 9,
-                "minor_version": 0,
-                "os_name": "AlmaLinux"
-            }
-        },
-        {
-            "action": 1,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 9078,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "libmtp-devel",
-                        "repository": "powertools"
-                    }
-                ],
-                "set_id": 12762
             },
             "initial_release": {
                 "major_version": 8,
@@ -320196,9 +319967,7 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 9136,
@@ -320209,7 +319978,7 @@
                             null
                         ],
                         "name": "file-roller-nautilus",
-                        "repository": "base"
+                        "repository": "almalinux8-appstream"
                     }
                 ],
                 "set_id": 12804
@@ -320276,7 +320045,7 @@
                             null
                         ],
                         "name": "tigervnc-server-applet",
-                        "repository": "base"
+                        "repository": "almalinux8-appstream"
                     }
                 ],
                 "set_id": 12805
@@ -320297,7 +320066,6 @@
         {
             "action": 2,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -320333,7 +320101,6 @@
             "architectures": [
                 "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 9140,
@@ -320344,7 +320111,7 @@
                             null
                         ],
                         "name": "gnome-software-editor",
-                        "repository": "base"
+                        "repository": "almalinux8-appstream"
                     }
                 ],
                 "set_id": 12806
@@ -320398,9 +320165,6 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 9142,
@@ -320432,9 +320196,6 @@
         {
             "action": 2,
             "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 9143,
@@ -320466,9 +320227,7 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 9144,
@@ -320479,7 +320238,7 @@
                             null
                         ],
                         "name": "gnome-shell-extension-alternate-tab",
-                        "repository": "base"
+                        "repository": "almalinux8-appstream"
                     }
                 ],
                 "set_id": 12808
@@ -320500,7 +320259,6 @@
         {
             "action": 2,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -372761,43 +372519,6 @@
                 "s390x",
                 "x86_64"
             ],
-            "id": 10577,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            {
-                                "name": "javapackages-tools",
-                                "stream": "201801"
-                            }
-                        ],
-                        "name": "antlr-C++",
-                        "repository": "powertools"
-                    }
-                ],
-                "set_id": 14621
-            },
-            "initial_release": {
-                "major_version": 8,
-                "minor_version": 6,
-                "os_name": "AlmaLinux"
-            },
-            "modulestream_maps": [],
-            "out_packageset": null,
-            "release": {
-                "major_version": 9,
-                "minor_version": 0,
-                "os_name": "AlmaLinux"
-            }
-        },
-        {
-            "action": 1,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
             "id": 10578,
             "in_packageset": {
                 "package": [
@@ -383051,7 +382772,7 @@
             }
         },
         {
-            "action": 1,
+            "action": 6,
             "architectures": [
                 "aarch64",
                 "ppc64le",
@@ -383079,8 +382800,27 @@
                 "minor_version": 6,
                 "os_name": "AlmaLinux"
             },
-            "modulestream_maps": [],
-            "out_packageset": null,
+            "modulestream_maps": [
+                {
+                    "in_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    },
+                    "out_modulestream": null
+                }
+            ],
+            "out_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "plexus-containers-container-default",
+                        "repository": "almalinux9-crb"
+                    }
+                ],
+                "set_id": 23983
+            },
             "release": {
                 "major_version": 9,
                 "minor_version": 0,
@@ -440669,7 +440409,7 @@
             },
             "initial_release": {
                 "major_version": 8,
-                "minor_version": 1,
+                "minor_version": 10,
                 "os_name": "AlmaLinux"
             },
             "modulestream_maps": [],
@@ -440710,14 +440450,14 @@
             },
             "initial_release": {
                 "major_version": 8,
-                "minor_version": 0,
+                "minor_version": 9,
                 "os_name": "AlmaLinux"
             },
             "modulestream_maps": [],
             "out_packageset": null,
             "release": {
                 "major_version": 8,
-                "minor_version": 1,
+                "minor_version": 10,
                 "os_name": "AlmaLinux"
             }
         },
@@ -512982,43 +512722,6 @@
             }
         },
         {
-            "action": 1,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 14345,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            {
-                                "name": "nodejs",
-                                "stream": "18"
-                            }
-                        ],
-                        "name": "nodejs",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 20190
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 5,
-                "os_name": "AlmaLinux"
-            },
-            "modulestream_maps": [],
-            "out_packageset": null,
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "AlmaLinux"
-            }
-        },
-        {
             "action": 6,
             "architectures": [
                 "aarch64",
@@ -513031,6 +512734,10 @@
                 "package": [
                     {
                         "modulestreams": [
+                            {
+                                "name": "nodejs",
+                                "stream": "18"
+                            },
                             {
                                 "name": "nodejs",
                                 "stream": "20"
@@ -513063,6 +512770,13 @@
                     "in_modulestream": {
                         "name": "nodejs",
                         "stream": "22"
+                    },
+                    "out_modulestream": null
+                },
+                {
+                    "in_modulestream": {
+                        "name": "nodejs",
+                        "stream": "18"
                     },
                     "out_modulestream": null
                 }
@@ -537428,7 +537142,7 @@
             }
         },
         {
-            "action": 6,
+            "action": 4,
             "architectures": [
                 "aarch64",
                 "ppc64le",
@@ -537472,6 +537186,13 @@
                             null
                         ],
                         "name": "mariadb",
+                        "repository": "almalinux10-appstream"
+                    },
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "mariadb-client-utils",
                         "repository": "almalinux10-appstream"
                     }
                 ],
@@ -537988,7 +537709,7 @@
             }
         },
         {
-            "action": 6,
+            "action": 7,
             "architectures": [
                 "aarch64",
                 "ppc64le",
@@ -538025,7 +537746,7 @@
                         "modulestreams": [
                             null
                         ],
-                        "name": "mysql-libs",
+                        "name": "mysql8.4-libs",
                         "repository": "almalinux10-appstream"
                     }
                 ],
@@ -559595,9 +559316,7 @@
         {
             "action": 2,
             "architectures": [
-                "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 15647,
@@ -559831,9 +559550,7 @@
         {
             "action": 2,
             "architectures": [
-                "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 15654,
@@ -560713,9 +560430,7 @@
         {
             "action": 2,
             "architectures": [
-                "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 15680,
@@ -560779,9 +560494,7 @@
         {
             "action": 2,
             "architectures": [
-                "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 15682,
@@ -561695,9 +561408,7 @@
         {
             "action": 2,
             "architectures": [
-                "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 15709,
@@ -597987,7 +597698,7 @@
             }
         },
         {
-            "action": 1,
+            "action": 3,
             "architectures": [
                 "aarch64",
                 "ppc64le",
@@ -598012,8 +597723,24 @@
                 "minor_version": 5,
                 "os_name": "AlmaLinux"
             },
-            "modulestream_maps": [],
-            "out_packageset": null,
+            "modulestream_maps": [
+                {
+                    "in_modulestream": null,
+                    "out_modulestream": null
+                }
+            ],
+            "out_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "papers",
+                        "repository": "almalinux10-appstream"
+                    }
+                ],
+                "set_id": 24002
+            },
             "release": {
                 "major_version": 10,
                 "minor_version": 0,
@@ -598055,7 +597782,7 @@
             }
         },
         {
-            "action": 1,
+            "action": 3,
             "architectures": [
                 "aarch64",
                 "ppc64le",
@@ -598080,8 +597807,24 @@
                 "minor_version": 5,
                 "os_name": "AlmaLinux"
             },
-            "modulestream_maps": [],
-            "out_packageset": null,
+            "modulestream_maps": [
+                {
+                    "in_modulestream": null,
+                    "out_modulestream": null
+                }
+            ],
+            "out_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "papers-libs",
+                        "repository": "almalinux10-appstream"
+                    }
+                ],
+                "set_id": 24001
+            },
             "release": {
                 "major_version": 10,
                 "minor_version": 0,
@@ -598123,7 +597866,7 @@
             }
         },
         {
-            "action": 1,
+            "action": 3,
             "architectures": [
                 "aarch64",
                 "ppc64le",
@@ -598148,8 +597891,24 @@
                 "minor_version": 5,
                 "os_name": "AlmaLinux"
             },
-            "modulestream_maps": [],
-            "out_packageset": null,
+            "modulestream_maps": [
+                {
+                    "in_modulestream": null,
+                    "out_modulestream": null
+                }
+            ],
+            "out_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "papers-nautilus",
+                        "repository": "almalinux10-appstream"
+                    }
+                ],
+                "set_id": 24000
+            },
             "release": {
                 "major_version": 10,
                 "minor_version": 0,
@@ -598191,7 +597950,7 @@
             }
         },
         {
-            "action": 1,
+            "action": 3,
             "architectures": [
                 "aarch64",
                 "ppc64le",
@@ -598216,8 +597975,24 @@
                 "minor_version": 5,
                 "os_name": "AlmaLinux"
             },
-            "modulestream_maps": [],
-            "out_packageset": null,
+            "modulestream_maps": [
+                {
+                    "in_modulestream": null,
+                    "out_modulestream": null
+                }
+            ],
+            "out_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "papers-previewer",
+                        "repository": "almalinux10-appstream"
+                    }
+                ],
+                "set_id": 23999
+            },
             "release": {
                 "major_version": 10,
                 "minor_version": 0,
@@ -598259,7 +598034,7 @@
             }
         },
         {
-            "action": 1,
+            "action": 3,
             "architectures": [
                 "aarch64",
                 "ppc64le",
@@ -598284,8 +598059,24 @@
                 "minor_version": 5,
                 "os_name": "AlmaLinux"
             },
-            "modulestream_maps": [],
-            "out_packageset": null,
+            "modulestream_maps": [
+                {
+                    "in_modulestream": null,
+                    "out_modulestream": null
+                }
+            ],
+            "out_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "papers-thumbnailer",
+                        "repository": "almalinux10-appstream"
+                    }
+                ],
+                "set_id": 23998
+            },
             "release": {
                 "major_version": 10,
                 "minor_version": 0,
@@ -605373,14 +605164,14 @@
                         "modulestreams": [
                             null
                         ],
-                        "name": "mysql-test",
+                        "name": "mysql8.4-test",
                         "repository": "almalinux10-crb"
                     },
                     {
                         "modulestreams": [
                             null
                         ],
-                        "name": "mysql-test-data",
+                        "name": "mysql8.4-test-data",
                         "repository": "almalinux10-crb"
                     }
                 ],
@@ -612322,7 +612113,7 @@
             }
         },
         {
-            "action": 1,
+            "action": 7,
             "architectures": [
                 "aarch64",
                 "ppc64le",
@@ -612347,8 +612138,24 @@
                 "minor_version": 5,
                 "os_name": "AlmaLinux"
             },
-            "modulestream_maps": [],
-            "out_packageset": null,
+            "modulestream_maps": [
+                {
+                    "in_modulestream": null,
+                    "out_modulestream": null
+                }
+            ],
+            "out_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "python-PyMySQL+rsa",
+                        "repository": "almalinux10-crb"
+                    }
+                ],
+                "set_id": 24283
+            },
             "release": {
                 "major_version": 10,
                 "minor_version": 0,
@@ -615876,8 +615683,6 @@
             "action": 0,
             "architectures": [
                 "aarch64",
-                "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 17278,
@@ -618968,2856 +618773,6 @@
             }
         },
         {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17360,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-libs",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23847
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "AlmaLinux"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-libs",
-                        "repository": "almalinux10-baseos"
-                    }
-                ],
-                "set_id": 23848
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "AlmaLinux"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17361,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-AutoLoader",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23849
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "AlmaLinux"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-AutoLoader",
-                        "repository": "almalinux10-baseos"
-                    }
-                ],
-                "set_id": 23850
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "AlmaLinux"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17362,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-B",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23851
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "AlmaLinux"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-B",
-                        "repository": "almalinux10-baseos"
-                    }
-                ],
-                "set_id": 23852
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "AlmaLinux"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17363,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Carp",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23853
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "AlmaLinux"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Carp",
-                        "repository": "almalinux10-baseos"
-                    }
-                ],
-                "set_id": 23854
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "AlmaLinux"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17364,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Class-Struct",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23855
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "AlmaLinux"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Class-Struct",
-                        "repository": "almalinux10-baseos"
-                    }
-                ],
-                "set_id": 23856
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "AlmaLinux"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17365,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Data-Dumper",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23857
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "AlmaLinux"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Data-Dumper",
-                        "repository": "almalinux10-baseos"
-                    }
-                ],
-                "set_id": 23858
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "AlmaLinux"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17366,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Digest",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23859
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "AlmaLinux"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Digest",
-                        "repository": "almalinux10-baseos"
-                    }
-                ],
-                "set_id": 23860
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "AlmaLinux"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17367,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Digest-MD5",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23861
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "AlmaLinux"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Digest-MD5",
-                        "repository": "almalinux10-baseos"
-                    }
-                ],
-                "set_id": 23862
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "AlmaLinux"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17368,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-DynaLoader",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23863
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "AlmaLinux"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-DynaLoader",
-                        "repository": "almalinux10-baseos"
-                    }
-                ],
-                "set_id": 23864
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "AlmaLinux"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17369,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Encode",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23865
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "AlmaLinux"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Encode",
-                        "repository": "almalinux10-baseos"
-                    }
-                ],
-                "set_id": 23866
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "AlmaLinux"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17370,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Errno",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23867
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "AlmaLinux"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Errno",
-                        "repository": "almalinux10-baseos"
-                    }
-                ],
-                "set_id": 23868
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "AlmaLinux"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17371,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Exporter",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23869
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "AlmaLinux"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Exporter",
-                        "repository": "almalinux10-baseos"
-                    }
-                ],
-                "set_id": 23870
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "AlmaLinux"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17372,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Fcntl",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23871
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "AlmaLinux"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Fcntl",
-                        "repository": "almalinux10-baseos"
-                    }
-                ],
-                "set_id": 23872
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "AlmaLinux"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17373,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-File-Basename",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23873
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "AlmaLinux"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-File-Basename",
-                        "repository": "almalinux10-baseos"
-                    }
-                ],
-                "set_id": 23874
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "AlmaLinux"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17374,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-File-Path",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23875
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "AlmaLinux"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-File-Path",
-                        "repository": "almalinux10-baseos"
-                    }
-                ],
-                "set_id": 23876
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "AlmaLinux"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17375,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-File-Temp",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23877
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "AlmaLinux"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-File-Temp",
-                        "repository": "almalinux10-baseos"
-                    }
-                ],
-                "set_id": 23878
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "AlmaLinux"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17376,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-File-stat",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23879
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "AlmaLinux"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-File-stat",
-                        "repository": "almalinux10-baseos"
-                    }
-                ],
-                "set_id": 23880
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "AlmaLinux"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17377,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-FileHandle",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23881
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "AlmaLinux"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-FileHandle",
-                        "repository": "almalinux10-baseos"
-                    }
-                ],
-                "set_id": 23882
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "AlmaLinux"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17378,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Getopt-Long",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23883
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "AlmaLinux"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Getopt-Long",
-                        "repository": "almalinux10-baseos"
-                    }
-                ],
-                "set_id": 23884
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "AlmaLinux"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17379,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Getopt-Std",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23885
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "AlmaLinux"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Getopt-Std",
-                        "repository": "almalinux10-baseos"
-                    }
-                ],
-                "set_id": 23886
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "AlmaLinux"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17380,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-HTTP-Tiny",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23887
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "AlmaLinux"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-HTTP-Tiny",
-                        "repository": "almalinux10-baseos"
-                    }
-                ],
-                "set_id": 23888
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "AlmaLinux"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17381,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-IO",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23889
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "AlmaLinux"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-IO",
-                        "repository": "almalinux10-baseos"
-                    }
-                ],
-                "set_id": 23890
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "AlmaLinux"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17382,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-IO-Socket-IP",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23891
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "AlmaLinux"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-IO-Socket-IP",
-                        "repository": "almalinux10-baseos"
-                    }
-                ],
-                "set_id": 23892
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "AlmaLinux"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17383,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-IO-Socket-SSL",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23893
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "AlmaLinux"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-IO-Socket-SSL",
-                        "repository": "almalinux10-baseos"
-                    }
-                ],
-                "set_id": 23894
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "AlmaLinux"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17384,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-IPC-Open3",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23895
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "AlmaLinux"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-IPC-Open3",
-                        "repository": "almalinux10-baseos"
-                    }
-                ],
-                "set_id": 23896
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "AlmaLinux"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17385,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-MIME-Base64",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23897
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "AlmaLinux"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-MIME-Base64",
-                        "repository": "almalinux10-baseos"
-                    }
-                ],
-                "set_id": 23898
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "AlmaLinux"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17386,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Mozilla-CA",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23899
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "AlmaLinux"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Mozilla-CA",
-                        "repository": "almalinux10-baseos"
-                    }
-                ],
-                "set_id": 23900
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "AlmaLinux"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17387,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Net-SSLeay",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23901
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "AlmaLinux"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Net-SSLeay",
-                        "repository": "almalinux10-baseos"
-                    }
-                ],
-                "set_id": 23902
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "AlmaLinux"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17388,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-POSIX",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23903
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "AlmaLinux"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-POSIX",
-                        "repository": "almalinux10-baseos"
-                    }
-                ],
-                "set_id": 23904
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "AlmaLinux"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17389,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-PathTools",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23905
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "AlmaLinux"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-PathTools",
-                        "repository": "almalinux10-baseos"
-                    }
-                ],
-                "set_id": 23906
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "AlmaLinux"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17390,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Pod-Escapes",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23907
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "AlmaLinux"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Pod-Escapes",
-                        "repository": "almalinux10-baseos"
-                    }
-                ],
-                "set_id": 23908
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "AlmaLinux"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17391,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Pod-Perldoc",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23909
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "AlmaLinux"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Pod-Perldoc",
-                        "repository": "almalinux10-baseos"
-                    }
-                ],
-                "set_id": 23910
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "AlmaLinux"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17392,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Pod-Simple",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23911
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "AlmaLinux"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Pod-Simple",
-                        "repository": "almalinux10-baseos"
-                    }
-                ],
-                "set_id": 23912
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "AlmaLinux"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17393,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Pod-Usage",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23913
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "AlmaLinux"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Pod-Usage",
-                        "repository": "almalinux10-baseos"
-                    }
-                ],
-                "set_id": 23914
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "AlmaLinux"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17394,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Scalar-List-Utils",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23915
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "AlmaLinux"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Scalar-List-Utils",
-                        "repository": "almalinux10-baseos"
-                    }
-                ],
-                "set_id": 23916
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "AlmaLinux"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17395,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-SelectSaver",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23917
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "AlmaLinux"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-SelectSaver",
-                        "repository": "almalinux10-baseos"
-                    }
-                ],
-                "set_id": 23918
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "AlmaLinux"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17396,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Socket",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23919
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "AlmaLinux"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Socket",
-                        "repository": "almalinux10-baseos"
-                    }
-                ],
-                "set_id": 23920
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "AlmaLinux"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17397,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Storable",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23921
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "AlmaLinux"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Storable",
-                        "repository": "almalinux10-baseos"
-                    }
-                ],
-                "set_id": 23922
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "AlmaLinux"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17398,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Symbol",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23923
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "AlmaLinux"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Symbol",
-                        "repository": "almalinux10-baseos"
-                    }
-                ],
-                "set_id": 23924
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "AlmaLinux"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17399,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Term-ANSIColor",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23925
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "AlmaLinux"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Term-ANSIColor",
-                        "repository": "almalinux10-baseos"
-                    }
-                ],
-                "set_id": 23926
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "AlmaLinux"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17400,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Term-Cap",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23927
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "AlmaLinux"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Term-Cap",
-                        "repository": "almalinux10-baseos"
-                    }
-                ],
-                "set_id": 23928
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "AlmaLinux"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17401,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Text-ParseWords",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23929
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "AlmaLinux"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Text-ParseWords",
-                        "repository": "almalinux10-baseos"
-                    }
-                ],
-                "set_id": 23930
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "AlmaLinux"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17402,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Text-Tabs+Wrap",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23931
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "AlmaLinux"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Text-Tabs+Wrap",
-                        "repository": "almalinux10-baseos"
-                    }
-                ],
-                "set_id": 23932
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "AlmaLinux"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17403,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Time-Local",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23933
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "AlmaLinux"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Time-Local",
-                        "repository": "almalinux10-baseos"
-                    }
-                ],
-                "set_id": 23934
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "AlmaLinux"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17404,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-URI",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23935
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "AlmaLinux"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-URI",
-                        "repository": "almalinux10-baseos"
-                    }
-                ],
-                "set_id": 23936
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "AlmaLinux"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17405,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-base",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23937
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "AlmaLinux"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-base",
-                        "repository": "almalinux10-baseos"
-                    }
-                ],
-                "set_id": 23938
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "AlmaLinux"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17406,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-constant",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23939
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "AlmaLinux"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-constant",
-                        "repository": "almalinux10-baseos"
-                    }
-                ],
-                "set_id": 23940
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "AlmaLinux"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17407,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-if",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23941
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "AlmaLinux"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-if",
-                        "repository": "almalinux10-baseos"
-                    }
-                ],
-                "set_id": 23942
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "AlmaLinux"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17408,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-interpreter",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23943
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "AlmaLinux"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-interpreter",
-                        "repository": "almalinux10-baseos"
-                    }
-                ],
-                "set_id": 23944
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "AlmaLinux"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17409,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-libnet",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23945
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "AlmaLinux"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-libnet",
-                        "repository": "almalinux10-baseos"
-                    }
-                ],
-                "set_id": 23946
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "AlmaLinux"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17410,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-locale",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23947
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "AlmaLinux"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-locale",
-                        "repository": "almalinux10-baseos"
-                    }
-                ],
-                "set_id": 23948
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "AlmaLinux"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17411,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-mro",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23949
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "AlmaLinux"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-mro",
-                        "repository": "almalinux10-baseos"
-                    }
-                ],
-                "set_id": 23950
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "AlmaLinux"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17412,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-overload",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23951
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "AlmaLinux"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-overload",
-                        "repository": "almalinux10-baseos"
-                    }
-                ],
-                "set_id": 23952
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "AlmaLinux"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17413,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-overloading",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23953
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "AlmaLinux"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-overloading",
-                        "repository": "almalinux10-baseos"
-                    }
-                ],
-                "set_id": 23954
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "AlmaLinux"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17414,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-parent",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23955
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "AlmaLinux"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-parent",
-                        "repository": "almalinux10-baseos"
-                    }
-                ],
-                "set_id": 23956
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "AlmaLinux"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17415,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-podlators",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23957
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "AlmaLinux"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-podlators",
-                        "repository": "almalinux10-baseos"
-                    }
-                ],
-                "set_id": 23958
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "AlmaLinux"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17416,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-vars",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23959
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "AlmaLinux"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-vars",
-                        "repository": "almalinux10-baseos"
-                    }
-                ],
-                "set_id": 23960
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "AlmaLinux"
-            }
-        },
-        {
             "action": 0,
             "architectures": [
                 "aarch64",
@@ -622243,6 +619198,9747 @@
             }
         },
         {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17430,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "usermode-gtk",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 23978
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17431,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "usermode-gtk",
+                        "repository": "almalinux9-appstream"
+                    }
+                ],
+                "set_id": 23979
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17432,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "gdisk",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 23980
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17433,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "gdisk",
+                        "repository": "almalinux9-appstream"
+                    }
+                ],
+                "set_id": 23981
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17434,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "gcc-toolset-14",
+                        "repository": "almalinux10-appstream"
+                    }
+                ],
+                "set_id": 23982
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 6,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17435,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
+                        ],
+                        "name": "antlr-C++",
+                        "repository": "powertools"
+                    }
+                ],
+                "set_id": 23984
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [
+                {
+                    "in_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    },
+                    "out_modulestream": null
+                }
+            ],
+            "out_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "antlr-C++",
+                        "repository": "almalinux9-crb"
+                    }
+                ],
+                "set_id": 23985
+            },
+            "release": {
+                "major_version": 9,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 6,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17436,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "python39-devel",
+                                "stream": "3.9"
+                            }
+                        ],
+                        "name": "python39-pybind11",
+                        "repository": "almalinux8-powertools"
+                    }
+                ],
+                "set_id": 23986
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 8,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [
+                {
+                    "in_modulestream": {
+                        "name": "python39-devel",
+                        "stream": "3.9"
+                    },
+                    "out_modulestream": {
+                        "name": "python39-devel",
+                        "stream": "3.9"
+                    }
+                }
+            ],
+            "out_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "python39-devel",
+                                "stream": "3.9"
+                            }
+                        ],
+                        "name": "python39-pybind11",
+                        "repository": "almalinux8-appstream"
+                    }
+                ],
+                "set_id": 23987
+            },
+            "release": {
+                "major_version": 8,
+                "minor_version": 9,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 6,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17437,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "python39-devel",
+                                "stream": "3.9"
+                            }
+                        ],
+                        "name": "python39-pybind11-devel",
+                        "repository": "almalinux8-powertools"
+                    }
+                ],
+                "set_id": 23988
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 8,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [
+                {
+                    "in_modulestream": {
+                        "name": "python39-devel",
+                        "stream": "3.9"
+                    },
+                    "out_modulestream": {
+                        "name": "python39-devel",
+                        "stream": "3.9"
+                    }
+                }
+            ],
+            "out_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "python39-devel",
+                                "stream": "3.9"
+                            }
+                        ],
+                        "name": "python39-pybind11-devel",
+                        "repository": "almalinux8-appstream"
+                    }
+                ],
+                "set_id": 23989
+            },
+            "release": {
+                "major_version": 8,
+                "minor_version": 9,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 6,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17438,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "python39-devel",
+                                "stream": "3.9"
+                            }
+                        ],
+                        "name": "python39-pybind11",
+                        "repository": "almalinux8-appstream"
+                    }
+                ],
+                "set_id": 23990
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 9,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [
+                {
+                    "in_modulestream": {
+                        "name": "python39-devel",
+                        "stream": "3.9"
+                    },
+                    "out_modulestream": {
+                        "name": "python39-devel",
+                        "stream": "3.9"
+                    }
+                }
+            ],
+            "out_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "python39-devel",
+                                "stream": "3.9"
+                            }
+                        ],
+                        "name": "python39-pybind11",
+                        "repository": "almalinux8-powertools"
+                    }
+                ],
+                "set_id": 23991
+            },
+            "release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 6,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17439,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "python39-devel",
+                                "stream": "3.9"
+                            }
+                        ],
+                        "name": "python39-pybind11-devel",
+                        "repository": "almalinux8-appstream"
+                    }
+                ],
+                "set_id": 23992
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 9,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [
+                {
+                    "in_modulestream": {
+                        "name": "python39-devel",
+                        "stream": "3.9"
+                    },
+                    "out_modulestream": {
+                        "name": "python39-devel",
+                        "stream": "3.9"
+                    }
+                }
+            ],
+            "out_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "python39-devel",
+                                "stream": "3.9"
+                            }
+                        ],
+                        "name": "python39-pybind11-devel",
+                        "repository": "almalinux8-powertools"
+                    }
+                ],
+                "set_id": 23993
+            },
+            "release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 5,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17440,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "cockpit-bridge",
+                        "repository": "baseos"
+                    },
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "cockpit-pcp",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 23996
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [
+                {
+                    "in_modulestream": null,
+                    "out_modulestream": null
+                }
+            ],
+            "out_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "cockpit-bridge",
+                        "repository": "almalinux10-baseos"
+                    }
+                ],
+                "set_id": 23997
+            },
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17442,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "papers-devel",
+                        "repository": "almalinux10-crb"
+                    }
+                ],
+                "set_id": 24004
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17443,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "xmlrpc-c",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24006
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17444,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "xmlrpc-c-c++",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24007
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17445,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "xmlrpc-c-client",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24008
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17446,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "xmlrpc-c-client++",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24009
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17447,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "xmlrpc-c-devel",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24010
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17448,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "satyr",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24011
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17449,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "satyr",
+                        "repository": "almalinux9-appstream"
+                    }
+                ],
+                "set_id": 24012
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17450,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "xmlrpc-c",
+                        "repository": "almalinux9-appstream"
+                    }
+                ],
+                "set_id": 24013
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17451,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "libreport",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24014
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17452,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "libreport",
+                        "repository": "almalinux9-appstream"
+                    }
+                ],
+                "set_id": 24015
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17453,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "libreport-anaconda",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24016
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17454,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "libreport-anaconda",
+                        "repository": "almalinux9-appstream"
+                    }
+                ],
+                "set_id": 24017
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17455,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "libreport-cli",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24018
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17456,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "libreport-cli",
+                        "repository": "almalinux9-appstream"
+                    }
+                ],
+                "set_id": 24019
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17457,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "libreport-filesystem",
+                        "repository": "baseos"
+                    }
+                ],
+                "set_id": 24020
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17458,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "libreport-filesystem",
+                        "repository": "almalinux9-baseos"
+                    }
+                ],
+                "set_id": 24021
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17459,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "libreport-gtk",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24022
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17460,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "libreport-gtk",
+                        "repository": "almalinux9-appstream"
+                    }
+                ],
+                "set_id": 24023
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17461,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "libreport-plugin-bugzilla",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24024
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17462,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "libreport-plugin-bugzilla",
+                        "repository": "almalinux9-appstream"
+                    }
+                ],
+                "set_id": 24025
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17463,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "libreport-plugin-reportuploader",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24026
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17464,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "libreport-plugin-reportuploader",
+                        "repository": "almalinux9-appstream"
+                    }
+                ],
+                "set_id": 24027
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17467,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "libreport-web",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24030
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17468,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "libreport-web",
+                        "repository": "almalinux9-appstream"
+                    }
+                ],
+                "set_id": 24031
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17469,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "python3-libreport",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24032
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17470,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "python3-libreport",
+                        "repository": "almalinux9-appstream"
+                    }
+                ],
+                "set_id": 24033
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17471,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "texlive-xdvi",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24034
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17472,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "texlive-xdvi",
+                        "repository": "almalinux9-appstream"
+                    }
+                ],
+                "set_id": 24035
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17473,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "totem-pl-parser",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24038
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17474,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "totem-pl-parser",
+                        "repository": "almalinux9-appstream"
+                    }
+                ],
+                "set_id": 24039
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17475,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "perl-libxml-perl",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24040
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17476,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "perltidy",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24041
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17477,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "perl-YAML-LibYAML",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24042
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17478,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "perl-Syntax-Keyword-Try",
+                        "repository": "almalinux10-crb"
+                    }
+                ],
+                "set_id": 24043
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17479,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "perl-XS-Parse-Keyword",
+                        "repository": "almalinux10-crb"
+                    }
+                ],
+                "set_id": 24044
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17480,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "libraw1394",
+                        "repository": "almalinux8-appstream"
+                    }
+                ],
+                "set_id": 24045
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 9,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17481,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "cdrdao",
+                        "repository": "almalinux8-appstream"
+                    }
+                ],
+                "set_id": 24046
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 9,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17482,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "perl-Net-DNS-Nameserver",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24047
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "x86_64"
+            ],
+            "id": 17483,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "command-line-assistant",
+                        "repository": "almalinux10-appstream"
+                    }
+                ],
+                "set_id": 24048
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17487,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "flatpak-rpm-macros",
+                        "repository": "almalinux9-crb"
+                    }
+                ],
+                "set_id": 24052
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17488,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "flatpak-runtime-config",
+                        "repository": "almalinux9-crb"
+                    }
+                ],
+                "set_id": 24053
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 7,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17489,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "mysql",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24054
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [
+                {
+                    "in_modulestream": null,
+                    "out_modulestream": null
+                }
+            ],
+            "out_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "mysql8.4",
+                        "repository": "almalinux10-appstream"
+                    }
+                ],
+                "set_id": 24055
+            },
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 7,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17490,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "mysql-server",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24056
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [
+                {
+                    "in_modulestream": null,
+                    "out_modulestream": null
+                }
+            ],
+            "out_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "mysql8.4-server",
+                        "repository": "almalinux10-appstream"
+                    }
+                ],
+                "set_id": 24057
+            },
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 7,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17491,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "mysql-errmsg",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24058
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [
+                {
+                    "in_modulestream": null,
+                    "out_modulestream": null
+                }
+            ],
+            "out_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "mysql8.4-errmsg",
+                        "repository": "almalinux10-appstream"
+                    }
+                ],
+                "set_id": 24059
+            },
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 7,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17492,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "mysql-devel",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24060
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [
+                {
+                    "in_modulestream": null,
+                    "out_modulestream": null
+                }
+            ],
+            "out_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "mysql8.4-devel",
+                        "repository": "almalinux10-crb"
+                    }
+                ],
+                "set_id": 24061
+            },
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17493,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-11-openjdk",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24062
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17494,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-11-openjdk",
+                        "repository": "almalinux9-appstream"
+                    }
+                ],
+                "set_id": 24063
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 4,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17495,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-11-openjdk-demo",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24064
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17496,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-11-openjdk-demo",
+                        "repository": "almalinux9-appstream"
+                    }
+                ],
+                "set_id": 24065
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 4,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17497,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-11-openjdk-devel",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24066
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17498,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-11-openjdk-devel",
+                        "repository": "almalinux9-appstream"
+                    }
+                ],
+                "set_id": 24067
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 4,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17499,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-11-openjdk-headless",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24068
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17500,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-11-openjdk-headless",
+                        "repository": "almalinux9-appstream"
+                    }
+                ],
+                "set_id": 24069
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 4,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17501,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-11-openjdk-javadoc",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24070
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17502,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-11-openjdk-javadoc",
+                        "repository": "almalinux9-appstream"
+                    }
+                ],
+                "set_id": 24071
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 4,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17503,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-11-openjdk-javadoc-zip",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24072
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17504,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-11-openjdk-javadoc-zip",
+                        "repository": "almalinux9-appstream"
+                    }
+                ],
+                "set_id": 24073
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 4,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17505,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-11-openjdk-jmods",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24074
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17506,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-11-openjdk-jmods",
+                        "repository": "almalinux9-appstream"
+                    }
+                ],
+                "set_id": 24075
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 4,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17507,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-11-openjdk-src",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24076
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17508,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-11-openjdk-src",
+                        "repository": "almalinux9-appstream"
+                    }
+                ],
+                "set_id": 24077
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 4,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17509,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-11-openjdk-static-libs",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24078
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17510,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-11-openjdk-static-libs",
+                        "repository": "almalinux9-appstream"
+                    }
+                ],
+                "set_id": 24079
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 4,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17511,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-11-openjdk-demo-fastdebug",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24080
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17512,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-11-openjdk-demo-slowdebug",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24081
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17513,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-11-openjdk-devel-fastdebug",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24082
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17514,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-11-openjdk-devel-slowdebug",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24083
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17515,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-11-openjdk-fastdebug",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24084
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17516,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-11-openjdk-headless-fastdebug",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24085
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17517,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-11-openjdk-headless-slowdebug",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24086
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17518,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-11-openjdk-jmods-fastdebug",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24087
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17519,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-11-openjdk-jmods-slowdebug",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24088
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17520,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-11-openjdk-slowdebug",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24089
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17521,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-11-openjdk-src-fastdebug",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24090
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17522,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-11-openjdk-src-slowdebug",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24091
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17523,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-11-openjdk-static-libs-fastdebug",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24092
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17524,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-11-openjdk-static-libs-slowdebug",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24093
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17525,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-17-openjdk",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24094
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17526,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-17-openjdk",
+                        "repository": "almalinux9-appstream"
+                    }
+                ],
+                "set_id": 24095
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17527,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-17-openjdk-demo",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24096
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17528,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-17-openjdk-demo",
+                        "repository": "almalinux9-appstream"
+                    }
+                ],
+                "set_id": 24097
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17529,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-17-openjdk-devel",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24098
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17530,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-17-openjdk-devel",
+                        "repository": "almalinux9-appstream"
+                    }
+                ],
+                "set_id": 24099
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17531,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-17-openjdk-headless",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24100
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17532,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-17-openjdk-headless",
+                        "repository": "almalinux9-appstream"
+                    }
+                ],
+                "set_id": 24101
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17533,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-17-openjdk-javadoc",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24102
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17534,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-17-openjdk-javadoc",
+                        "repository": "almalinux9-appstream"
+                    }
+                ],
+                "set_id": 24103
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17535,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-17-openjdk-javadoc-zip",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24104
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17536,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-17-openjdk-javadoc-zip",
+                        "repository": "almalinux9-appstream"
+                    }
+                ],
+                "set_id": 24105
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17537,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-17-openjdk-jmods",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24106
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17538,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-17-openjdk-jmods",
+                        "repository": "almalinux9-appstream"
+                    }
+                ],
+                "set_id": 24107
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17539,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-17-openjdk-src",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24108
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17540,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-17-openjdk-src",
+                        "repository": "almalinux9-appstream"
+                    }
+                ],
+                "set_id": 24109
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17541,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-17-openjdk-static-libs",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24110
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17542,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-17-openjdk-static-libs",
+                        "repository": "almalinux9-appstream"
+                    }
+                ],
+                "set_id": 24111
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17543,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-17-openjdk-demo-fastdebug",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24112
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17544,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-17-openjdk-demo-slowdebug",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24113
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17545,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-17-openjdk-devel-fastdebug",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24114
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17546,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-17-openjdk-devel-slowdebug",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24115
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17547,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-17-openjdk-fastdebug",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24116
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17548,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-17-openjdk-headless-fastdebug",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24117
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17549,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-17-openjdk-headless-slowdebug",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24118
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17550,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-17-openjdk-jmods-fastdebug",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24119
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17551,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-17-openjdk-jmods-slowdebug",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24120
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17552,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-17-openjdk-slowdebug",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24121
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17553,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-17-openjdk-src-fastdebug",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24122
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17554,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-17-openjdk-src-slowdebug",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24123
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17555,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-17-openjdk-static-libs-fastdebug",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24124
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17556,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-17-openjdk-static-libs-slowdebug",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24125
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17557,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-1.8.0-openjdk",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24126
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17558,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-1.8.0-openjdk",
+                        "repository": "almalinux9-appstream"
+                    }
+                ],
+                "set_id": 24127
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17559,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-1.8.0-openjdk-demo",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24128
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17560,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-1.8.0-openjdk-demo",
+                        "repository": "almalinux9-appstream"
+                    }
+                ],
+                "set_id": 24129
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17561,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-1.8.0-openjdk-devel",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24130
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17562,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-1.8.0-openjdk-devel",
+                        "repository": "almalinux9-appstream"
+                    }
+                ],
+                "set_id": 24131
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17563,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-1.8.0-openjdk-headless",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24132
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17564,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-1.8.0-openjdk-headless",
+                        "repository": "almalinux9-appstream"
+                    }
+                ],
+                "set_id": 24133
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17565,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-1.8.0-openjdk-javadoc",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24134
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17566,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-1.8.0-openjdk-javadoc",
+                        "repository": "almalinux9-appstream"
+                    }
+                ],
+                "set_id": 24135
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17567,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-1.8.0-openjdk-javadoc-zip",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24136
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17568,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-1.8.0-openjdk-javadoc-zip",
+                        "repository": "almalinux9-appstream"
+                    }
+                ],
+                "set_id": 24137
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17569,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-1.8.0-openjdk-src",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24138
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17570,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-1.8.0-openjdk-src",
+                        "repository": "almalinux9-appstream"
+                    }
+                ],
+                "set_id": 24139
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17571,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-1.8.0-openjdk-demo-fastdebug",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24140
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17572,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-1.8.0-openjdk-demo-slowdebug",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24141
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17573,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-1.8.0-openjdk-devel-fastdebug",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24142
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17574,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-1.8.0-openjdk-devel-slowdebug",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24143
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17575,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-1.8.0-openjdk-fastdebug",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24144
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17576,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-1.8.0-openjdk-headless-fastdebug",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24145
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17577,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-1.8.0-openjdk-headless-slowdebug",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24146
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17578,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-1.8.0-openjdk-slowdebug",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24147
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17579,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-1.8.0-openjdk-src-fastdebug",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24148
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17580,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-1.8.0-openjdk-src-slowdebug",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24149
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17581,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "jigawatts",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24150
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17582,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "jigawatts",
+                        "repository": "almalinux9-appstream"
+                    }
+                ],
+                "set_id": 24151
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17583,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "jigawatts-javadoc",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24152
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17584,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "jigawatts-javadoc",
+                        "repository": "almalinux9-appstream"
+                    }
+                ],
+                "set_id": 24153
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17586,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "rust-std-static-wasm32-wasi",
+                        "repository": "almalinux9-appstream"
+                    }
+                ],
+                "set_id": 24156
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17587,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "rust-std-static-wasm32-wasi",
+                        "repository": "almalinux8-appstream"
+                    }
+                ],
+                "set_id": 24157
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 9,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "x86_64"
+            ],
+            "id": 17588,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "command-line-assistant-selinux",
+                        "repository": "almalinux10-appstream"
+                    }
+                ],
+                "set_id": 24158
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17589,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "python3-snapm",
+                        "repository": "almalinux9-appstream"
+                    }
+                ],
+                "set_id": 24159
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17590,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "python3-snapm-doc",
+                        "repository": "almalinux9-appstream"
+                    }
+                ],
+                "set_id": 24160
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17591,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "snapm",
+                        "repository": "almalinux9-appstream"
+                    }
+                ],
+                "set_id": 24161
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17592,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "snapm",
+                        "repository": "almalinux10-appstream"
+                    }
+                ],
+                "set_id": 24162
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17593,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "python3-snapm",
+                        "repository": "almalinux10-appstream"
+                    }
+                ],
+                "set_id": 24163
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17594,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "python3-snapm-doc",
+                        "repository": "almalinux10-appstream"
+                    }
+                ],
+                "set_id": 24164
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 7,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17595,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "mysql",
+                                "stream": "8.4"
+                            }
+                        ],
+                        "name": "mysql-test",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24165
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [
+                {
+                    "in_modulestream": {
+                        "name": "mysql",
+                        "stream": "8.4"
+                    },
+                    "out_modulestream": null
+                }
+            ],
+            "out_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "mysql8.4-test",
+                        "repository": "almalinux10-crb"
+                    }
+                ],
+                "set_id": 24166
+            },
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 7,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17596,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "mysql",
+                                "stream": "8.4"
+                            }
+                        ],
+                        "name": "mysql-test-data",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24167
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [
+                {
+                    "in_modulestream": {
+                        "name": "mysql",
+                        "stream": "8.4"
+                    },
+                    "out_modulestream": null
+                }
+            ],
+            "out_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "mysql8.4-test-data",
+                        "repository": "almalinux10-crb"
+                    }
+                ],
+                "set_id": 24168
+            },
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "x86_64"
+            ],
+            "id": 17597,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "qat-zstd-plugin",
+                        "repository": "almalinux9-appstream"
+                    }
+                ],
+                "set_id": 24169
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "x86_64"
+            ],
+            "id": 17598,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "qat-zstd-plugin-devel",
+                        "repository": "almalinux9-appstream"
+                    }
+                ],
+                "set_id": 24170
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "x86_64"
+            ],
+            "id": 17599,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "qat-zstd-plugin-static",
+                        "repository": "almalinux9-crb"
+                    }
+                ],
+                "set_id": 24171
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17600,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "legacy-printer-app",
+                        "repository": "almalinux10-appstream"
+                    }
+                ],
+                "set_id": 24172
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17601,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "pappl-retrofit",
+                        "repository": "almalinux10-appstream"
+                    }
+                ],
+                "set_id": 24173
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17602,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "nodejs",
+                                "stream": "22"
+                            }
+                        ],
+                        "name": "nodejs",
+                        "repository": "almalinux8-appstream"
+                    }
+                ],
+                "set_id": 24174
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 9,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17603,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "nodejs",
+                                "stream": "22"
+                            }
+                        ],
+                        "name": "nodejs-devel",
+                        "repository": "almalinux8-appstream"
+                    }
+                ],
+                "set_id": 24175
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 9,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17604,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "nodejs",
+                                "stream": "22"
+                            }
+                        ],
+                        "name": "nodejs-docs",
+                        "repository": "almalinux8-appstream"
+                    }
+                ],
+                "set_id": 24176
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 9,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17605,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "nodejs",
+                                "stream": "22"
+                            }
+                        ],
+                        "name": "nodejs-full-i18n",
+                        "repository": "almalinux8-appstream"
+                    }
+                ],
+                "set_id": 24177
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 9,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17606,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "nodejs",
+                                "stream": "22"
+                            }
+                        ],
+                        "name": "nodejs-libs",
+                        "repository": "almalinux8-appstream"
+                    }
+                ],
+                "set_id": 24178
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 9,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17607,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "nodejs",
+                                "stream": "22"
+                            }
+                        ],
+                        "name": "nodejs-nodemon",
+                        "repository": "almalinux8-appstream"
+                    }
+                ],
+                "set_id": 24179
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 9,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17608,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "nodejs",
+                                "stream": "22"
+                            }
+                        ],
+                        "name": "nodejs-packaging",
+                        "repository": "almalinux8-appstream"
+                    }
+                ],
+                "set_id": 24180
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 9,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17609,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "nodejs",
+                                "stream": "22"
+                            }
+                        ],
+                        "name": "nodejs-packaging-bundler",
+                        "repository": "almalinux8-appstream"
+                    }
+                ],
+                "set_id": 24181
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 9,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17610,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "nodejs",
+                                "stream": "22"
+                            }
+                        ],
+                        "name": "npm",
+                        "repository": "almalinux8-appstream"
+                    }
+                ],
+                "set_id": 24182
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 9,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17611,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "nodejs",
+                                "stream": "22"
+                            }
+                        ],
+                        "name": "v8-12.4-devel",
+                        "repository": "almalinux8-appstream"
+                    }
+                ],
+                "set_id": 24183
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 9,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 4,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17612,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "opensc",
+                        "repository": "baseos"
+                    }
+                ],
+                "set_id": 24184
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [
+                {
+                    "in_modulestream": null,
+                    "out_modulestream": null
+                }
+            ],
+            "out_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "opensc",
+                        "repository": "almalinux10-baseos"
+                    },
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "opensc-libs",
+                        "repository": "almalinux10-baseos"
+                    }
+                ],
+                "set_id": 24185
+            },
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17613,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "copy-jdk-configs",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24186
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17614,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "leapp",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24187
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17615,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "leapp-deps",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24188
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17616,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "python3-leapp",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24189
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17617,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "snactor",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24190
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17618,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "leapp-upgrade-el8toel9",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24191
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17619,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "leapp-upgrade-el8toel9-deps",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24192
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17620,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "cockpit-leapp",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24193
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17621,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "leapp",
+                        "repository": "almalinux9-appstream"
+                    }
+                ],
+                "set_id": 24194
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17622,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "leapp-deps",
+                        "repository": "almalinux9-appstream"
+                    }
+                ],
+                "set_id": 24195
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17623,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "python3-leapp",
+                        "repository": "almalinux9-appstream"
+                    }
+                ],
+                "set_id": 24196
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17624,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "snactor",
+                        "repository": "almalinux9-crb"
+                    }
+                ],
+                "set_id": 24197
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17625,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "leapp-upgrade-el9toel10",
+                        "repository": "almalinux9-appstream"
+                    }
+                ],
+                "set_id": 24198
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17626,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "leapp-upgrade-el9toel10-deps",
+                        "repository": "almalinux9-appstream"
+                    }
+                ],
+                "set_id": 24199
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17627,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "cockpit-leapp",
+                        "repository": "almalinux9-appstream"
+                    }
+                ],
+                "set_id": 24200
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17628,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "libportal-qt6",
+                        "repository": "almalinux10-appstream"
+                    }
+                ],
+                "set_id": 24201
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 7,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17629,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "libportal-qt6-devel",
+                        "repository": "almalinux10-crb"
+                    }
+                ],
+                "set_id": 24202
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 7,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17630,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "pidgin-sipe",
+                        "repository": "almalinux8-appstream"
+                    }
+                ],
+                "set_id": 24205
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 9,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17631,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "pidgin",
+                        "repository": "almalinux8-appstream"
+                    }
+                ],
+                "set_id": 24206
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 9,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17632,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "gtkspell",
+                        "repository": "almalinux8-appstream"
+                    }
+                ],
+                "set_id": 24207
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 9,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17633,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "gvfs-afc",
+                        "repository": "almalinux8-appstream"
+                    }
+                ],
+                "set_id": 24208
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 9,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17634,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "dleyna-renderer",
+                        "repository": "almalinux8-appstream"
+                    }
+                ],
+                "set_id": 24209
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 9,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17635,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "dleyna-server",
+                        "repository": "almalinux8-appstream"
+                    }
+                ],
+                "set_id": 24210
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 9,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17636,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "dleyna-connector-dbus",
+                        "repository": "almalinux8-appstream"
+                    }
+                ],
+                "set_id": 24211
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 9,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17637,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "php",
+                                "stream": "8.3"
+                            }
+                        ],
+                        "name": "apcu-panel",
+                        "repository": "almalinux9-appstream"
+                    }
+                ],
+                "set_id": 24212
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17638,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "php",
+                                "stream": "8.3"
+                            }
+                        ],
+                        "name": "php",
+                        "repository": "almalinux9-appstream"
+                    }
+                ],
+                "set_id": 24213
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17639,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "php",
+                                "stream": "8.3"
+                            }
+                        ],
+                        "name": "php-bcmath",
+                        "repository": "almalinux9-appstream"
+                    }
+                ],
+                "set_id": 24214
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17640,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "php",
+                                "stream": "8.3"
+                            }
+                        ],
+                        "name": "php-cli",
+                        "repository": "almalinux9-appstream"
+                    }
+                ],
+                "set_id": 24215
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17641,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "php",
+                                "stream": "8.3"
+                            }
+                        ],
+                        "name": "php-common",
+                        "repository": "almalinux9-appstream"
+                    }
+                ],
+                "set_id": 24216
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17642,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "php",
+                                "stream": "8.3"
+                            }
+                        ],
+                        "name": "php-dba",
+                        "repository": "almalinux9-appstream"
+                    }
+                ],
+                "set_id": 24217
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17643,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "php",
+                                "stream": "8.3"
+                            }
+                        ],
+                        "name": "php-dbg",
+                        "repository": "almalinux9-appstream"
+                    }
+                ],
+                "set_id": 24218
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17644,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "php",
+                                "stream": "8.3"
+                            }
+                        ],
+                        "name": "php-devel",
+                        "repository": "almalinux9-appstream"
+                    }
+                ],
+                "set_id": 24219
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17645,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "php",
+                                "stream": "8.3"
+                            }
+                        ],
+                        "name": "php-embedded",
+                        "repository": "almalinux9-appstream"
+                    }
+                ],
+                "set_id": 24220
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17646,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "php",
+                                "stream": "8.3"
+                            }
+                        ],
+                        "name": "php-enchant",
+                        "repository": "almalinux9-appstream"
+                    }
+                ],
+                "set_id": 24221
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17647,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "php",
+                                "stream": "8.3"
+                            }
+                        ],
+                        "name": "php-ffi",
+                        "repository": "almalinux9-appstream"
+                    }
+                ],
+                "set_id": 24222
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17648,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "php",
+                                "stream": "8.3"
+                            }
+                        ],
+                        "name": "php-fpm",
+                        "repository": "almalinux9-appstream"
+                    }
+                ],
+                "set_id": 24223
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17649,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "php",
+                                "stream": "8.3"
+                            }
+                        ],
+                        "name": "php-gd",
+                        "repository": "almalinux9-appstream"
+                    }
+                ],
+                "set_id": 24224
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17650,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "php",
+                                "stream": "8.3"
+                            }
+                        ],
+                        "name": "php-gmp",
+                        "repository": "almalinux9-appstream"
+                    }
+                ],
+                "set_id": 24225
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17651,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "php",
+                                "stream": "8.3"
+                            }
+                        ],
+                        "name": "php-intl",
+                        "repository": "almalinux9-appstream"
+                    }
+                ],
+                "set_id": 24226
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17652,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "php",
+                                "stream": "8.3"
+                            }
+                        ],
+                        "name": "php-ldap",
+                        "repository": "almalinux9-appstream"
+                    }
+                ],
+                "set_id": 24227
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17653,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "php",
+                                "stream": "8.3"
+                            }
+                        ],
+                        "name": "php-mbstring",
+                        "repository": "almalinux9-appstream"
+                    }
+                ],
+                "set_id": 24228
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17654,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "php",
+                                "stream": "8.3"
+                            }
+                        ],
+                        "name": "php-mysqlnd",
+                        "repository": "almalinux9-appstream"
+                    }
+                ],
+                "set_id": 24229
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17655,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "php",
+                                "stream": "8.3"
+                            }
+                        ],
+                        "name": "php-odbc",
+                        "repository": "almalinux9-appstream"
+                    }
+                ],
+                "set_id": 24230
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17656,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "php",
+                                "stream": "8.3"
+                            }
+                        ],
+                        "name": "php-opcache",
+                        "repository": "almalinux9-appstream"
+                    }
+                ],
+                "set_id": 24231
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17657,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "php",
+                                "stream": "8.3"
+                            }
+                        ],
+                        "name": "php-pdo",
+                        "repository": "almalinux9-appstream"
+                    }
+                ],
+                "set_id": 24232
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17658,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "php",
+                                "stream": "8.3"
+                            }
+                        ],
+                        "name": "php-pecl-apcu",
+                        "repository": "almalinux9-appstream"
+                    }
+                ],
+                "set_id": 24233
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17659,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "php",
+                                "stream": "8.3"
+                            }
+                        ],
+                        "name": "php-pecl-apcu-devel",
+                        "repository": "almalinux9-appstream"
+                    }
+                ],
+                "set_id": 24234
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17660,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "php",
+                                "stream": "8.3"
+                            }
+                        ],
+                        "name": "php-pecl-redis6",
+                        "repository": "almalinux9-appstream"
+                    }
+                ],
+                "set_id": 24235
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17661,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "php",
+                                "stream": "8.3"
+                            }
+                        ],
+                        "name": "php-pecl-rrd",
+                        "repository": "almalinux9-appstream"
+                    }
+                ],
+                "set_id": 24236
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17662,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "php",
+                                "stream": "8.3"
+                            }
+                        ],
+                        "name": "php-pecl-xdebug3",
+                        "repository": "almalinux9-appstream"
+                    }
+                ],
+                "set_id": 24237
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17663,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "php",
+                                "stream": "8.3"
+                            }
+                        ],
+                        "name": "php-pecl-zip",
+                        "repository": "almalinux9-appstream"
+                    }
+                ],
+                "set_id": 24238
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17664,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "php",
+                                "stream": "8.3"
+                            }
+                        ],
+                        "name": "php-pgsql",
+                        "repository": "almalinux9-appstream"
+                    }
+                ],
+                "set_id": 24239
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17665,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "php",
+                                "stream": "8.3"
+                            }
+                        ],
+                        "name": "php-process",
+                        "repository": "almalinux9-appstream"
+                    }
+                ],
+                "set_id": 24240
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17666,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "php",
+                                "stream": "8.3"
+                            }
+                        ],
+                        "name": "php-snmp",
+                        "repository": "almalinux9-appstream"
+                    }
+                ],
+                "set_id": 24241
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17667,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "php",
+                                "stream": "8.3"
+                            }
+                        ],
+                        "name": "php-soap",
+                        "repository": "almalinux9-appstream"
+                    }
+                ],
+                "set_id": 24242
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17668,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "php",
+                                "stream": "8.3"
+                            }
+                        ],
+                        "name": "php-xml",
+                        "repository": "almalinux9-appstream"
+                    }
+                ],
+                "set_id": 24243
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17669,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "nginx",
+                                "stream": "1.26"
+                            }
+                        ],
+                        "name": "nginx",
+                        "repository": "almalinux9-appstream"
+                    }
+                ],
+                "set_id": 24244
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17670,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "nginx",
+                                "stream": "1.26"
+                            }
+                        ],
+                        "name": "nginx-all-modules",
+                        "repository": "almalinux9-appstream"
+                    }
+                ],
+                "set_id": 24245
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17671,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "nginx",
+                                "stream": "1.26"
+                            }
+                        ],
+                        "name": "nginx-core",
+                        "repository": "almalinux9-appstream"
+                    }
+                ],
+                "set_id": 24246
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17672,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "nginx",
+                                "stream": "1.26"
+                            }
+                        ],
+                        "name": "nginx-filesystem",
+                        "repository": "almalinux9-appstream"
+                    }
+                ],
+                "set_id": 24247
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17673,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "nginx",
+                                "stream": "1.26"
+                            }
+                        ],
+                        "name": "nginx-mod-devel",
+                        "repository": "almalinux9-appstream"
+                    }
+                ],
+                "set_id": 24248
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17674,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "nginx",
+                                "stream": "1.26"
+                            }
+                        ],
+                        "name": "nginx-mod-http-image-filter",
+                        "repository": "almalinux9-appstream"
+                    }
+                ],
+                "set_id": 24249
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17675,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "nginx",
+                                "stream": "1.26"
+                            }
+                        ],
+                        "name": "nginx-mod-http-perl",
+                        "repository": "almalinux9-appstream"
+                    }
+                ],
+                "set_id": 24250
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17676,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "nginx",
+                                "stream": "1.26"
+                            }
+                        ],
+                        "name": "nginx-mod-http-xslt-filter",
+                        "repository": "almalinux9-appstream"
+                    }
+                ],
+                "set_id": 24251
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17677,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "nginx",
+                                "stream": "1.26"
+                            }
+                        ],
+                        "name": "nginx-mod-mail",
+                        "repository": "almalinux9-appstream"
+                    }
+                ],
+                "set_id": 24252
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17678,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "nginx",
+                                "stream": "1.26"
+                            }
+                        ],
+                        "name": "nginx-mod-stream",
+                        "repository": "almalinux9-appstream"
+                    }
+                ],
+                "set_id": 24253
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "x86_64"
+            ],
+            "id": 17679,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "gnome-boxes",
+                        "repository": "almalinux8-appstream"
+                    }
+                ],
+                "set_id": 24254
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 9,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17680,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "dleyna-core",
+                        "repository": "almalinux8-appstream"
+                    }
+                ],
+                "set_id": 24255
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 9,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17681,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "redhat-menus",
+                        "repository": "almalinux8-appstream"
+                    }
+                ],
+                "set_id": 24256
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 9,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "x86_64"
+            ],
+            "id": 17682,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "dbxtool",
+                        "repository": "almalinux8-baseos"
+                    }
+                ],
+                "set_id": 24257
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 9,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17683,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "gnome-online-miners",
+                        "repository": "almalinux8-appstream"
+                    }
+                ],
+                "set_id": 24258
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 9,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17684,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "gfbgraph",
+                        "repository": "almalinux8-appstream"
+                    }
+                ],
+                "set_id": 24259
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 9,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17685,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "webkitgtk3",
+                        "repository": "base"
+                    }
+                ],
+                "set_id": 24260
+            },
+            "initial_release": {
+                "major_version": 7,
+                "minor_version": 8,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 7,
+                "minor_version": 9,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 6,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17686,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "php",
+                                "stream": "8.3"
+                            }
+                        ],
+                        "name": "php-pecl-redis6",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24261
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 7,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [
+                {
+                    "in_modulestream": {
+                        "name": "php",
+                        "stream": "8.3"
+                    },
+                    "out_modulestream": null
+                }
+            ],
+            "out_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "php-pecl-redis6",
+                        "repository": "almalinux10-appstream"
+                    }
+                ],
+                "set_id": 24262
+            },
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17687,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "nginx",
+                                "stream": "1.26"
+                            }
+                        ],
+                        "name": "nginx",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24263
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 7,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17688,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "nginx",
+                                "stream": "1.26"
+                            }
+                        ],
+                        "name": "nginx",
+                        "repository": "almalinux9-appstream"
+                    }
+                ],
+                "set_id": 24264
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 7,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "x86_64"
+            ],
+            "id": 17689,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "trustee-guest-components",
+                        "repository": "almalinux9-appstream"
+                    }
+                ],
+                "set_id": 24265
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "x86_64"
+            ],
+            "id": 17690,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "python3-libcpuid",
+                        "repository": "almalinux10-baseos"
+                    }
+                ],
+                "set_id": 24266
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 7,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "x86_64"
+            ],
+            "id": 17691,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "libcamera",
+                        "repository": "almalinux10-appstream"
+                    }
+                ],
+                "set_id": 24267
+            },
+            "initial_release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 1,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17692,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "gnome-settings-daemon-server-defaults",
+                        "repository": "almalinux10-appstream"
+                    }
+                ],
+                "set_id": 24268
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 7,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 6,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17693,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "bpftool",
+                        "repository": "almalinux9-baseos"
+                    }
+                ],
+                "set_id": 24269
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [
+                {
+                    "in_modulestream": null,
+                    "out_modulestream": null
+                }
+            ],
+            "out_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "bpftool",
+                        "repository": "almalinux9-appstream"
+                    }
+                ],
+                "set_id": 24270
+            },
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17694,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "tomcat-jakartaee-migration",
+                        "repository": "almalinux10-appstream"
+                    }
+                ],
+                "set_id": 24271
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17695,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "unbound-dracut",
+                        "repository": "almalinux10-appstream"
+                    }
+                ],
+                "set_id": 24272
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 7,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17696,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "unbound-dracut",
+                        "repository": "almalinux9-appstream"
+                    }
+                ],
+                "set_id": 24273
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17697,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "bpftool",
+                        "repository": "almalinux10-appstream"
+                    }
+                ],
+                "set_id": 24274
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 7,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17698,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "libspelling",
+                        "repository": "almalinux10-appstream"
+                    }
+                ],
+                "set_id": 24275
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 7,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17699,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "libspelling-devel",
+                        "repository": "almalinux10-crb"
+                    }
+                ],
+                "set_id": 24276
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 7,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 3,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17700,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "tomcat-el-3.0-api",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24277
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 7,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [
+                {
+                    "in_modulestream": null,
+                    "out_modulestream": null
+                }
+            ],
+            "out_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "tomcat-el-5.0-api",
+                        "repository": "almalinux10-appstream"
+                    }
+                ],
+                "set_id": 24278
+            },
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 3,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17701,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "tomcat-servlet-4.0-api",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24279
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 7,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [
+                {
+                    "in_modulestream": null,
+                    "out_modulestream": null
+                }
+            ],
+            "out_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "tomcat-servlet-6.0-api",
+                        "repository": "almalinux10-appstream"
+                    }
+                ],
+                "set_id": 24280
+            },
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 3,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17702,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "tomcat-jsp-2.3-api",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24281
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 7,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [
+                {
+                    "in_modulestream": null,
+                    "out_modulestream": null
+                }
+            ],
+            "out_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "tomcat-jsp-3.1-api",
+                        "repository": "almalinux10-appstream"
+                    }
+                ],
+                "set_id": 24282
+            },
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17703,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "perl-DBD-MariaDB",
+                        "repository": "almalinux10-appstream"
+                    }
+                ],
+                "set_id": 24284
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 7,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17704,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "perl-DBD-MySQL",
+                        "repository": "almalinux10-appstream"
+                    }
+                ],
+                "set_id": 24285
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 7,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 3,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17705,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "cockpit-composer",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24286
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 7,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [
+                {
+                    "in_modulestream": null,
+                    "out_modulestream": null
+                }
+            ],
+            "out_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "cockpit-image-builder",
+                        "repository": "almalinux10-appstream"
+                    }
+                ],
+                "set_id": 24287
+            },
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17706,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "cockpit-composer",
+                        "repository": "almalinux9-appstream"
+                    }
+                ],
+                "set_id": 24288
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "x86_64"
+            ],
+            "id": 17707,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "trustee-guest-components",
+                        "repository": "almalinux10-appstream"
+                    }
+                ],
+                "set_id": 24289
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 7,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 4,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17708,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "rsync",
+                        "repository": "almalinux9-baseos"
+                    }
+                ],
+                "set_id": 24290
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [
+                {
+                    "in_modulestream": null,
+                    "out_modulestream": null
+                }
+            ],
+            "out_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "rsync",
+                        "repository": "almalinux9-baseos"
+                    },
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "rsync-rrsync",
+                        "repository": "almalinux9-appstream"
+                    }
+                ],
+                "set_id": 24291
+            },
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17709,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "dnsconfd-micro",
+                        "repository": "almalinux10-appstream"
+                    }
+                ],
+                "set_id": 24292
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 7,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
             "action": 3,
             "architectures": [
                 "x86_64",
@@ -622250,7 +628946,7 @@
                 "ppc64le",
                 "s390x"
             ],
-            "id": 17430,
+            "id": 17710,
             "in_packageset": {
                 "package": [
                     {
@@ -622261,7 +628957,7 @@
                         "repository": "base"
                     }
                 ],
-                "set_id": 23979
+                "set_id": 24294
             },
             "initial_release": {
                 "major_version": 7,
@@ -622286,7 +628982,7 @@
                         "repository": "almalinux8-baseos"
                     }
                 ],
-                "set_id": 23978
+                "set_id": 24293
             },
             "release": {
                 "major_version": 8,
@@ -622304,7 +629000,7 @@
                 "ppc64le",
                 "s390x"
             ],
-            "id": 17431,
+            "id": 17711,
             "in_packageset": {
                 "package": [
                     {
@@ -622315,7 +629011,7 @@
                         "repository": "base"
                     }
                 ],
-                "set_id": 23980
+                "set_id": 24295
             },
             "initial_release": {
                 "major_version": 7,
@@ -622338,7 +629034,7 @@
                 "ppc64le",
                 "s390x"
             ],
-            "id": 17432,
+            "id": 17712,
             "in_packageset": {
                 "package": [
                     {
@@ -622349,7 +629045,7 @@
                         "repository": "base"
                     }
                 ],
-                "set_id": 23982
+                "set_id": 24297
             },
             "initial_release": {
                 "major_version": 7,
@@ -622374,7 +629070,7 @@
                         "repository": "almalinux8-baseos"
                     }
                 ],
-                "set_id": 23981
+                "set_id": 24296
             },
             "release": {
                 "major_version": 8,
@@ -622392,7 +629088,7 @@
                 "ppc64le",
                 "s390x"
             ],
-            "id": 17433,
+            "id": 17713,
             "in_packageset": {
                 "package": [
                     {
@@ -622403,7 +629099,7 @@
                         "repository": "base"
                     }
                 ],
-                "set_id": 23984
+                "set_id": 24299
             },
             "initial_release": {
                 "major_version": 7,
@@ -622428,7 +629124,7 @@
                         "repository": "almalinux8-baseos"
                     }
                 ],
-                "set_id": 23983
+                "set_id": 24298
             },
             "release": {
                 "major_version": 8,
@@ -622446,7 +629142,7 @@
                 "ppc64le",
                 "s390x"
             ],
-            "id": 17434,
+            "id": 17714,
             "in_packageset": {
                 "package": [
                     {
@@ -622457,7 +629153,7 @@
                         "repository": "base"
                     }
                 ],
-                "set_id": 23986
+                "set_id": 24301
             },
             "initial_release": {
                 "major_version": 7,
@@ -622482,7 +629178,7 @@
                         "repository": "almalinux8-baseos"
                     }
                 ],
-                "set_id": 23985
+                "set_id": 24300
             },
             "release": {
                 "major_version": 8,
@@ -622500,7 +629196,7 @@
                 "ppc64le",
                 "s390x"
             ],
-            "id": 17435,
+            "id": 17715,
             "in_packageset": {
                 "package": [
                     {
@@ -622511,7 +629207,7 @@
                         "repository": "powertools"
                     }
                 ],
-                "set_id": 23987
+                "set_id": 24302
             },
             "initial_release": {
                 "major_version": 8,
@@ -622543,7 +629239,7 @@
                 "ppc64le",
                 "s390x"
             ],
-            "id": 17436,
+            "id": 17716,
             "in_packageset": {
                 "package": [
                     {
@@ -622554,7 +629250,7 @@
                         "repository": "appstream"
                     }
                 ],
-                "set_id": 23988
+                "set_id": 24303
             },
             "initial_release": {
                 "major_version": 8,
@@ -622586,7 +629282,7 @@
                 "ppc64le",
                 "s390x"
             ],
-            "id": 17437,
+            "id": 17717,
             "in_packageset": {
                 "package": [
                     {
@@ -622597,7 +629293,7 @@
                         "repository": "appstream"
                     }
                 ],
-                "set_id": 23989
+                "set_id": 24304
             },
             "initial_release": {
                 "major_version": 8,
@@ -622629,7 +629325,7 @@
                 "ppc64le",
                 "s390x"
             ],
-            "id": 17438,
+            "id": 17718,
             "in_packageset": {
                 "package": [
                     {
@@ -622640,7 +629336,7 @@
                         "repository": "baseos"
                     }
                 ],
-                "set_id": 23990
+                "set_id": 24305
             },
             "initial_release": {
                 "major_version": 8,
@@ -622672,7 +629368,7 @@
                 "ppc64le",
                 "s390x"
             ],
-            "id": 17439,
+            "id": 17719,
             "in_packageset": {
                 "package": [
                     {
@@ -622683,7 +629379,7 @@
                         "repository": "appstream"
                     }
                 ],
-                "set_id": 23991
+                "set_id": 24306
             },
             "initial_release": {
                 "major_version": 8,
@@ -622715,7 +629411,7 @@
                 "ppc64le",
                 "s390x"
             ],
-            "id": 17440,
+            "id": 17720,
             "in_packageset": {
                 "package": [
                     {
@@ -622726,7 +629422,7 @@
                         "repository": "appstream"
                     }
                 ],
-                "set_id": 23992
+                "set_id": 24307
             },
             "initial_release": {
                 "major_version": 8,
@@ -622758,7 +629454,7 @@
                 "ppc64le",
                 "s390x"
             ],
-            "id": 17441,
+            "id": 17721,
             "in_packageset": {
                 "package": [
                     {
@@ -622769,7 +629465,7 @@
                         "repository": "baseos"
                     }
                 ],
-                "set_id": 23993
+                "set_id": 24308
             },
             "initial_release": {
                 "major_version": 8,
@@ -622801,7 +629497,7 @@
                 "ppc64le",
                 "s390x"
             ],
-            "id": 17442,
+            "id": 17722,
             "in_packageset": {
                 "package": [
                     {
@@ -622812,7 +629508,7 @@
                         "repository": "baseos"
                     }
                 ],
-                "set_id": 23994
+                "set_id": 24309
             },
             "initial_release": {
                 "major_version": 8,
@@ -622844,7 +629540,7 @@
                 "ppc64le",
                 "s390x"
             ],
-            "id": 17443,
+            "id": 17723,
             "in_packageset": {
                 "package": [
                     {
@@ -622855,7 +629551,7 @@
                         "repository": "appstream"
                     }
                 ],
-                "set_id": 23995
+                "set_id": 24310
             },
             "initial_release": {
                 "major_version": 8,
@@ -622887,7 +629583,7 @@
                 "ppc64le",
                 "s390x"
             ],
-            "id": 17444,
+            "id": 17724,
             "in_packageset": {
                 "package": [
                     {
@@ -622898,7 +629594,7 @@
                         "repository": "appstream"
                     }
                 ],
-                "set_id": 23996
+                "set_id": 24311
             },
             "initial_release": {
                 "major_version": 8,
@@ -622930,7 +629626,7 @@
                 "ppc64le",
                 "s390x"
             ],
-            "id": 17445,
+            "id": 17725,
             "in_packageset": {
                 "package": [
                     {
@@ -622941,7 +629637,7 @@
                         "repository": "appstream"
                     }
                 ],
-                "set_id": 23997
+                "set_id": 24312
             },
             "initial_release": {
                 "major_version": 8,
@@ -622973,7 +629669,7 @@
                 "ppc64le",
                 "s390x"
             ],
-            "id": 17446,
+            "id": 17726,
             "in_packageset": {
                 "package": [
                     {
@@ -622984,7 +629680,7 @@
                         "repository": "appstream"
                     }
                 ],
-                "set_id": 23998
+                "set_id": 24313
             },
             "initial_release": {
                 "major_version": 8,
@@ -623016,7 +629712,7 @@
                 "ppc64le",
                 "s390x"
             ],
-            "id": 17447,
+            "id": 17727,
             "in_packageset": {
                 "package": [
                     {
@@ -623027,7 +629723,7 @@
                         "repository": "appstream"
                     }
                 ],
-                "set_id": 23999
+                "set_id": 24314
             },
             "initial_release": {
                 "major_version": 8,
@@ -623059,7 +629755,7 @@
                 "ppc64le",
                 "s390x"
             ],
-            "id": 17448,
+            "id": 17728,
             "in_packageset": {
                 "package": [
                     {
@@ -623070,7 +629766,7 @@
                         "repository": "appstream"
                     }
                 ],
-                "set_id": 24000
+                "set_id": 24315
             },
             "initial_release": {
                 "major_version": 8,
@@ -623102,7 +629798,7 @@
                 "ppc64le",
                 "s390x"
             ],
-            "id": 17449,
+            "id": 17729,
             "in_packageset": {
                 "package": [
                     {
@@ -623113,7 +629809,7 @@
                         "repository": "appstream"
                     }
                 ],
-                "set_id": 24001
+                "set_id": 24316
             },
             "initial_release": {
                 "major_version": 8,
@@ -623145,7 +629841,7 @@
                 "ppc64le",
                 "s390x"
             ],
-            "id": 17450,
+            "id": 17730,
             "in_packageset": {
                 "package": [
                     {
@@ -623156,7 +629852,7 @@
                         "repository": "appstream"
                     }
                 ],
-                "set_id": 24002
+                "set_id": 24317
             },
             "initial_release": {
                 "major_version": 8,
@@ -623185,7 +629881,7 @@
             "architectures": [
                 "x86_64"
             ],
-            "id": 17451,
+            "id": 17731,
             "in_packageset": {
                 "package": [
                     {
@@ -623196,7 +629892,7 @@
                         "repository": "sl"
                     }
                 ],
-                "set_id": 24003
+                "set_id": 24318
             },
             "initial_release": {
                 "major_version": 7,
@@ -623216,7 +629912,7 @@
             "architectures": [
                 "x86_64"
             ],
-            "id": 17452,
+            "id": 17732,
             "in_packageset": {
                 "package": [
                     {
@@ -623227,7 +629923,7 @@
                         "repository": "sl"
                     }
                 ],
-                "set_id": 24004
+                "set_id": 24319
             },
             "initial_release": {
                 "major_version": 7,
@@ -623247,7 +629943,7 @@
             "architectures": [
                 "x86_64"
             ],
-            "id": 17453,
+            "id": 17733,
             "in_packageset": {
                 "package": [
                     {
@@ -623258,7 +629954,7 @@
                         "repository": "repos"
                     }
                 ],
-                "set_id": 24005
+                "set_id": 24320
             },
             "initial_release": {
                 "major_version": 7,
@@ -623278,7 +629974,7 @@
             "architectures": [
                 "x86_64"
             ],
-            "id": 17454,
+            "id": 17734,
             "in_packageset": {
                 "package": [
                     {
@@ -623289,7 +629985,7 @@
                         "repository": "repos"
                     }
                 ],
-                "set_id": 24006
+                "set_id": 24321
             },
             "initial_release": {
                 "major_version": 7,
@@ -623309,7 +630005,7 @@
             "architectures": [
                 "x86_64"
             ],
-            "id": 17455,
+            "id": 17735,
             "in_packageset": {
                 "package": [
                     {
@@ -623320,7 +630016,7 @@
                         "repository": "sl"
                     }
                 ],
-                "set_id": 24007
+                "set_id": 24322
             },
             "initial_release": {
                 "major_version": 7,
@@ -623340,7 +630036,7 @@
             "architectures": [
                 "x86_64"
             ],
-            "id": 17456,
+            "id": 17736,
             "in_packageset": {
                 "package": [
                     {
@@ -623351,7 +630047,7 @@
                         "repository": "sl"
                     }
                 ],
-                "set_id": 24008
+                "set_id": 24323
             },
             "initial_release": {
                 "major_version": 7,
@@ -623372,7 +630068,7 @@
                 "x86_64",
                 "aarch64"
             ],
-            "id": 17457,
+            "id": 17737,
             "in_packageset": {
                 "package": [
                     {
@@ -623383,7 +630079,7 @@
                         "repository": "sl"
                     }
                 ],
-                "set_id": 24010
+                "set_id": 24325
             },
             "initial_release": {
                 "major_version": 7,
@@ -623408,7 +630104,7 @@
                         "repository": "almalinux8-baseos"
                     }
                 ],
-                "set_id": 24009
+                "set_id": 24324
             },
             "release": {
                 "major_version": 8,
@@ -623424,7 +630120,7 @@
                 "x86_64",
                 "aarch64"
             ],
-            "id": 17458,
+            "id": 17738,
             "in_packageset": {
                 "package": [
                     {
@@ -623435,7 +630131,7 @@
                         "repository": "sl"
                     }
                 ],
-                "set_id": 24012
+                "set_id": 24327
             },
             "initial_release": {
                 "major_version": 7,
@@ -623460,7 +630156,7 @@
                         "repository": "almalinux8-appstream"
                     }
                 ],
-                "set_id": 24011
+                "set_id": 24326
             },
             "release": {
                 "major_version": 8,
@@ -623476,7 +630172,7 @@
                 "x86_64",
                 "aarch64"
             ],
-            "id": 17459,
+            "id": 17739,
             "in_packageset": {
                 "package": [
                     {
@@ -623487,7 +630183,7 @@
                         "repository": "sl"
                     }
                 ],
-                "set_id": 24014
+                "set_id": 24329
             },
             "initial_release": {
                 "major_version": 7,
@@ -623512,7 +630208,7 @@
                         "repository": "almalinux8-baseos"
                     }
                 ],
-                "set_id": 24013
+                "set_id": 24328
             },
             "release": {
                 "major_version": 8,
@@ -623528,7 +630224,7 @@
                 "x86_64",
                 "aarch64"
             ],
-            "id": 17460,
+            "id": 17740,
             "in_packageset": {
                 "package": [
                     {
@@ -623539,7 +630235,7 @@
                         "repository": "sl"
                     }
                 ],
-                "set_id": 24016
+                "set_id": 24331
             },
             "initial_release": {
                 "major_version": 7,
@@ -623564,7 +630260,7 @@
                         "repository": "almalinux8-baseos"
                     }
                 ],
-                "set_id": 24015
+                "set_id": 24330
             },
             "release": {
                 "major_version": 8,
@@ -623579,7 +630275,7 @@
             "architectures": [
                 "x86_64"
             ],
-            "id": 17461,
+            "id": 17741,
             "in_packageset": {
                 "package": [
                     {
@@ -623590,7 +630286,7 @@
                         "repository": "sl"
                     }
                 ],
-                "set_id": 24017
+                "set_id": 24332
             },
             "initial_release": {
                 "major_version": 7,
@@ -623611,7 +630307,7 @@
                 "x86_64",
                 "aarch64"
             ],
-            "id": 17462,
+            "id": 17742,
             "in_packageset": {
                 "package": [
                     {
@@ -623622,7 +630318,7 @@
                         "repository": "sl"
                     }
                 ],
-                "set_id": 24019
+                "set_id": 24334
             },
             "initial_release": {
                 "major_version": 7,
@@ -623647,7 +630343,7 @@
                         "repository": "almalinux8-baseos"
                     }
                 ],
-                "set_id": 24018
+                "set_id": 24333
             },
             "release": {
                 "major_version": 8,
@@ -623662,7 +630358,7 @@
             "architectures": [
                 "x86_64"
             ],
-            "id": 17463,
+            "id": 17743,
             "in_packageset": {
                 "package": [
                     {
@@ -623673,7 +630369,7 @@
                         "repository": "sl"
                     }
                 ],
-                "set_id": 24020
+                "set_id": 24335
             },
             "initial_release": {
                 "major_version": 7,
@@ -623693,7 +630389,7 @@
             "architectures": [
                 "x86_64"
             ],
-            "id": 17464,
+            "id": 17744,
             "in_packageset": {
                 "package": [
                     {
@@ -623704,7 +630400,7 @@
                         "repository": "sl"
                     }
                 ],
-                "set_id": 24021
+                "set_id": 24336
             },
             "initial_release": {
                 "major_version": 7,
@@ -623724,7 +630420,7 @@
             "architectures": [
                 "x86_64"
             ],
-            "id": 17465,
+            "id": 17745,
             "in_packageset": {
                 "package": [
                     {
@@ -623735,7 +630431,7 @@
                         "repository": "sl"
                     }
                 ],
-                "set_id": 24022
+                "set_id": 24337
             },
             "initial_release": {
                 "major_version": 7,
@@ -623755,7 +630451,7 @@
             "architectures": [
                 "x86_64"
             ],
-            "id": 17466,
+            "id": 17746,
             "in_packageset": {
                 "package": [
                     {
@@ -623766,7 +630462,7 @@
                         "repository": "sl"
                     }
                 ],
-                "set_id": 24023
+                "set_id": 24338
             },
             "initial_release": {
                 "major_version": 7,
@@ -623786,7 +630482,7 @@
             "architectures": [
                 "x86_64"
             ],
-            "id": 17467,
+            "id": 17747,
             "in_packageset": {
                 "package": [
                     {
@@ -623797,7 +630493,7 @@
                         "repository": "sl"
                     }
                 ],
-                "set_id": 24024
+                "set_id": 24339
             },
             "initial_release": {
                 "major_version": 7,
@@ -623817,7 +630513,7 @@
             "architectures": [
                 "x86_64"
             ],
-            "id": 17468,
+            "id": 17748,
             "in_packageset": {
                 "package": [
                     {
@@ -623828,7 +630524,7 @@
                         "repository": "sl"
                     }
                 ],
-                "set_id": 24025
+                "set_id": 24340
             },
             "initial_release": {
                 "major_version": 7,
@@ -623848,7 +630544,7 @@
             "architectures": [
                 "x86_64"
             ],
-            "id": 17469,
+            "id": 17749,
             "in_packageset": {
                 "package": [
                     {
@@ -623859,7 +630555,7 @@
                         "repository": "sl"
                     }
                 ],
-                "set_id": 24026
+                "set_id": 24341
             },
             "initial_release": {
                 "major_version": 7,
@@ -623879,7 +630575,7 @@
             "architectures": [
                 "x86_64"
             ],
-            "id": 17470,
+            "id": 17750,
             "in_packageset": {
                 "package": [
                     {
@@ -623890,7 +630586,7 @@
                         "repository": "sl"
                     }
                 ],
-                "set_id": 24027
+                "set_id": 24342
             },
             "initial_release": {
                 "major_version": 7,
@@ -623910,7 +630606,7 @@
             "architectures": [
                 "x86_64"
             ],
-            "id": 17471,
+            "id": 17751,
             "in_packageset": {
                 "package": [
                     {
@@ -623921,7 +630617,7 @@
                         "repository": "sl"
                     }
                 ],
-                "set_id": 24028
+                "set_id": 24343
             },
             "initial_release": {
                 "major_version": 7,
@@ -623941,7 +630637,7 @@
             "architectures": [
                 "x86_64"
             ],
-            "id": 17472,
+            "id": 17752,
             "in_packageset": {
                 "package": [
                     {
@@ -623952,7 +630648,7 @@
                         "repository": "sl"
                     }
                 ],
-                "set_id": 24029
+                "set_id": 24344
             },
             "initial_release": {
                 "major_version": 7,

--- a/files/centos/device_driver_deprecation_data.json
+++ b/files/centos/device_driver_deprecation_data.json
@@ -1557,7 +1557,7 @@
       "device_id": "",
       "device_name": "",
       "device_type": "pci",
-      "driver_name": "3w-9xxx",
+      "driver_name": "3w_9xxx",
       "maintained_in_rhel": []
     },
     {
@@ -1568,7 +1568,7 @@
       "device_id": "",
       "device_name": "",
       "device_type": "pci",
-      "driver_name": "3w-sas",
+      "driver_name": "3w_sas",
       "maintained_in_rhel": []
     },
     {
@@ -2429,7 +2429,7 @@
       "device_id": "",
       "device_name": "",
       "device_type": "pci",
-      "driver_name": "acard-ahci",
+      "driver_name": "acard_ahci",
       "maintained_in_rhel": []
     },
     {
@@ -2444,6 +2444,42 @@
       "device_name": "PF_KEY sockets",
       "device_type": "pci",
       "driver_name": "af_key",
+      "maintained_in_rhel": [
+        7,
+        8,
+        9
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7,
+        8,
+        9,
+        10
+      ],
+      "deprecation_announced": "",
+      "device_id": "",
+      "device_name": "Seattle AHCI SATA platform driver",
+      "device_type": "pci",
+      "driver_name": "ahci_seattle",
+      "maintained_in_rhel": [
+        7,
+        8,
+        9
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7,
+        8,
+        9,
+        10
+      ],
+      "deprecation_announced": "",
+      "device_id": "",
+      "device_name": "APM X-Gene AHCI SATA driver",
+      "device_type": "pci",
+      "driver_name": "ahci_xgene",
       "maintained_in_rhel": [
         7,
         8,
@@ -2891,7 +2927,7 @@
       "device_id": "",
       "device_name": "",
       "device_type": "pci",
-      "driver_name": "firewire-core",
+      "driver_name": "firewire_core",
       "maintained_in_rhel": [
         7,
         8,
@@ -2940,7 +2976,8 @@
       "available_in_rhel": [
         7,
         8,
-        9
+        9,
+        10
       ],
       "deprecation_announced": "",
       "device_id": "",
@@ -2949,7 +2986,27 @@
       "driver_name": "hfi1",
       "maintained_in_rhel": [
         7,
-        8
+        8,
+        9,
+        10
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7,
+        8,
+        9,
+        10
+      ],
+      "deprecation_announced": "",
+      "device_id": "",
+      "device_name": "HISILICON SAS controller driver",
+      "device_type": "pci",
+      "driver_name": "hisi_sas_main",
+      "maintained_in_rhel": [
+        7,
+        8,
+        9
       ]
     },
     {
@@ -4265,6 +4322,30 @@
     },
     {
       "available_in_rhel": [
+        9,
+        10
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x15B3:0x1023",
+      "device_name": "ConnectX-8",
+      "device_type": "pci",
+      "driver_name": "mlx5",
+      "maintained_in_rhel": [
+        9,
+        10
+      ]
+    },
+    {
+      "available_in_rhel": [],
+      "deprecation_announced": "",
+      "device_id": "0x15B3:0x1025",
+      "device_name": "ConnectX-9",
+      "device_type": "pci",
+      "driver_name": "mlx5",
+      "maintained_in_rhel": []
+    },
+    {
+      "available_in_rhel": [
         7,
         8,
         9,
@@ -4276,7 +4357,9 @@
       "device_type": "pci",
       "driver_name": "mlx5",
       "maintained_in_rhel": [
-        7
+        7,
+        9,
+        10
       ]
     },
     {
@@ -4828,7 +4911,7 @@
       "device_id": "",
       "device_name": "",
       "device_type": "pci",
-      "driver_name": "nvmet-fc",
+      "driver_name": "nvmet_fc",
       "maintained_in_rhel": [
         7
       ]
@@ -4844,7 +4927,7 @@
       "device_id": "",
       "device_name": "",
       "device_type": "pci",
-      "driver_name": "nvmet-tcp",
+      "driver_name": "nvmet_tcp",
       "maintained_in_rhel": [
         7
       ]

--- a/files/centos/pes-events.json
+++ b/files/centos/pes-events.json
@@ -1,5 +1,5 @@
 {
-    "timestamp": "202411121506Z",
+    "timestamp": "202502132105Z",
     "provided_data_streams": [
         "3.0",
         "3.1",
@@ -10024,7 +10024,14 @@
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "postgresql",
+                                "stream": "10"
+                            },
+                            {
+                                "name": "postgresql",
+                                "stream": "9.6"
+                            }
                         ],
                         "name": "postgresql-test-rpm-macros",
                         "repository": "centos8-appstream"
@@ -10032,7 +10039,11 @@
                 ],
                 "set_id": 391
             },
-            "initial_release": null,
+            "initial_release": {
+                "major_version": 7,
+                "minor_version": 9,
+                "os_name": "CentOS"
+            },
             "modulestream_maps": [],
             "out_packageset": null,
             "release": {
@@ -10782,7 +10793,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -10818,7 +10828,7 @@
                             null
                         ],
                         "name": "libjpeg-turbo-utils",
-                        "repository": "centos8-baseos"
+                        "repository": "centos8-appstream"
                     }
                 ],
                 "set_id": 432
@@ -10981,9 +10991,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 337,
@@ -65010,7 +65017,6 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -65044,7 +65050,6 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -65078,7 +65083,6 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -65112,7 +65116,6 @@
         {
             "action": 7,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -65260,9 +65263,6 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 1645,
@@ -65294,9 +65294,6 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 1646,
@@ -65328,9 +65325,6 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 1647,
@@ -65362,9 +65356,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 1648,
@@ -65398,7 +65389,7 @@
                             null
                         ],
                         "name": "libappindicator-gtk3-devel",
-                        "repository": "centos8-appstream"
+                        "repository": "centos8-powertools"
                     }
                 ],
                 "set_id": 5296
@@ -65412,9 +65403,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 1649,
@@ -65448,7 +65436,7 @@
                             null
                         ],
                         "name": "libdbusmenu-devel",
-                        "repository": "centos8-appstream"
+                        "repository": "centos8-powertools"
                     }
                 ],
                 "set_id": 5298
@@ -65462,9 +65450,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 1650,
@@ -65512,9 +65497,6 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 1651,
@@ -65546,9 +65528,6 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 1652,
@@ -65580,9 +65559,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 1653,
@@ -65630,9 +65606,6 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 1654,
@@ -65664,9 +65637,6 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 1655,
@@ -65698,9 +65668,6 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 1656,
@@ -65732,9 +65699,6 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 1657,
@@ -65766,9 +65730,6 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 1658,
@@ -65800,9 +65761,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 1659,
@@ -65850,9 +65808,6 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 1660,
@@ -65884,9 +65839,6 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 1661,
@@ -71210,7 +71162,6 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -71230,7 +71181,7 @@
             },
             "initial_release": {
                 "major_version": 7,
-                "minor_version": 7,
+                "minor_version": 9,
                 "os_name": "CentOS"
             },
             "modulestream_maps": [],
@@ -71362,9 +71313,6 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 2136,
@@ -71382,7 +71330,7 @@
             },
             "initial_release": {
                 "major_version": 7,
-                "minor_version": 7,
+                "minor_version": 9,
                 "os_name": "CentOS"
             },
             "modulestream_maps": [],
@@ -83317,7 +83265,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -83353,7 +83300,7 @@
                             null
                         ],
                         "name": "dovecot-devel",
-                        "repository": "centos8-appstream"
+                        "repository": "centos8-powertools"
                     }
                 ],
                 "set_id": 3995
@@ -83553,7 +83500,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -83589,7 +83535,7 @@
                             null
                         ],
                         "name": "gpgme-devel",
-                        "repository": "centos8-baseos"
+                        "repository": "centos8-powertools"
                     }
                 ],
                 "set_id": 4007
@@ -85433,7 +85379,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -85469,7 +85414,7 @@
                             null
                         ],
                         "name": "uuid-devel",
-                        "repository": "centos8-appstream"
+                        "repository": "centos8-powertools"
                     }
                 ],
                 "set_id": 4097
@@ -115861,9 +115806,7 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 3208,
@@ -115897,7 +115840,7 @@
                             null
                         ],
                         "name": "devhelp-devel",
-                        "repository": "centos8-appstream"
+                        "repository": "centos8-powertools"
                     }
                 ],
                 "set_id": 5300
@@ -115911,9 +115854,6 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 3209,
@@ -115945,9 +115885,7 @@
         {
             "action": 7,
             "architectures": [
-                "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 3210,
@@ -115995,7 +115933,6 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -116029,7 +115966,6 @@
         {
             "action": 7,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -116079,9 +116015,7 @@
         {
             "action": 7,
             "architectures": [
-                "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 3213,
@@ -116129,7 +116063,6 @@
         {
             "action": 7,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -116179,9 +116112,7 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 3215,
@@ -116215,7 +116146,7 @@
                             null
                         ],
                         "name": "yelp-devel",
-                        "repository": "centos8-appstream"
+                        "repository": "centos8-powertools"
                     }
                 ],
                 "set_id": 5313
@@ -116229,7 +116160,6 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -242213,40 +242143,6 @@
                 "s390x",
                 "x86_64"
             ],
-            "id": 6711,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "librsvg-tools",
-                        "repository": "centos8-baseos"
-                    }
-                ],
-                "set_id": 10196
-            },
-            "initial_release": {
-                "major_version": 8,
-                "minor_version": 0,
-                "os_name": "CentOS"
-            },
-            "modulestream_maps": [],
-            "out_packageset": null,
-            "release": {
-                "major_version": 8,
-                "minor_version": 1,
-                "os_name": "CentOS"
-            }
-        },
-        {
-            "action": 0,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
             "id": 6712,
             "in_packageset": {
                 "package": [
@@ -242833,7 +242729,7 @@
                             null
                         ],
                         "name": "dovecot-pigeonhole",
-                        "repository": "centos8-baseos"
+                        "repository": "centos8-appstream"
                     }
                 ],
                 "set_id": 10219
@@ -242866,7 +242762,7 @@
                         "modulestreams": [
                             null
                         ],
-                        "name": "libxkbfile-1.1.0-1.el8",
+                        "name": "libxkbfile",
                         "repository": "centos8-appstream"
                     }
                 ],
@@ -243036,7 +242932,7 @@
                         "modulestreams": [
                             null
                         ],
-                        "name": "pipewire0.2",
+                        "name": "pipewire0.2-libs",
                         "repository": "centos8-appstream"
                     }
                 ],
@@ -248787,9 +248683,7 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 6935,
@@ -248856,8 +248750,6 @@
             "action": 1,
             "architectures": [
                 "aarch64",
-                "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 6937,
@@ -248926,9 +248818,7 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 6940,
@@ -248994,9 +248884,7 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 6942,
@@ -249376,7 +249264,6 @@
             "architectures": [
                 "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 6953,
@@ -249387,7 +249274,7 @@
                             null
                         ],
                         "name": "libraw1394",
-                        "repository": "baseos"
+                        "repository": "appstream"
                     }
                 ],
                 "set_id": 10540
@@ -256478,7 +256365,7 @@
                             null
                         ],
                         "name": "jakarta-mail",
-                        "repository": "centos9-crb"
+                        "repository": "centos9-appstream"
                     }
                 ],
                 "set_id": 10706
@@ -272478,7 +272365,6 @@
             "architectures": [
                 "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 7739,
@@ -272512,7 +272398,6 @@
             "architectures": [
                 "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 7740,
@@ -314565,56 +314450,6 @@
                 "s390x",
                 "x86_64"
             ],
-            "id": 8982,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "python3-gobject-base",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 12693
-            },
-            "initial_release": {
-                "major_version": 8,
-                "minor_version": 6,
-                "os_name": "CentOS"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "python3-gobject-base",
-                        "repository": "centos9-crb"
-                    }
-                ],
-                "set_id": 12694
-            },
-            "release": {
-                "major_version": 9,
-                "minor_version": 0,
-                "os_name": "CentOS"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
             "id": 8983,
             "in_packageset": {
                 "package": [
@@ -315286,9 +315121,7 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 9001,
@@ -315320,9 +315153,7 @@
         {
             "action": 2,
             "architectures": [
-                "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 9002,
@@ -315490,9 +315321,7 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 9008,
@@ -315524,9 +315353,7 @@
         {
             "action": 2,
             "architectures": [
-                "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 9009,
@@ -315558,9 +315385,7 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 9010,
@@ -315592,9 +315417,7 @@
         {
             "action": 2,
             "architectures": [
-                "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 9011,
@@ -315626,9 +315449,7 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 9012,
@@ -315660,9 +315481,7 @@
         {
             "action": 2,
             "architectures": [
-                "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 9013,
@@ -315900,7 +315719,6 @@
             "architectures": [
                 "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 9020,
@@ -315934,7 +315752,6 @@
             "architectures": [
                 "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 9021,
@@ -316578,9 +316395,7 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 9040,
@@ -316612,9 +316427,7 @@
         {
             "action": 2,
             "architectures": [
-                "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 9041,
@@ -316646,9 +316459,7 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 9042,
@@ -316680,9 +316491,7 @@
         {
             "action": 2,
             "architectures": [
-                "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 9043,
@@ -317292,9 +317101,7 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 9062,
@@ -317305,7 +317112,7 @@
                             null
                         ],
                         "name": "gtkspell",
-                        "repository": "powertools"
+                        "repository": "appstream"
                     }
                 ],
                 "set_id": 12745
@@ -317666,9 +317473,7 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 9073,
@@ -317785,40 +317590,6 @@
                     }
                 ],
                 "set_id": 12761
-            },
-            "initial_release": {
-                "major_version": 8,
-                "minor_version": 6,
-                "os_name": "CentOS"
-            },
-            "modulestream_maps": [],
-            "out_packageset": null,
-            "release": {
-                "major_version": 9,
-                "minor_version": 0,
-                "os_name": "CentOS"
-            }
-        },
-        {
-            "action": 1,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 9078,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "libmtp-devel",
-                        "repository": "powertools"
-                    }
-                ],
-                "set_id": 12762
             },
             "initial_release": {
                 "major_version": 8,
@@ -319280,9 +319051,7 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 9136,
@@ -319293,7 +319062,7 @@
                             null
                         ],
                         "name": "file-roller-nautilus",
-                        "repository": "base"
+                        "repository": "centos8-appstream"
                     }
                 ],
                 "set_id": 12804
@@ -319360,7 +319129,7 @@
                             null
                         ],
                         "name": "tigervnc-server-applet",
-                        "repository": "base"
+                        "repository": "centos8-appstream"
                     }
                 ],
                 "set_id": 12805
@@ -319381,7 +319150,6 @@
         {
             "action": 2,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -319417,7 +319185,6 @@
             "architectures": [
                 "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 9140,
@@ -319428,7 +319195,7 @@
                             null
                         ],
                         "name": "gnome-software-editor",
-                        "repository": "base"
+                        "repository": "centos8-appstream"
                     }
                 ],
                 "set_id": 12806
@@ -319482,9 +319249,6 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 9142,
@@ -319516,9 +319280,6 @@
         {
             "action": 2,
             "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 9143,
@@ -319550,9 +319311,7 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 9144,
@@ -319563,7 +319322,7 @@
                             null
                         ],
                         "name": "gnome-shell-extension-alternate-tab",
-                        "repository": "base"
+                        "repository": "centos8-appstream"
                     }
                 ],
                 "set_id": 12808
@@ -319584,7 +319343,6 @@
         {
             "action": 2,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -371709,43 +371467,6 @@
                 "s390x",
                 "x86_64"
             ],
-            "id": 10577,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            {
-                                "name": "javapackages-tools",
-                                "stream": "201801"
-                            }
-                        ],
-                        "name": "antlr-C++",
-                        "repository": "powertools"
-                    }
-                ],
-                "set_id": 14621
-            },
-            "initial_release": {
-                "major_version": 8,
-                "minor_version": 6,
-                "os_name": "CentOS"
-            },
-            "modulestream_maps": [],
-            "out_packageset": null,
-            "release": {
-                "major_version": 9,
-                "minor_version": 0,
-                "os_name": "CentOS"
-            }
-        },
-        {
-            "action": 1,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
             "id": 10578,
             "in_packageset": {
                 "package": [
@@ -381999,7 +381720,7 @@
             }
         },
         {
-            "action": 1,
+            "action": 6,
             "architectures": [
                 "aarch64",
                 "ppc64le",
@@ -382027,8 +381748,27 @@
                 "minor_version": 6,
                 "os_name": "CentOS"
             },
-            "modulestream_maps": [],
-            "out_packageset": null,
+            "modulestream_maps": [
+                {
+                    "in_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    },
+                    "out_modulestream": null
+                }
+            ],
+            "out_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "plexus-containers-container-default",
+                        "repository": "centos9-crb"
+                    }
+                ],
+                "set_id": 23983
+            },
             "release": {
                 "major_version": 9,
                 "minor_version": 0,
@@ -439617,7 +439357,7 @@
             },
             "initial_release": {
                 "major_version": 8,
-                "minor_version": 1,
+                "minor_version": 10,
                 "os_name": "CentOS"
             },
             "modulestream_maps": [],
@@ -439658,14 +439398,14 @@
             },
             "initial_release": {
                 "major_version": 8,
-                "minor_version": 0,
+                "minor_version": 9,
                 "os_name": "CentOS"
             },
             "modulestream_maps": [],
             "out_packageset": null,
             "release": {
                 "major_version": 8,
-                "minor_version": 1,
+                "minor_version": 10,
                 "os_name": "CentOS"
             }
         },
@@ -511897,43 +511637,6 @@
             }
         },
         {
-            "action": 1,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 14345,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            {
-                                "name": "nodejs",
-                                "stream": "18"
-                            }
-                        ],
-                        "name": "nodejs",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 20190
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 5,
-                "os_name": "CentOS"
-            },
-            "modulestream_maps": [],
-            "out_packageset": null,
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "CentOS"
-            }
-        },
-        {
             "action": 6,
             "architectures": [
                 "aarch64",
@@ -511946,6 +511649,10 @@
                 "package": [
                     {
                         "modulestreams": [
+                            {
+                                "name": "nodejs",
+                                "stream": "18"
+                            },
                             {
                                 "name": "nodejs",
                                 "stream": "20"
@@ -511978,6 +511685,13 @@
                     "in_modulestream": {
                         "name": "nodejs",
                         "stream": "22"
+                    },
+                    "out_modulestream": null
+                },
+                {
+                    "in_modulestream": {
+                        "name": "nodejs",
+                        "stream": "18"
                     },
                     "out_modulestream": null
                 }
@@ -536211,7 +535925,7 @@
             }
         },
         {
-            "action": 6,
+            "action": 4,
             "architectures": [
                 "aarch64",
                 "ppc64le",
@@ -536255,6 +535969,13 @@
                             null
                         ],
                         "name": "mariadb",
+                        "repository": "centos10-appstream"
+                    },
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "mariadb-client-utils",
                         "repository": "centos10-appstream"
                     }
                 ],
@@ -536771,7 +536492,7 @@
             }
         },
         {
-            "action": 6,
+            "action": 7,
             "architectures": [
                 "aarch64",
                 "ppc64le",
@@ -536808,7 +536529,7 @@
                         "modulestreams": [
                             null
                         ],
-                        "name": "mysql-libs",
+                        "name": "mysql8.4-libs",
                         "repository": "centos10-appstream"
                     }
                 ],
@@ -558246,9 +557967,7 @@
         {
             "action": 2,
             "architectures": [
-                "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 15647,
@@ -558482,9 +558201,7 @@
         {
             "action": 2,
             "architectures": [
-                "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 15654,
@@ -559364,9 +559081,7 @@
         {
             "action": 2,
             "architectures": [
-                "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 15680,
@@ -559430,9 +559145,7 @@
         {
             "action": 2,
             "architectures": [
-                "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 15682,
@@ -560346,9 +560059,7 @@
         {
             "action": 2,
             "architectures": [
-                "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 15709,
@@ -596638,7 +596349,7 @@
             }
         },
         {
-            "action": 1,
+            "action": 3,
             "architectures": [
                 "aarch64",
                 "ppc64le",
@@ -596663,8 +596374,24 @@
                 "minor_version": 5,
                 "os_name": "CentOS"
             },
-            "modulestream_maps": [],
-            "out_packageset": null,
+            "modulestream_maps": [
+                {
+                    "in_modulestream": null,
+                    "out_modulestream": null
+                }
+            ],
+            "out_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "papers",
+                        "repository": "centos10-appstream"
+                    }
+                ],
+                "set_id": 24002
+            },
             "release": {
                 "major_version": 10,
                 "minor_version": 0,
@@ -596706,7 +596433,7 @@
             }
         },
         {
-            "action": 1,
+            "action": 3,
             "architectures": [
                 "aarch64",
                 "ppc64le",
@@ -596731,8 +596458,24 @@
                 "minor_version": 5,
                 "os_name": "CentOS"
             },
-            "modulestream_maps": [],
-            "out_packageset": null,
+            "modulestream_maps": [
+                {
+                    "in_modulestream": null,
+                    "out_modulestream": null
+                }
+            ],
+            "out_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "papers-libs",
+                        "repository": "centos10-appstream"
+                    }
+                ],
+                "set_id": 24001
+            },
             "release": {
                 "major_version": 10,
                 "minor_version": 0,
@@ -596774,7 +596517,7 @@
             }
         },
         {
-            "action": 1,
+            "action": 3,
             "architectures": [
                 "aarch64",
                 "ppc64le",
@@ -596799,8 +596542,24 @@
                 "minor_version": 5,
                 "os_name": "CentOS"
             },
-            "modulestream_maps": [],
-            "out_packageset": null,
+            "modulestream_maps": [
+                {
+                    "in_modulestream": null,
+                    "out_modulestream": null
+                }
+            ],
+            "out_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "papers-nautilus",
+                        "repository": "centos10-appstream"
+                    }
+                ],
+                "set_id": 24000
+            },
             "release": {
                 "major_version": 10,
                 "minor_version": 0,
@@ -596842,7 +596601,7 @@
             }
         },
         {
-            "action": 1,
+            "action": 3,
             "architectures": [
                 "aarch64",
                 "ppc64le",
@@ -596867,8 +596626,24 @@
                 "minor_version": 5,
                 "os_name": "CentOS"
             },
-            "modulestream_maps": [],
-            "out_packageset": null,
+            "modulestream_maps": [
+                {
+                    "in_modulestream": null,
+                    "out_modulestream": null
+                }
+            ],
+            "out_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "papers-previewer",
+                        "repository": "centos10-appstream"
+                    }
+                ],
+                "set_id": 23999
+            },
             "release": {
                 "major_version": 10,
                 "minor_version": 0,
@@ -596910,7 +596685,7 @@
             }
         },
         {
-            "action": 1,
+            "action": 3,
             "architectures": [
                 "aarch64",
                 "ppc64le",
@@ -596935,8 +596710,24 @@
                 "minor_version": 5,
                 "os_name": "CentOS"
             },
-            "modulestream_maps": [],
-            "out_packageset": null,
+            "modulestream_maps": [
+                {
+                    "in_modulestream": null,
+                    "out_modulestream": null
+                }
+            ],
+            "out_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "papers-thumbnailer",
+                        "repository": "centos10-appstream"
+                    }
+                ],
+                "set_id": 23998
+            },
             "release": {
                 "major_version": 10,
                 "minor_version": 0,
@@ -603992,14 +603783,14 @@
                         "modulestreams": [
                             null
                         ],
-                        "name": "mysql-test",
+                        "name": "mysql8.4-test",
                         "repository": "centos10-crb"
                     },
                     {
                         "modulestreams": [
                             null
                         ],
-                        "name": "mysql-test-data",
+                        "name": "mysql8.4-test-data",
                         "repository": "centos10-crb"
                     }
                 ],
@@ -610941,7 +610732,7 @@
             }
         },
         {
-            "action": 1,
+            "action": 7,
             "architectures": [
                 "aarch64",
                 "ppc64le",
@@ -610966,8 +610757,24 @@
                 "minor_version": 5,
                 "os_name": "CentOS"
             },
-            "modulestream_maps": [],
-            "out_packageset": null,
+            "modulestream_maps": [
+                {
+                    "in_modulestream": null,
+                    "out_modulestream": null
+                }
+            ],
+            "out_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "python-PyMySQL+rsa",
+                        "repository": "centos10-crb"
+                    }
+                ],
+                "set_id": 24283
+            },
             "release": {
                 "major_version": 10,
                 "minor_version": 0,
@@ -614495,8 +614302,6 @@
             "action": 0,
             "architectures": [
                 "aarch64",
-                "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 17278,
@@ -617587,2856 +617392,6 @@
             }
         },
         {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17360,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-libs",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23847
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "CentOS"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-libs",
-                        "repository": "centos10-baseos"
-                    }
-                ],
-                "set_id": 23848
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "CentOS"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17361,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-AutoLoader",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23849
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "CentOS"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-AutoLoader",
-                        "repository": "centos10-baseos"
-                    }
-                ],
-                "set_id": 23850
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "CentOS"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17362,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-B",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23851
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "CentOS"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-B",
-                        "repository": "centos10-baseos"
-                    }
-                ],
-                "set_id": 23852
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "CentOS"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17363,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Carp",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23853
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "CentOS"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Carp",
-                        "repository": "centos10-baseos"
-                    }
-                ],
-                "set_id": 23854
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "CentOS"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17364,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Class-Struct",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23855
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "CentOS"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Class-Struct",
-                        "repository": "centos10-baseos"
-                    }
-                ],
-                "set_id": 23856
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "CentOS"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17365,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Data-Dumper",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23857
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "CentOS"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Data-Dumper",
-                        "repository": "centos10-baseos"
-                    }
-                ],
-                "set_id": 23858
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "CentOS"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17366,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Digest",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23859
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "CentOS"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Digest",
-                        "repository": "centos10-baseos"
-                    }
-                ],
-                "set_id": 23860
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "CentOS"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17367,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Digest-MD5",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23861
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "CentOS"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Digest-MD5",
-                        "repository": "centos10-baseos"
-                    }
-                ],
-                "set_id": 23862
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "CentOS"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17368,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-DynaLoader",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23863
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "CentOS"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-DynaLoader",
-                        "repository": "centos10-baseos"
-                    }
-                ],
-                "set_id": 23864
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "CentOS"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17369,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Encode",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23865
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "CentOS"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Encode",
-                        "repository": "centos10-baseos"
-                    }
-                ],
-                "set_id": 23866
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "CentOS"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17370,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Errno",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23867
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "CentOS"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Errno",
-                        "repository": "centos10-baseos"
-                    }
-                ],
-                "set_id": 23868
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "CentOS"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17371,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Exporter",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23869
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "CentOS"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Exporter",
-                        "repository": "centos10-baseos"
-                    }
-                ],
-                "set_id": 23870
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "CentOS"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17372,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Fcntl",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23871
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "CentOS"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Fcntl",
-                        "repository": "centos10-baseos"
-                    }
-                ],
-                "set_id": 23872
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "CentOS"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17373,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-File-Basename",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23873
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "CentOS"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-File-Basename",
-                        "repository": "centos10-baseos"
-                    }
-                ],
-                "set_id": 23874
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "CentOS"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17374,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-File-Path",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23875
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "CentOS"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-File-Path",
-                        "repository": "centos10-baseos"
-                    }
-                ],
-                "set_id": 23876
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "CentOS"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17375,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-File-Temp",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23877
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "CentOS"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-File-Temp",
-                        "repository": "centos10-baseos"
-                    }
-                ],
-                "set_id": 23878
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "CentOS"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17376,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-File-stat",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23879
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "CentOS"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-File-stat",
-                        "repository": "centos10-baseos"
-                    }
-                ],
-                "set_id": 23880
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "CentOS"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17377,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-FileHandle",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23881
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "CentOS"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-FileHandle",
-                        "repository": "centos10-baseos"
-                    }
-                ],
-                "set_id": 23882
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "CentOS"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17378,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Getopt-Long",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23883
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "CentOS"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Getopt-Long",
-                        "repository": "centos10-baseos"
-                    }
-                ],
-                "set_id": 23884
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "CentOS"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17379,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Getopt-Std",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23885
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "CentOS"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Getopt-Std",
-                        "repository": "centos10-baseos"
-                    }
-                ],
-                "set_id": 23886
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "CentOS"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17380,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-HTTP-Tiny",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23887
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "CentOS"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-HTTP-Tiny",
-                        "repository": "centos10-baseos"
-                    }
-                ],
-                "set_id": 23888
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "CentOS"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17381,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-IO",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23889
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "CentOS"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-IO",
-                        "repository": "centos10-baseos"
-                    }
-                ],
-                "set_id": 23890
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "CentOS"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17382,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-IO-Socket-IP",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23891
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "CentOS"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-IO-Socket-IP",
-                        "repository": "centos10-baseos"
-                    }
-                ],
-                "set_id": 23892
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "CentOS"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17383,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-IO-Socket-SSL",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23893
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "CentOS"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-IO-Socket-SSL",
-                        "repository": "centos10-baseos"
-                    }
-                ],
-                "set_id": 23894
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "CentOS"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17384,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-IPC-Open3",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23895
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "CentOS"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-IPC-Open3",
-                        "repository": "centos10-baseos"
-                    }
-                ],
-                "set_id": 23896
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "CentOS"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17385,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-MIME-Base64",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23897
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "CentOS"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-MIME-Base64",
-                        "repository": "centos10-baseos"
-                    }
-                ],
-                "set_id": 23898
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "CentOS"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17386,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Mozilla-CA",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23899
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "CentOS"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Mozilla-CA",
-                        "repository": "centos10-baseos"
-                    }
-                ],
-                "set_id": 23900
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "CentOS"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17387,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Net-SSLeay",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23901
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "CentOS"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Net-SSLeay",
-                        "repository": "centos10-baseos"
-                    }
-                ],
-                "set_id": 23902
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "CentOS"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17388,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-POSIX",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23903
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "CentOS"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-POSIX",
-                        "repository": "centos10-baseos"
-                    }
-                ],
-                "set_id": 23904
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "CentOS"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17389,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-PathTools",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23905
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "CentOS"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-PathTools",
-                        "repository": "centos10-baseos"
-                    }
-                ],
-                "set_id": 23906
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "CentOS"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17390,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Pod-Escapes",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23907
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "CentOS"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Pod-Escapes",
-                        "repository": "centos10-baseos"
-                    }
-                ],
-                "set_id": 23908
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "CentOS"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17391,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Pod-Perldoc",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23909
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "CentOS"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Pod-Perldoc",
-                        "repository": "centos10-baseos"
-                    }
-                ],
-                "set_id": 23910
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "CentOS"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17392,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Pod-Simple",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23911
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "CentOS"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Pod-Simple",
-                        "repository": "centos10-baseos"
-                    }
-                ],
-                "set_id": 23912
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "CentOS"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17393,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Pod-Usage",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23913
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "CentOS"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Pod-Usage",
-                        "repository": "centos10-baseos"
-                    }
-                ],
-                "set_id": 23914
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "CentOS"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17394,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Scalar-List-Utils",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23915
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "CentOS"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Scalar-List-Utils",
-                        "repository": "centos10-baseos"
-                    }
-                ],
-                "set_id": 23916
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "CentOS"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17395,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-SelectSaver",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23917
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "CentOS"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-SelectSaver",
-                        "repository": "centos10-baseos"
-                    }
-                ],
-                "set_id": 23918
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "CentOS"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17396,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Socket",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23919
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "CentOS"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Socket",
-                        "repository": "centos10-baseos"
-                    }
-                ],
-                "set_id": 23920
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "CentOS"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17397,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Storable",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23921
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "CentOS"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Storable",
-                        "repository": "centos10-baseos"
-                    }
-                ],
-                "set_id": 23922
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "CentOS"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17398,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Symbol",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23923
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "CentOS"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Symbol",
-                        "repository": "centos10-baseos"
-                    }
-                ],
-                "set_id": 23924
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "CentOS"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17399,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Term-ANSIColor",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23925
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "CentOS"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Term-ANSIColor",
-                        "repository": "centos10-baseos"
-                    }
-                ],
-                "set_id": 23926
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "CentOS"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17400,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Term-Cap",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23927
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "CentOS"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Term-Cap",
-                        "repository": "centos10-baseos"
-                    }
-                ],
-                "set_id": 23928
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "CentOS"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17401,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Text-ParseWords",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23929
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "CentOS"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Text-ParseWords",
-                        "repository": "centos10-baseos"
-                    }
-                ],
-                "set_id": 23930
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "CentOS"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17402,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Text-Tabs+Wrap",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23931
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "CentOS"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Text-Tabs+Wrap",
-                        "repository": "centos10-baseos"
-                    }
-                ],
-                "set_id": 23932
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "CentOS"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17403,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Time-Local",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23933
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "CentOS"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Time-Local",
-                        "repository": "centos10-baseos"
-                    }
-                ],
-                "set_id": 23934
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "CentOS"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17404,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-URI",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23935
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "CentOS"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-URI",
-                        "repository": "centos10-baseos"
-                    }
-                ],
-                "set_id": 23936
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "CentOS"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17405,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-base",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23937
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "CentOS"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-base",
-                        "repository": "centos10-baseos"
-                    }
-                ],
-                "set_id": 23938
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "CentOS"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17406,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-constant",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23939
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "CentOS"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-constant",
-                        "repository": "centos10-baseos"
-                    }
-                ],
-                "set_id": 23940
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "CentOS"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17407,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-if",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23941
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "CentOS"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-if",
-                        "repository": "centos10-baseos"
-                    }
-                ],
-                "set_id": 23942
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "CentOS"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17408,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-interpreter",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23943
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "CentOS"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-interpreter",
-                        "repository": "centos10-baseos"
-                    }
-                ],
-                "set_id": 23944
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "CentOS"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17409,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-libnet",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23945
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "CentOS"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-libnet",
-                        "repository": "centos10-baseos"
-                    }
-                ],
-                "set_id": 23946
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "CentOS"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17410,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-locale",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23947
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "CentOS"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-locale",
-                        "repository": "centos10-baseos"
-                    }
-                ],
-                "set_id": 23948
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "CentOS"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17411,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-mro",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23949
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "CentOS"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-mro",
-                        "repository": "centos10-baseos"
-                    }
-                ],
-                "set_id": 23950
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "CentOS"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17412,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-overload",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23951
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "CentOS"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-overload",
-                        "repository": "centos10-baseos"
-                    }
-                ],
-                "set_id": 23952
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "CentOS"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17413,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-overloading",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23953
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "CentOS"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-overloading",
-                        "repository": "centos10-baseos"
-                    }
-                ],
-                "set_id": 23954
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "CentOS"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17414,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-parent",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23955
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "CentOS"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-parent",
-                        "repository": "centos10-baseos"
-                    }
-                ],
-                "set_id": 23956
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "CentOS"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17415,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-podlators",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23957
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "CentOS"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-podlators",
-                        "repository": "centos10-baseos"
-                    }
-                ],
-                "set_id": 23958
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "CentOS"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17416,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-vars",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23959
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "CentOS"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-vars",
-                        "repository": "centos10-baseos"
-                    }
-                ],
-                "set_id": 23960
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "CentOS"
-            }
-        },
-        {
             "action": 0,
             "architectures": [
                 "aarch64",
@@ -620864,12 +617819,9923 @@
         {
             "action": 1,
             "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17430,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "usermode-gtk",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 23978
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17431,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "usermode-gtk",
+                        "repository": "centos9-appstream"
+                    }
+                ],
+                "set_id": 23979
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17432,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "gdisk",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 23980
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17433,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "gdisk",
+                        "repository": "centos9-appstream"
+                    }
+                ],
+                "set_id": 23981
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17434,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "gcc-toolset-14",
+                        "repository": "centos10-appstream"
+                    }
+                ],
+                "set_id": 23982
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 6,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17435,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
+                        ],
+                        "name": "antlr-C++",
+                        "repository": "powertools"
+                    }
+                ],
+                "set_id": 23984
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [
+                {
+                    "in_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    },
+                    "out_modulestream": null
+                }
+            ],
+            "out_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "antlr-C++",
+                        "repository": "centos9-crb"
+                    }
+                ],
+                "set_id": 23985
+            },
+            "release": {
+                "major_version": 9,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 6,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17436,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "python39-devel",
+                                "stream": "3.9"
+                            }
+                        ],
+                        "name": "python39-pybind11",
+                        "repository": "centos8-powertools"
+                    }
+                ],
+                "set_id": 23986
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 8,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [
+                {
+                    "in_modulestream": {
+                        "name": "python39-devel",
+                        "stream": "3.9"
+                    },
+                    "out_modulestream": {
+                        "name": "python39-devel",
+                        "stream": "3.9"
+                    }
+                }
+            ],
+            "out_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "python39-devel",
+                                "stream": "3.9"
+                            }
+                        ],
+                        "name": "python39-pybind11",
+                        "repository": "centos8-appstream"
+                    }
+                ],
+                "set_id": 23987
+            },
+            "release": {
+                "major_version": 8,
+                "minor_version": 9,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 6,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17437,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "python39-devel",
+                                "stream": "3.9"
+                            }
+                        ],
+                        "name": "python39-pybind11-devel",
+                        "repository": "centos8-powertools"
+                    }
+                ],
+                "set_id": 23988
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 8,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [
+                {
+                    "in_modulestream": {
+                        "name": "python39-devel",
+                        "stream": "3.9"
+                    },
+                    "out_modulestream": {
+                        "name": "python39-devel",
+                        "stream": "3.9"
+                    }
+                }
+            ],
+            "out_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "python39-devel",
+                                "stream": "3.9"
+                            }
+                        ],
+                        "name": "python39-pybind11-devel",
+                        "repository": "centos8-appstream"
+                    }
+                ],
+                "set_id": 23989
+            },
+            "release": {
+                "major_version": 8,
+                "minor_version": 9,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 6,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17438,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "python39-devel",
+                                "stream": "3.9"
+                            }
+                        ],
+                        "name": "python39-pybind11",
+                        "repository": "centos8-appstream"
+                    }
+                ],
+                "set_id": 23990
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 9,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [
+                {
+                    "in_modulestream": {
+                        "name": "python39-devel",
+                        "stream": "3.9"
+                    },
+                    "out_modulestream": {
+                        "name": "python39-devel",
+                        "stream": "3.9"
+                    }
+                }
+            ],
+            "out_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "python39-devel",
+                                "stream": "3.9"
+                            }
+                        ],
+                        "name": "python39-pybind11",
+                        "repository": "centos8-powertools"
+                    }
+                ],
+                "set_id": 23991
+            },
+            "release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 6,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17439,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "python39-devel",
+                                "stream": "3.9"
+                            }
+                        ],
+                        "name": "python39-pybind11-devel",
+                        "repository": "centos8-appstream"
+                    }
+                ],
+                "set_id": 23992
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 9,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [
+                {
+                    "in_modulestream": {
+                        "name": "python39-devel",
+                        "stream": "3.9"
+                    },
+                    "out_modulestream": {
+                        "name": "python39-devel",
+                        "stream": "3.9"
+                    }
+                }
+            ],
+            "out_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "python39-devel",
+                                "stream": "3.9"
+                            }
+                        ],
+                        "name": "python39-pybind11-devel",
+                        "repository": "centos8-powertools"
+                    }
+                ],
+                "set_id": 23993
+            },
+            "release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 5,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17440,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "cockpit-bridge",
+                        "repository": "baseos"
+                    },
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "cockpit-pcp",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 23996
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [
+                {
+                    "in_modulestream": null,
+                    "out_modulestream": null
+                }
+            ],
+            "out_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "cockpit-bridge",
+                        "repository": "centos10-baseos"
+                    }
+                ],
+                "set_id": 23997
+            },
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17442,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "papers-devel",
+                        "repository": "centos10-crb"
+                    }
+                ],
+                "set_id": 24004
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17443,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "xmlrpc-c",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24006
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17444,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "xmlrpc-c-c++",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24007
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17445,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "xmlrpc-c-client",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24008
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17446,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "xmlrpc-c-client++",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24009
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17447,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "xmlrpc-c-devel",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24010
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17448,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "satyr",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24011
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17449,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "satyr",
+                        "repository": "centos9-appstream"
+                    }
+                ],
+                "set_id": 24012
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17450,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "xmlrpc-c",
+                        "repository": "centos9-appstream"
+                    }
+                ],
+                "set_id": 24013
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17451,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "libreport",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24014
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17452,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "libreport",
+                        "repository": "centos9-appstream"
+                    }
+                ],
+                "set_id": 24015
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17453,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "libreport-anaconda",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24016
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17454,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "libreport-anaconda",
+                        "repository": "centos9-appstream"
+                    }
+                ],
+                "set_id": 24017
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17455,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "libreport-cli",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24018
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17456,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "libreport-cli",
+                        "repository": "centos9-appstream"
+                    }
+                ],
+                "set_id": 24019
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17457,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "libreport-filesystem",
+                        "repository": "baseos"
+                    }
+                ],
+                "set_id": 24020
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17458,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "libreport-filesystem",
+                        "repository": "centos9-baseos"
+                    }
+                ],
+                "set_id": 24021
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17459,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "libreport-gtk",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24022
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17460,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "libreport-gtk",
+                        "repository": "centos9-appstream"
+                    }
+                ],
+                "set_id": 24023
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17461,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "libreport-plugin-bugzilla",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24024
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17462,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "libreport-plugin-bugzilla",
+                        "repository": "centos9-appstream"
+                    }
+                ],
+                "set_id": 24025
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17463,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "libreport-plugin-reportuploader",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24026
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17464,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "libreport-plugin-reportuploader",
+                        "repository": "centos9-appstream"
+                    }
+                ],
+                "set_id": 24027
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17465,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "libreport-rhel-anaconda-bugzilla",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24028
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17466,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "libreport-rhel-anaconda-bugzilla",
+                        "repository": "centos9-appstream"
+                    }
+                ],
+                "set_id": 24029
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17467,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "libreport-web",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24030
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17468,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "libreport-web",
+                        "repository": "centos9-appstream"
+                    }
+                ],
+                "set_id": 24031
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17469,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "python3-libreport",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24032
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17470,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "python3-libreport",
+                        "repository": "centos9-appstream"
+                    }
+                ],
+                "set_id": 24033
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17471,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "texlive-xdvi",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24034
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17472,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "texlive-xdvi",
+                        "repository": "centos9-appstream"
+                    }
+                ],
+                "set_id": 24035
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17473,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "totem-pl-parser",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24038
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17474,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "totem-pl-parser",
+                        "repository": "centos9-appstream"
+                    }
+                ],
+                "set_id": 24039
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17475,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "perl-libxml-perl",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24040
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17476,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "perltidy",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24041
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17477,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "perl-YAML-LibYAML",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24042
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17478,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "perl-Syntax-Keyword-Try",
+                        "repository": "centos10-crb"
+                    }
+                ],
+                "set_id": 24043
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17479,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "perl-XS-Parse-Keyword",
+                        "repository": "centos10-crb"
+                    }
+                ],
+                "set_id": 24044
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17480,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "libraw1394",
+                        "repository": "centos8-appstream"
+                    }
+                ],
+                "set_id": 24045
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 9,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17481,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "cdrdao",
+                        "repository": "centos8-appstream"
+                    }
+                ],
+                "set_id": 24046
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 9,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17482,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "perl-Net-DNS-Nameserver",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24047
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "x86_64"
+            ],
+            "id": 17483,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "command-line-assistant",
+                        "repository": "centos10-appstream"
+                    }
+                ],
+                "set_id": 24048
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17484,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "redhat-flatpak-preinstall-firefox",
+                        "repository": "centos10-appstream"
+                    }
+                ],
+                "set_id": 24049
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17485,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "redhat-flatpak-preinstall-thunderbird",
+                        "repository": "centos10-appstream"
+                    }
+                ],
+                "set_id": 24050
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17486,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "redhat-flatpak-repo",
+                        "repository": "centos10-appstream"
+                    }
+                ],
+                "set_id": 24051
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17487,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "flatpak-rpm-macros",
+                        "repository": "centos9-crb"
+                    }
+                ],
+                "set_id": 24052
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17488,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "flatpak-runtime-config",
+                        "repository": "centos9-crb"
+                    }
+                ],
+                "set_id": 24053
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 7,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17489,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "mysql",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24054
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [
+                {
+                    "in_modulestream": null,
+                    "out_modulestream": null
+                }
+            ],
+            "out_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "mysql8.4",
+                        "repository": "centos10-appstream"
+                    }
+                ],
+                "set_id": 24055
+            },
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 7,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17490,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "mysql-server",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24056
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [
+                {
+                    "in_modulestream": null,
+                    "out_modulestream": null
+                }
+            ],
+            "out_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "mysql8.4-server",
+                        "repository": "centos10-appstream"
+                    }
+                ],
+                "set_id": 24057
+            },
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 7,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17491,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "mysql-errmsg",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24058
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [
+                {
+                    "in_modulestream": null,
+                    "out_modulestream": null
+                }
+            ],
+            "out_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "mysql8.4-errmsg",
+                        "repository": "centos10-appstream"
+                    }
+                ],
+                "set_id": 24059
+            },
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 7,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17492,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "mysql-devel",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24060
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [
+                {
+                    "in_modulestream": null,
+                    "out_modulestream": null
+                }
+            ],
+            "out_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "mysql8.4-devel",
+                        "repository": "centos10-crb"
+                    }
+                ],
+                "set_id": 24061
+            },
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17493,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-11-openjdk",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24062
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17494,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-11-openjdk",
+                        "repository": "centos9-appstream"
+                    }
+                ],
+                "set_id": 24063
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 4,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17495,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-11-openjdk-demo",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24064
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17496,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-11-openjdk-demo",
+                        "repository": "centos9-appstream"
+                    }
+                ],
+                "set_id": 24065
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 4,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17497,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-11-openjdk-devel",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24066
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17498,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-11-openjdk-devel",
+                        "repository": "centos9-appstream"
+                    }
+                ],
+                "set_id": 24067
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 4,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17499,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-11-openjdk-headless",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24068
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17500,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-11-openjdk-headless",
+                        "repository": "centos9-appstream"
+                    }
+                ],
+                "set_id": 24069
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 4,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17501,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-11-openjdk-javadoc",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24070
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17502,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-11-openjdk-javadoc",
+                        "repository": "centos9-appstream"
+                    }
+                ],
+                "set_id": 24071
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 4,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17503,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-11-openjdk-javadoc-zip",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24072
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17504,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-11-openjdk-javadoc-zip",
+                        "repository": "centos9-appstream"
+                    }
+                ],
+                "set_id": 24073
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 4,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17505,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-11-openjdk-jmods",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24074
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17506,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-11-openjdk-jmods",
+                        "repository": "centos9-appstream"
+                    }
+                ],
+                "set_id": 24075
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 4,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17507,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-11-openjdk-src",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24076
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17508,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-11-openjdk-src",
+                        "repository": "centos9-appstream"
+                    }
+                ],
+                "set_id": 24077
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 4,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17509,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-11-openjdk-static-libs",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24078
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17510,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-11-openjdk-static-libs",
+                        "repository": "centos9-appstream"
+                    }
+                ],
+                "set_id": 24079
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 4,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17511,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-11-openjdk-demo-fastdebug",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24080
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17512,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-11-openjdk-demo-slowdebug",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24081
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17513,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-11-openjdk-devel-fastdebug",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24082
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17514,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-11-openjdk-devel-slowdebug",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24083
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17515,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-11-openjdk-fastdebug",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24084
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17516,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-11-openjdk-headless-fastdebug",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24085
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17517,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-11-openjdk-headless-slowdebug",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24086
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17518,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-11-openjdk-jmods-fastdebug",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24087
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17519,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-11-openjdk-jmods-slowdebug",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24088
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17520,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-11-openjdk-slowdebug",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24089
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17521,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-11-openjdk-src-fastdebug",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24090
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17522,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-11-openjdk-src-slowdebug",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24091
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17523,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-11-openjdk-static-libs-fastdebug",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24092
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17524,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-11-openjdk-static-libs-slowdebug",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24093
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17525,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-17-openjdk",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24094
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17526,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-17-openjdk",
+                        "repository": "centos9-appstream"
+                    }
+                ],
+                "set_id": 24095
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17527,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-17-openjdk-demo",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24096
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17528,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-17-openjdk-demo",
+                        "repository": "centos9-appstream"
+                    }
+                ],
+                "set_id": 24097
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17529,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-17-openjdk-devel",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24098
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17530,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-17-openjdk-devel",
+                        "repository": "centos9-appstream"
+                    }
+                ],
+                "set_id": 24099
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17531,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-17-openjdk-headless",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24100
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17532,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-17-openjdk-headless",
+                        "repository": "centos9-appstream"
+                    }
+                ],
+                "set_id": 24101
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17533,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-17-openjdk-javadoc",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24102
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17534,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-17-openjdk-javadoc",
+                        "repository": "centos9-appstream"
+                    }
+                ],
+                "set_id": 24103
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17535,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-17-openjdk-javadoc-zip",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24104
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17536,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-17-openjdk-javadoc-zip",
+                        "repository": "centos9-appstream"
+                    }
+                ],
+                "set_id": 24105
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17537,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-17-openjdk-jmods",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24106
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17538,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-17-openjdk-jmods",
+                        "repository": "centos9-appstream"
+                    }
+                ],
+                "set_id": 24107
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17539,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-17-openjdk-src",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24108
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17540,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-17-openjdk-src",
+                        "repository": "centos9-appstream"
+                    }
+                ],
+                "set_id": 24109
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17541,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-17-openjdk-static-libs",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24110
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17542,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-17-openjdk-static-libs",
+                        "repository": "centos9-appstream"
+                    }
+                ],
+                "set_id": 24111
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17543,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-17-openjdk-demo-fastdebug",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24112
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17544,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-17-openjdk-demo-slowdebug",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24113
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17545,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-17-openjdk-devel-fastdebug",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24114
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17546,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-17-openjdk-devel-slowdebug",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24115
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17547,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-17-openjdk-fastdebug",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24116
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17548,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-17-openjdk-headless-fastdebug",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24117
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17549,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-17-openjdk-headless-slowdebug",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24118
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17550,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-17-openjdk-jmods-fastdebug",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24119
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17551,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-17-openjdk-jmods-slowdebug",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24120
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17552,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-17-openjdk-slowdebug",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24121
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17553,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-17-openjdk-src-fastdebug",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24122
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17554,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-17-openjdk-src-slowdebug",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24123
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17555,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-17-openjdk-static-libs-fastdebug",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24124
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17556,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-17-openjdk-static-libs-slowdebug",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24125
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17557,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-1.8.0-openjdk",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24126
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17558,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-1.8.0-openjdk",
+                        "repository": "centos9-appstream"
+                    }
+                ],
+                "set_id": 24127
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17559,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-1.8.0-openjdk-demo",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24128
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17560,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-1.8.0-openjdk-demo",
+                        "repository": "centos9-appstream"
+                    }
+                ],
+                "set_id": 24129
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17561,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-1.8.0-openjdk-devel",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24130
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17562,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-1.8.0-openjdk-devel",
+                        "repository": "centos9-appstream"
+                    }
+                ],
+                "set_id": 24131
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17563,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-1.8.0-openjdk-headless",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24132
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17564,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-1.8.0-openjdk-headless",
+                        "repository": "centos9-appstream"
+                    }
+                ],
+                "set_id": 24133
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17565,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-1.8.0-openjdk-javadoc",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24134
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17566,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-1.8.0-openjdk-javadoc",
+                        "repository": "centos9-appstream"
+                    }
+                ],
+                "set_id": 24135
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17567,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-1.8.0-openjdk-javadoc-zip",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24136
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17568,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-1.8.0-openjdk-javadoc-zip",
+                        "repository": "centos9-appstream"
+                    }
+                ],
+                "set_id": 24137
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17569,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-1.8.0-openjdk-src",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24138
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17570,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-1.8.0-openjdk-src",
+                        "repository": "centos9-appstream"
+                    }
+                ],
+                "set_id": 24139
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17571,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-1.8.0-openjdk-demo-fastdebug",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24140
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17572,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-1.8.0-openjdk-demo-slowdebug",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24141
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17573,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-1.8.0-openjdk-devel-fastdebug",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24142
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17574,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-1.8.0-openjdk-devel-slowdebug",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24143
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17575,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-1.8.0-openjdk-fastdebug",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24144
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17576,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-1.8.0-openjdk-headless-fastdebug",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24145
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17577,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-1.8.0-openjdk-headless-slowdebug",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24146
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17578,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-1.8.0-openjdk-slowdebug",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24147
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17579,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-1.8.0-openjdk-src-fastdebug",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24148
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17580,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-1.8.0-openjdk-src-slowdebug",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24149
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17581,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "jigawatts",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24150
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17582,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "jigawatts",
+                        "repository": "centos9-appstream"
+                    }
+                ],
+                "set_id": 24151
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17583,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "jigawatts-javadoc",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24152
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17584,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "jigawatts-javadoc",
+                        "repository": "centos9-appstream"
+                    }
+                ],
+                "set_id": 24153
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17586,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "rust-std-static-wasm32-wasi",
+                        "repository": "centos9-appstream"
+                    }
+                ],
+                "set_id": 24156
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17587,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "rust-std-static-wasm32-wasi",
+                        "repository": "centos8-appstream"
+                    }
+                ],
+                "set_id": 24157
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 9,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "x86_64"
+            ],
+            "id": 17588,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "command-line-assistant-selinux",
+                        "repository": "centos10-appstream"
+                    }
+                ],
+                "set_id": 24158
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17589,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "python3-snapm",
+                        "repository": "centos9-appstream"
+                    }
+                ],
+                "set_id": 24159
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17590,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "python3-snapm-doc",
+                        "repository": "centos9-appstream"
+                    }
+                ],
+                "set_id": 24160
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17591,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "snapm",
+                        "repository": "centos9-appstream"
+                    }
+                ],
+                "set_id": 24161
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17592,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "snapm",
+                        "repository": "centos10-appstream"
+                    }
+                ],
+                "set_id": 24162
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17593,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "python3-snapm",
+                        "repository": "centos10-appstream"
+                    }
+                ],
+                "set_id": 24163
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17594,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "python3-snapm-doc",
+                        "repository": "centos10-appstream"
+                    }
+                ],
+                "set_id": 24164
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 7,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17595,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "mysql",
+                                "stream": "8.4"
+                            }
+                        ],
+                        "name": "mysql-test",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24165
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [
+                {
+                    "in_modulestream": {
+                        "name": "mysql",
+                        "stream": "8.4"
+                    },
+                    "out_modulestream": null
+                }
+            ],
+            "out_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "mysql8.4-test",
+                        "repository": "centos10-crb"
+                    }
+                ],
+                "set_id": 24166
+            },
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 7,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17596,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "mysql",
+                                "stream": "8.4"
+                            }
+                        ],
+                        "name": "mysql-test-data",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24167
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [
+                {
+                    "in_modulestream": {
+                        "name": "mysql",
+                        "stream": "8.4"
+                    },
+                    "out_modulestream": null
+                }
+            ],
+            "out_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "mysql8.4-test-data",
+                        "repository": "centos10-crb"
+                    }
+                ],
+                "set_id": 24168
+            },
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "x86_64"
+            ],
+            "id": 17597,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "qat-zstd-plugin",
+                        "repository": "centos9-appstream"
+                    }
+                ],
+                "set_id": 24169
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "x86_64"
+            ],
+            "id": 17598,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "qat-zstd-plugin-devel",
+                        "repository": "centos9-appstream"
+                    }
+                ],
+                "set_id": 24170
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "x86_64"
+            ],
+            "id": 17599,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "qat-zstd-plugin-static",
+                        "repository": "centos9-crb"
+                    }
+                ],
+                "set_id": 24171
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17600,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "legacy-printer-app",
+                        "repository": "centos10-appstream"
+                    }
+                ],
+                "set_id": 24172
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17601,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "pappl-retrofit",
+                        "repository": "centos10-appstream"
+                    }
+                ],
+                "set_id": 24173
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17602,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "nodejs",
+                                "stream": "22"
+                            }
+                        ],
+                        "name": "nodejs",
+                        "repository": "centos8-appstream"
+                    }
+                ],
+                "set_id": 24174
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 9,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17603,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "nodejs",
+                                "stream": "22"
+                            }
+                        ],
+                        "name": "nodejs-devel",
+                        "repository": "centos8-appstream"
+                    }
+                ],
+                "set_id": 24175
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 9,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17604,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "nodejs",
+                                "stream": "22"
+                            }
+                        ],
+                        "name": "nodejs-docs",
+                        "repository": "centos8-appstream"
+                    }
+                ],
+                "set_id": 24176
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 9,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17605,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "nodejs",
+                                "stream": "22"
+                            }
+                        ],
+                        "name": "nodejs-full-i18n",
+                        "repository": "centos8-appstream"
+                    }
+                ],
+                "set_id": 24177
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 9,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17606,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "nodejs",
+                                "stream": "22"
+                            }
+                        ],
+                        "name": "nodejs-libs",
+                        "repository": "centos8-appstream"
+                    }
+                ],
+                "set_id": 24178
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 9,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17607,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "nodejs",
+                                "stream": "22"
+                            }
+                        ],
+                        "name": "nodejs-nodemon",
+                        "repository": "centos8-appstream"
+                    }
+                ],
+                "set_id": 24179
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 9,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17608,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "nodejs",
+                                "stream": "22"
+                            }
+                        ],
+                        "name": "nodejs-packaging",
+                        "repository": "centos8-appstream"
+                    }
+                ],
+                "set_id": 24180
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 9,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17609,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "nodejs",
+                                "stream": "22"
+                            }
+                        ],
+                        "name": "nodejs-packaging-bundler",
+                        "repository": "centos8-appstream"
+                    }
+                ],
+                "set_id": 24181
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 9,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17610,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "nodejs",
+                                "stream": "22"
+                            }
+                        ],
+                        "name": "npm",
+                        "repository": "centos8-appstream"
+                    }
+                ],
+                "set_id": 24182
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 9,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17611,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "nodejs",
+                                "stream": "22"
+                            }
+                        ],
+                        "name": "v8-12.4-devel",
+                        "repository": "centos8-appstream"
+                    }
+                ],
+                "set_id": 24183
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 9,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 4,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17612,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "opensc",
+                        "repository": "baseos"
+                    }
+                ],
+                "set_id": 24184
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [
+                {
+                    "in_modulestream": null,
+                    "out_modulestream": null
+                }
+            ],
+            "out_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "opensc",
+                        "repository": "centos10-baseos"
+                    },
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "opensc-libs",
+                        "repository": "centos10-baseos"
+                    }
+                ],
+                "set_id": 24185
+            },
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17613,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "copy-jdk-configs",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24186
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17614,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "leapp",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24187
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17615,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "leapp-deps",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24188
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17616,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "python3-leapp",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24189
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17617,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "snactor",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24190
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17618,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "leapp-upgrade-el8toel9",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24191
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17619,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "leapp-upgrade-el8toel9-deps",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24192
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17620,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "cockpit-leapp",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24193
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17621,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "leapp",
+                        "repository": "centos9-appstream"
+                    }
+                ],
+                "set_id": 24194
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17622,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "leapp-deps",
+                        "repository": "centos9-appstream"
+                    }
+                ],
+                "set_id": 24195
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17623,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "python3-leapp",
+                        "repository": "centos9-appstream"
+                    }
+                ],
+                "set_id": 24196
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17624,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "snactor",
+                        "repository": "centos9-crb"
+                    }
+                ],
+                "set_id": 24197
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17625,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "leapp-upgrade-el9toel10",
+                        "repository": "centos9-appstream"
+                    }
+                ],
+                "set_id": 24198
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17626,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "leapp-upgrade-el9toel10-deps",
+                        "repository": "centos9-appstream"
+                    }
+                ],
+                "set_id": 24199
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17627,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "cockpit-leapp",
+                        "repository": "centos9-appstream"
+                    }
+                ],
+                "set_id": 24200
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17628,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "libportal-qt6",
+                        "repository": "centos10-appstream"
+                    }
+                ],
+                "set_id": 24201
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 7,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17629,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "libportal-qt6-devel",
+                        "repository": "centos10-crb"
+                    }
+                ],
+                "set_id": 24202
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 7,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17630,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "pidgin-sipe",
+                        "repository": "centos8-appstream"
+                    }
+                ],
+                "set_id": 24205
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 9,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17631,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "pidgin",
+                        "repository": "centos8-appstream"
+                    }
+                ],
+                "set_id": 24206
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 9,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17632,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "gtkspell",
+                        "repository": "centos8-appstream"
+                    }
+                ],
+                "set_id": 24207
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 9,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17633,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "gvfs-afc",
+                        "repository": "centos8-appstream"
+                    }
+                ],
+                "set_id": 24208
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 9,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17634,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "dleyna-renderer",
+                        "repository": "centos8-appstream"
+                    }
+                ],
+                "set_id": 24209
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 9,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17635,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "dleyna-server",
+                        "repository": "centos8-appstream"
+                    }
+                ],
+                "set_id": 24210
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 9,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17636,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "dleyna-connector-dbus",
+                        "repository": "centos8-appstream"
+                    }
+                ],
+                "set_id": 24211
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 9,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17637,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "php",
+                                "stream": "8.3"
+                            }
+                        ],
+                        "name": "apcu-panel",
+                        "repository": "centos9-appstream"
+                    }
+                ],
+                "set_id": 24212
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17638,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "php",
+                                "stream": "8.3"
+                            }
+                        ],
+                        "name": "php",
+                        "repository": "centos9-appstream"
+                    }
+                ],
+                "set_id": 24213
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17639,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "php",
+                                "stream": "8.3"
+                            }
+                        ],
+                        "name": "php-bcmath",
+                        "repository": "centos9-appstream"
+                    }
+                ],
+                "set_id": 24214
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17640,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "php",
+                                "stream": "8.3"
+                            }
+                        ],
+                        "name": "php-cli",
+                        "repository": "centos9-appstream"
+                    }
+                ],
+                "set_id": 24215
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17641,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "php",
+                                "stream": "8.3"
+                            }
+                        ],
+                        "name": "php-common",
+                        "repository": "centos9-appstream"
+                    }
+                ],
+                "set_id": 24216
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17642,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "php",
+                                "stream": "8.3"
+                            }
+                        ],
+                        "name": "php-dba",
+                        "repository": "centos9-appstream"
+                    }
+                ],
+                "set_id": 24217
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17643,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "php",
+                                "stream": "8.3"
+                            }
+                        ],
+                        "name": "php-dbg",
+                        "repository": "centos9-appstream"
+                    }
+                ],
+                "set_id": 24218
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17644,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "php",
+                                "stream": "8.3"
+                            }
+                        ],
+                        "name": "php-devel",
+                        "repository": "centos9-appstream"
+                    }
+                ],
+                "set_id": 24219
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17645,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "php",
+                                "stream": "8.3"
+                            }
+                        ],
+                        "name": "php-embedded",
+                        "repository": "centos9-appstream"
+                    }
+                ],
+                "set_id": 24220
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17646,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "php",
+                                "stream": "8.3"
+                            }
+                        ],
+                        "name": "php-enchant",
+                        "repository": "centos9-appstream"
+                    }
+                ],
+                "set_id": 24221
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17647,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "php",
+                                "stream": "8.3"
+                            }
+                        ],
+                        "name": "php-ffi",
+                        "repository": "centos9-appstream"
+                    }
+                ],
+                "set_id": 24222
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17648,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "php",
+                                "stream": "8.3"
+                            }
+                        ],
+                        "name": "php-fpm",
+                        "repository": "centos9-appstream"
+                    }
+                ],
+                "set_id": 24223
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17649,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "php",
+                                "stream": "8.3"
+                            }
+                        ],
+                        "name": "php-gd",
+                        "repository": "centos9-appstream"
+                    }
+                ],
+                "set_id": 24224
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17650,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "php",
+                                "stream": "8.3"
+                            }
+                        ],
+                        "name": "php-gmp",
+                        "repository": "centos9-appstream"
+                    }
+                ],
+                "set_id": 24225
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17651,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "php",
+                                "stream": "8.3"
+                            }
+                        ],
+                        "name": "php-intl",
+                        "repository": "centos9-appstream"
+                    }
+                ],
+                "set_id": 24226
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17652,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "php",
+                                "stream": "8.3"
+                            }
+                        ],
+                        "name": "php-ldap",
+                        "repository": "centos9-appstream"
+                    }
+                ],
+                "set_id": 24227
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17653,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "php",
+                                "stream": "8.3"
+                            }
+                        ],
+                        "name": "php-mbstring",
+                        "repository": "centos9-appstream"
+                    }
+                ],
+                "set_id": 24228
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17654,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "php",
+                                "stream": "8.3"
+                            }
+                        ],
+                        "name": "php-mysqlnd",
+                        "repository": "centos9-appstream"
+                    }
+                ],
+                "set_id": 24229
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17655,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "php",
+                                "stream": "8.3"
+                            }
+                        ],
+                        "name": "php-odbc",
+                        "repository": "centos9-appstream"
+                    }
+                ],
+                "set_id": 24230
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17656,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "php",
+                                "stream": "8.3"
+                            }
+                        ],
+                        "name": "php-opcache",
+                        "repository": "centos9-appstream"
+                    }
+                ],
+                "set_id": 24231
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17657,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "php",
+                                "stream": "8.3"
+                            }
+                        ],
+                        "name": "php-pdo",
+                        "repository": "centos9-appstream"
+                    }
+                ],
+                "set_id": 24232
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17658,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "php",
+                                "stream": "8.3"
+                            }
+                        ],
+                        "name": "php-pecl-apcu",
+                        "repository": "centos9-appstream"
+                    }
+                ],
+                "set_id": 24233
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17659,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "php",
+                                "stream": "8.3"
+                            }
+                        ],
+                        "name": "php-pecl-apcu-devel",
+                        "repository": "centos9-appstream"
+                    }
+                ],
+                "set_id": 24234
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17660,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "php",
+                                "stream": "8.3"
+                            }
+                        ],
+                        "name": "php-pecl-redis6",
+                        "repository": "centos9-appstream"
+                    }
+                ],
+                "set_id": 24235
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17661,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "php",
+                                "stream": "8.3"
+                            }
+                        ],
+                        "name": "php-pecl-rrd",
+                        "repository": "centos9-appstream"
+                    }
+                ],
+                "set_id": 24236
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17662,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "php",
+                                "stream": "8.3"
+                            }
+                        ],
+                        "name": "php-pecl-xdebug3",
+                        "repository": "centos9-appstream"
+                    }
+                ],
+                "set_id": 24237
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17663,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "php",
+                                "stream": "8.3"
+                            }
+                        ],
+                        "name": "php-pecl-zip",
+                        "repository": "centos9-appstream"
+                    }
+                ],
+                "set_id": 24238
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17664,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "php",
+                                "stream": "8.3"
+                            }
+                        ],
+                        "name": "php-pgsql",
+                        "repository": "centos9-appstream"
+                    }
+                ],
+                "set_id": 24239
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17665,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "php",
+                                "stream": "8.3"
+                            }
+                        ],
+                        "name": "php-process",
+                        "repository": "centos9-appstream"
+                    }
+                ],
+                "set_id": 24240
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17666,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "php",
+                                "stream": "8.3"
+                            }
+                        ],
+                        "name": "php-snmp",
+                        "repository": "centos9-appstream"
+                    }
+                ],
+                "set_id": 24241
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17667,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "php",
+                                "stream": "8.3"
+                            }
+                        ],
+                        "name": "php-soap",
+                        "repository": "centos9-appstream"
+                    }
+                ],
+                "set_id": 24242
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17668,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "php",
+                                "stream": "8.3"
+                            }
+                        ],
+                        "name": "php-xml",
+                        "repository": "centos9-appstream"
+                    }
+                ],
+                "set_id": 24243
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17669,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "nginx",
+                                "stream": "1.26"
+                            }
+                        ],
+                        "name": "nginx",
+                        "repository": "centos9-appstream"
+                    }
+                ],
+                "set_id": 24244
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17670,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "nginx",
+                                "stream": "1.26"
+                            }
+                        ],
+                        "name": "nginx-all-modules",
+                        "repository": "centos9-appstream"
+                    }
+                ],
+                "set_id": 24245
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17671,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "nginx",
+                                "stream": "1.26"
+                            }
+                        ],
+                        "name": "nginx-core",
+                        "repository": "centos9-appstream"
+                    }
+                ],
+                "set_id": 24246
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17672,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "nginx",
+                                "stream": "1.26"
+                            }
+                        ],
+                        "name": "nginx-filesystem",
+                        "repository": "centos9-appstream"
+                    }
+                ],
+                "set_id": 24247
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17673,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "nginx",
+                                "stream": "1.26"
+                            }
+                        ],
+                        "name": "nginx-mod-devel",
+                        "repository": "centos9-appstream"
+                    }
+                ],
+                "set_id": 24248
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17674,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "nginx",
+                                "stream": "1.26"
+                            }
+                        ],
+                        "name": "nginx-mod-http-image-filter",
+                        "repository": "centos9-appstream"
+                    }
+                ],
+                "set_id": 24249
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17675,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "nginx",
+                                "stream": "1.26"
+                            }
+                        ],
+                        "name": "nginx-mod-http-perl",
+                        "repository": "centos9-appstream"
+                    }
+                ],
+                "set_id": 24250
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17676,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "nginx",
+                                "stream": "1.26"
+                            }
+                        ],
+                        "name": "nginx-mod-http-xslt-filter",
+                        "repository": "centos9-appstream"
+                    }
+                ],
+                "set_id": 24251
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17677,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "nginx",
+                                "stream": "1.26"
+                            }
+                        ],
+                        "name": "nginx-mod-mail",
+                        "repository": "centos9-appstream"
+                    }
+                ],
+                "set_id": 24252
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17678,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "nginx",
+                                "stream": "1.26"
+                            }
+                        ],
+                        "name": "nginx-mod-stream",
+                        "repository": "centos9-appstream"
+                    }
+                ],
+                "set_id": 24253
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "x86_64"
+            ],
+            "id": 17679,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "gnome-boxes",
+                        "repository": "centos8-appstream"
+                    }
+                ],
+                "set_id": 24254
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 9,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17680,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "dleyna-core",
+                        "repository": "centos8-appstream"
+                    }
+                ],
+                "set_id": 24255
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 9,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17681,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "redhat-menus",
+                        "repository": "centos8-appstream"
+                    }
+                ],
+                "set_id": 24256
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 9,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "x86_64"
+            ],
+            "id": 17682,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "dbxtool",
+                        "repository": "centos8-baseos"
+                    }
+                ],
+                "set_id": 24257
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 9,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17683,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "gnome-online-miners",
+                        "repository": "centos8-appstream"
+                    }
+                ],
+                "set_id": 24258
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 9,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17684,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "gfbgraph",
+                        "repository": "centos8-appstream"
+                    }
+                ],
+                "set_id": 24259
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 9,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17685,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "webkitgtk3",
+                        "repository": "base"
+                    }
+                ],
+                "set_id": 24260
+            },
+            "initial_release": {
+                "major_version": 7,
+                "minor_version": 8,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 7,
+                "minor_version": 9,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 6,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17686,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "php",
+                                "stream": "8.3"
+                            }
+                        ],
+                        "name": "php-pecl-redis6",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24261
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 7,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [
+                {
+                    "in_modulestream": {
+                        "name": "php",
+                        "stream": "8.3"
+                    },
+                    "out_modulestream": null
+                }
+            ],
+            "out_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "php-pecl-redis6",
+                        "repository": "centos10-appstream"
+                    }
+                ],
+                "set_id": 24262
+            },
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17687,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "nginx",
+                                "stream": "1.26"
+                            }
+                        ],
+                        "name": "nginx",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24263
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 7,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17688,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "nginx",
+                                "stream": "1.26"
+                            }
+                        ],
+                        "name": "nginx",
+                        "repository": "centos9-appstream"
+                    }
+                ],
+                "set_id": 24264
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 7,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "x86_64"
+            ],
+            "id": 17689,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "trustee-guest-components",
+                        "repository": "centos9-appstream"
+                    }
+                ],
+                "set_id": 24265
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "x86_64"
+            ],
+            "id": 17690,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "python3-libcpuid",
+                        "repository": "centos10-baseos"
+                    }
+                ],
+                "set_id": 24266
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 7,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "x86_64"
+            ],
+            "id": 17691,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "libcamera",
+                        "repository": "centos10-appstream"
+                    }
+                ],
+                "set_id": 24267
+            },
+            "initial_release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 1,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17692,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "gnome-settings-daemon-server-defaults",
+                        "repository": "centos10-appstream"
+                    }
+                ],
+                "set_id": 24268
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 7,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 6,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17693,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "bpftool",
+                        "repository": "centos9-baseos"
+                    }
+                ],
+                "set_id": 24269
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [
+                {
+                    "in_modulestream": null,
+                    "out_modulestream": null
+                }
+            ],
+            "out_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "bpftool",
+                        "repository": "centos9-appstream"
+                    }
+                ],
+                "set_id": 24270
+            },
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17694,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "tomcat-jakartaee-migration",
+                        "repository": "centos10-appstream"
+                    }
+                ],
+                "set_id": 24271
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17695,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "unbound-dracut",
+                        "repository": "centos10-appstream"
+                    }
+                ],
+                "set_id": 24272
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 7,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17696,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "unbound-dracut",
+                        "repository": "centos9-appstream"
+                    }
+                ],
+                "set_id": 24273
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17697,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "bpftool",
+                        "repository": "centos10-appstream"
+                    }
+                ],
+                "set_id": 24274
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 7,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17698,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "libspelling",
+                        "repository": "centos10-appstream"
+                    }
+                ],
+                "set_id": 24275
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 7,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17699,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "libspelling-devel",
+                        "repository": "centos10-crb"
+                    }
+                ],
+                "set_id": 24276
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 7,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 3,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17700,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "tomcat-el-3.0-api",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24277
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 7,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [
+                {
+                    "in_modulestream": null,
+                    "out_modulestream": null
+                }
+            ],
+            "out_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "tomcat-el-5.0-api",
+                        "repository": "centos10-appstream"
+                    }
+                ],
+                "set_id": 24278
+            },
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 3,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17701,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "tomcat-servlet-4.0-api",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24279
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 7,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [
+                {
+                    "in_modulestream": null,
+                    "out_modulestream": null
+                }
+            ],
+            "out_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "tomcat-servlet-6.0-api",
+                        "repository": "centos10-appstream"
+                    }
+                ],
+                "set_id": 24280
+            },
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 3,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17702,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "tomcat-jsp-2.3-api",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24281
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 7,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [
+                {
+                    "in_modulestream": null,
+                    "out_modulestream": null
+                }
+            ],
+            "out_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "tomcat-jsp-3.1-api",
+                        "repository": "centos10-appstream"
+                    }
+                ],
+                "set_id": 24282
+            },
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17703,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "perl-DBD-MariaDB",
+                        "repository": "centos10-appstream"
+                    }
+                ],
+                "set_id": 24284
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 7,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17704,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "perl-DBD-MySQL",
+                        "repository": "centos10-appstream"
+                    }
+                ],
+                "set_id": 24285
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 7,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 3,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17705,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "cockpit-composer",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24286
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 7,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [
+                {
+                    "in_modulestream": null,
+                    "out_modulestream": null
+                }
+            ],
+            "out_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "cockpit-image-builder",
+                        "repository": "centos10-appstream"
+                    }
+                ],
+                "set_id": 24287
+            },
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17706,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "cockpit-composer",
+                        "repository": "centos9-appstream"
+                    }
+                ],
+                "set_id": 24288
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "x86_64"
+            ],
+            "id": 17707,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "trustee-guest-components",
+                        "repository": "centos10-appstream"
+                    }
+                ],
+                "set_id": 24289
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 7,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 4,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17708,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "rsync",
+                        "repository": "centos9-baseos"
+                    }
+                ],
+                "set_id": 24290
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [
+                {
+                    "in_modulestream": null,
+                    "out_modulestream": null
+                }
+            ],
+            "out_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "rsync",
+                        "repository": "centos9-baseos"
+                    },
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "rsync-rrsync",
+                        "repository": "centos9-appstream"
+                    }
+                ],
+                "set_id": 24291
+            },
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17709,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "dnsconfd-micro",
+                        "repository": "centos10-appstream"
+                    }
+                ],
+                "set_id": 24292
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 7,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
                 "x86_64",
                 "aarch64",
                 "ppc64le",
                 "s390x"
             ],
-            "id": 17430,
+            "id": 17710,
             "in_packageset": {
                 "package": [
                     {
@@ -620880,7 +627746,7 @@
                         "repository": "base"
                     }
                 ],
-                "set_id": 23978
+                "set_id": 24293
             },
             "initial_release": {
                 "major_version": 7,
@@ -620903,7 +627769,7 @@
                 "ppc64le",
                 "s390x"
             ],
-            "id": 17431,
+            "id": 17711,
             "in_packageset": {
                 "package": [
                     {
@@ -620914,7 +627780,7 @@
                         "repository": "base"
                     }
                 ],
-                "set_id": 23980
+                "set_id": 24295
             },
             "initial_release": {
                 "major_version": 7,
@@ -620939,7 +627805,7 @@
                         "repository": "centos8-baseos"
                     }
                 ],
-                "set_id": 23979
+                "set_id": 24294
             },
             "release": {
                 "major_version": 8,
@@ -620957,7 +627823,7 @@
                 "ppc64le",
                 "s390x"
             ],
-            "id": 17432,
+            "id": 17712,
             "in_packageset": {
                 "package": [
                     {
@@ -620968,7 +627834,7 @@
                         "repository": "base"
                     }
                 ],
-                "set_id": 23982
+                "set_id": 24297
             },
             "initial_release": {
                 "major_version": 7,
@@ -620993,7 +627859,7 @@
                         "repository": "centos8-baseos"
                     }
                 ],
-                "set_id": 23981
+                "set_id": 24296
             },
             "release": {
                 "major_version": 8,
@@ -621011,7 +627877,7 @@
                 "ppc64le",
                 "s390x"
             ],
-            "id": 17433,
+            "id": 17713,
             "in_packageset": {
                 "package": [
                     {
@@ -621022,7 +627888,7 @@
                         "repository": "base"
                     }
                 ],
-                "set_id": 23984
+                "set_id": 24299
             },
             "initial_release": {
                 "major_version": 7,
@@ -621047,7 +627913,7 @@
                         "repository": "centos8-baseos"
                     }
                 ],
-                "set_id": 23983
+                "set_id": 24298
             },
             "release": {
                 "major_version": 8,
@@ -621065,7 +627931,7 @@
                 "ppc64le",
                 "s390x"
             ],
-            "id": 17434,
+            "id": 17714,
             "in_packageset": {
                 "package": [
                     {
@@ -621076,7 +627942,7 @@
                         "repository": "powertools"
                     }
                 ],
-                "set_id": 23985
+                "set_id": 24300
             },
             "initial_release": {
                 "major_version": 8,
@@ -621108,7 +627974,7 @@
                 "ppc64le",
                 "s390x"
             ],
-            "id": 17435,
+            "id": 17715,
             "in_packageset": {
                 "package": [
                     {
@@ -621119,7 +627985,7 @@
                         "repository": "appstream"
                     }
                 ],
-                "set_id": 23986
+                "set_id": 24301
             },
             "initial_release": {
                 "major_version": 8,
@@ -621151,7 +628017,7 @@
                 "ppc64le",
                 "s390x"
             ],
-            "id": 17436,
+            "id": 17716,
             "in_packageset": {
                 "package": [
                     {
@@ -621162,7 +628028,7 @@
                         "repository": "appstream"
                     }
                 ],
-                "set_id": 23987
+                "set_id": 24302
             },
             "initial_release": {
                 "major_version": 8,
@@ -621194,7 +628060,7 @@
                 "ppc64le",
                 "s390x"
             ],
-            "id": 17437,
+            "id": 17717,
             "in_packageset": {
                 "package": [
                     {
@@ -621205,7 +628071,7 @@
                         "repository": "baseos"
                     }
                 ],
-                "set_id": 23988
+                "set_id": 24303
             },
             "initial_release": {
                 "major_version": 8,
@@ -621237,7 +628103,7 @@
                 "ppc64le",
                 "s390x"
             ],
-            "id": 17438,
+            "id": 17718,
             "in_packageset": {
                 "package": [
                     {
@@ -621248,7 +628114,7 @@
                         "repository": "appstream"
                     }
                 ],
-                "set_id": 23989
+                "set_id": 24304
             },
             "initial_release": {
                 "major_version": 8,
@@ -621280,7 +628146,7 @@
                 "ppc64le",
                 "s390x"
             ],
-            "id": 17439,
+            "id": 17719,
             "in_packageset": {
                 "package": [
                     {
@@ -621291,7 +628157,7 @@
                         "repository": "appstream"
                     }
                 ],
-                "set_id": 23990
+                "set_id": 24305
             },
             "initial_release": {
                 "major_version": 8,
@@ -621323,7 +628189,7 @@
                 "ppc64le",
                 "s390x"
             ],
-            "id": 17440,
+            "id": 17720,
             "in_packageset": {
                 "package": [
                     {
@@ -621334,7 +628200,7 @@
                         "repository": "baseos"
                     }
                 ],
-                "set_id": 23991
+                "set_id": 24306
             },
             "initial_release": {
                 "major_version": 8,
@@ -621366,7 +628232,7 @@
                 "ppc64le",
                 "s390x"
             ],
-            "id": 17441,
+            "id": 17721,
             "in_packageset": {
                 "package": [
                     {
@@ -621377,7 +628243,7 @@
                         "repository": "baseos"
                     }
                 ],
-                "set_id": 23992
+                "set_id": 24307
             },
             "initial_release": {
                 "major_version": 8,
@@ -621409,7 +628275,7 @@
                 "ppc64le",
                 "s390x"
             ],
-            "id": 17442,
+            "id": 17722,
             "in_packageset": {
                 "package": [
                     {
@@ -621420,7 +628286,7 @@
                         "repository": "appstream"
                     }
                 ],
-                "set_id": 23993
+                "set_id": 24308
             },
             "initial_release": {
                 "major_version": 8,
@@ -621452,7 +628318,7 @@
                 "ppc64le",
                 "s390x"
             ],
-            "id": 17443,
+            "id": 17723,
             "in_packageset": {
                 "package": [
                     {
@@ -621463,7 +628329,7 @@
                         "repository": "appstream"
                     }
                 ],
-                "set_id": 23994
+                "set_id": 24309
             },
             "initial_release": {
                 "major_version": 8,
@@ -621495,7 +628361,7 @@
                 "ppc64le",
                 "s390x"
             ],
-            "id": 17444,
+            "id": 17724,
             "in_packageset": {
                 "package": [
                     {
@@ -621506,7 +628372,7 @@
                         "repository": "appstream"
                     }
                 ],
-                "set_id": 23995
+                "set_id": 24310
             },
             "initial_release": {
                 "major_version": 8,
@@ -621538,7 +628404,7 @@
                 "ppc64le",
                 "s390x"
             ],
-            "id": 17445,
+            "id": 17725,
             "in_packageset": {
                 "package": [
                     {
@@ -621549,7 +628415,7 @@
                         "repository": "appstream"
                     }
                 ],
-                "set_id": 23996
+                "set_id": 24311
             },
             "initial_release": {
                 "major_version": 8,
@@ -621581,7 +628447,7 @@
                 "ppc64le",
                 "s390x"
             ],
-            "id": 17446,
+            "id": 17726,
             "in_packageset": {
                 "package": [
                     {
@@ -621592,7 +628458,7 @@
                         "repository": "appstream"
                     }
                 ],
-                "set_id": 23997
+                "set_id": 24312
             },
             "initial_release": {
                 "major_version": 8,
@@ -621624,7 +628490,7 @@
                 "ppc64le",
                 "s390x"
             ],
-            "id": 17447,
+            "id": 17727,
             "in_packageset": {
                 "package": [
                     {
@@ -621635,7 +628501,7 @@
                         "repository": "appstream"
                     }
                 ],
-                "set_id": 23998
+                "set_id": 24313
             },
             "initial_release": {
                 "major_version": 8,
@@ -621667,7 +628533,7 @@
                 "ppc64le",
                 "s390x"
             ],
-            "id": 17448,
+            "id": 17728,
             "in_packageset": {
                 "package": [
                     {
@@ -621678,7 +628544,7 @@
                         "repository": "appstream"
                     }
                 ],
-                "set_id": 23999
+                "set_id": 24314
             },
             "initial_release": {
                 "major_version": 8,
@@ -621710,7 +628576,7 @@
                 "ppc64le",
                 "s390x"
             ],
-            "id": 17449,
+            "id": 17729,
             "in_packageset": {
                 "package": [
                     {
@@ -621721,7 +628587,7 @@
                         "repository": "appstream"
                     }
                 ],
-                "set_id": 24000
+                "set_id": 24315
             },
             "initial_release": {
                 "major_version": 8,
@@ -621753,7 +628619,7 @@
                 "ppc64le",
                 "s390x"
             ],
-            "id": 17450,
+            "id": 17730,
             "in_packageset": {
                 "package": [
                     {
@@ -621764,7 +628630,7 @@
                         "repository": "appstream"
                     }
                 ],
-                "set_id": 24001
+                "set_id": 24316
             },
             "initial_release": {
                 "major_version": 8,

--- a/files/oraclelinux/config.json
+++ b/files/oraclelinux/config.json
@@ -231,6 +231,31 @@
             "name": "redhat-cloud-client-configuration",
             "initial_release": 8,
             "target_release": 9
+        },
+        {
+            "name": "libreport-rhel-anaconda-bugzilla",
+            "initial_release": 9,
+            "target_release": 9
+        },
+        {
+            "name": "libreport-rhel-anaconda-bugzilla",
+            "initial_release": 9,
+            "target_release": 10
+        },
+        {
+            "name": "redhat-flatpak-preinstall-firefox",
+            "initial_release": 9,
+            "target_release": 10
+        },
+        {
+            "name": "redhat-flatpak-preinstall-thunderbird",
+            "initial_release": 9,
+            "target_release": 10
+        },
+        {
+            "name": "redhat-flatpak-repo",
+            "initial_release": 9,
+            "target_release": 10
         }
     ],
 

--- a/files/oraclelinux/device_driver_deprecation_data.json
+++ b/files/oraclelinux/device_driver_deprecation_data.json
@@ -1557,7 +1557,7 @@
       "device_id": "",
       "device_name": "",
       "device_type": "pci",
-      "driver_name": "3w-9xxx",
+      "driver_name": "3w_9xxx",
       "maintained_in_rhel": []
     },
     {
@@ -1568,7 +1568,7 @@
       "device_id": "",
       "device_name": "",
       "device_type": "pci",
-      "driver_name": "3w-sas",
+      "driver_name": "3w_sas",
       "maintained_in_rhel": []
     },
     {
@@ -2429,7 +2429,7 @@
       "device_id": "",
       "device_name": "",
       "device_type": "pci",
-      "driver_name": "acard-ahci",
+      "driver_name": "acard_ahci",
       "maintained_in_rhel": []
     },
     {
@@ -2444,6 +2444,42 @@
       "device_name": "PF_KEY sockets",
       "device_type": "pci",
       "driver_name": "af_key",
+      "maintained_in_rhel": [
+        7,
+        8,
+        9
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7,
+        8,
+        9,
+        10
+      ],
+      "deprecation_announced": "",
+      "device_id": "",
+      "device_name": "Seattle AHCI SATA platform driver",
+      "device_type": "pci",
+      "driver_name": "ahci_seattle",
+      "maintained_in_rhel": [
+        7,
+        8,
+        9
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7,
+        8,
+        9,
+        10
+      ],
+      "deprecation_announced": "",
+      "device_id": "",
+      "device_name": "APM X-Gene AHCI SATA driver",
+      "device_type": "pci",
+      "driver_name": "ahci_xgene",
       "maintained_in_rhel": [
         7,
         8,
@@ -2891,7 +2927,7 @@
       "device_id": "",
       "device_name": "",
       "device_type": "pci",
-      "driver_name": "firewire-core",
+      "driver_name": "firewire_core",
       "maintained_in_rhel": [
         7,
         8,
@@ -2940,7 +2976,8 @@
       "available_in_rhel": [
         7,
         8,
-        9
+        9,
+        10
       ],
       "deprecation_announced": "",
       "device_id": "",
@@ -2949,7 +2986,27 @@
       "driver_name": "hfi1",
       "maintained_in_rhel": [
         7,
-        8
+        8,
+        9,
+        10
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7,
+        8,
+        9,
+        10
+      ],
+      "deprecation_announced": "",
+      "device_id": "",
+      "device_name": "HISILICON SAS controller driver",
+      "device_type": "pci",
+      "driver_name": "hisi_sas_main",
+      "maintained_in_rhel": [
+        7,
+        8,
+        9
       ]
     },
     {
@@ -4265,6 +4322,30 @@
     },
     {
       "available_in_rhel": [
+        9,
+        10
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x15B3:0x1023",
+      "device_name": "ConnectX-8",
+      "device_type": "pci",
+      "driver_name": "mlx5",
+      "maintained_in_rhel": [
+        9,
+        10
+      ]
+    },
+    {
+      "available_in_rhel": [],
+      "deprecation_announced": "",
+      "device_id": "0x15B3:0x1025",
+      "device_name": "ConnectX-9",
+      "device_type": "pci",
+      "driver_name": "mlx5",
+      "maintained_in_rhel": []
+    },
+    {
+      "available_in_rhel": [
         7,
         8,
         9,
@@ -4276,7 +4357,9 @@
       "device_type": "pci",
       "driver_name": "mlx5",
       "maintained_in_rhel": [
-        7
+        7,
+        9,
+        10
       ]
     },
     {
@@ -4828,7 +4911,7 @@
       "device_id": "",
       "device_name": "",
       "device_type": "pci",
-      "driver_name": "nvmet-fc",
+      "driver_name": "nvmet_fc",
       "maintained_in_rhel": [
         7
       ]
@@ -4844,7 +4927,7 @@
       "device_id": "",
       "device_name": "",
       "device_type": "pci",
-      "driver_name": "nvmet-tcp",
+      "driver_name": "nvmet_tcp",
       "maintained_in_rhel": [
         7
       ]

--- a/files/oraclelinux/pes-events.json
+++ b/files/oraclelinux/pes-events.json
@@ -1,5 +1,5 @@
 {
-    "timestamp": "202411121506Z",
+    "timestamp": "202502132105Z",
     "provided_data_streams": [
         "3.0",
         "3.1",
@@ -10024,7 +10024,14 @@
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "postgresql",
+                                "stream": "10"
+                            },
+                            {
+                                "name": "postgresql",
+                                "stream": "9.6"
+                            }
                         ],
                         "name": "postgresql-test-rpm-macros",
                         "repository": "ol8-appstream"
@@ -10032,7 +10039,11 @@
                 ],
                 "set_id": 391
             },
-            "initial_release": null,
+            "initial_release": {
+                "major_version": 7,
+                "minor_version": 9,
+                "os_name": "CentOS"
+            },
             "modulestream_maps": [],
             "out_packageset": null,
             "release": {
@@ -10782,7 +10793,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -10818,7 +10828,7 @@
                             null
                         ],
                         "name": "libjpeg-turbo-utils",
-                        "repository": "ol8-baseos"
+                        "repository": "ol8-appstream"
                     }
                 ],
                 "set_id": 432
@@ -10981,9 +10991,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 337,
@@ -65010,7 +65017,6 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -65044,7 +65050,6 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -65078,7 +65083,6 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -65112,7 +65116,6 @@
         {
             "action": 7,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -65260,9 +65263,6 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 1645,
@@ -65294,9 +65294,6 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 1646,
@@ -65328,9 +65325,6 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 1647,
@@ -65362,9 +65356,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 1648,
@@ -65398,7 +65389,7 @@
                             null
                         ],
                         "name": "libappindicator-gtk3-devel",
-                        "repository": "ol8-appstream"
+                        "repository": "ol8-crb"
                     }
                 ],
                 "set_id": 5296
@@ -65412,9 +65403,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 1649,
@@ -65448,7 +65436,7 @@
                             null
                         ],
                         "name": "libdbusmenu-devel",
-                        "repository": "ol8-appstream"
+                        "repository": "ol8-crb"
                     }
                 ],
                 "set_id": 5298
@@ -65462,9 +65450,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 1650,
@@ -65512,9 +65497,6 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 1651,
@@ -65546,9 +65528,6 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 1652,
@@ -65580,9 +65559,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 1653,
@@ -65630,9 +65606,6 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 1654,
@@ -65664,9 +65637,6 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 1655,
@@ -65698,9 +65668,6 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 1656,
@@ -65732,9 +65699,6 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 1657,
@@ -65766,9 +65730,6 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 1658,
@@ -65800,9 +65761,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 1659,
@@ -65850,9 +65808,6 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 1660,
@@ -65884,9 +65839,6 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 1661,
@@ -71210,7 +71162,6 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -71230,7 +71181,7 @@
             },
             "initial_release": {
                 "major_version": 7,
-                "minor_version": 7,
+                "minor_version": 9,
                 "os_name": "CentOS"
             },
             "modulestream_maps": [],
@@ -71362,9 +71313,6 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 2136,
@@ -71382,7 +71330,7 @@
             },
             "initial_release": {
                 "major_version": 7,
-                "minor_version": 7,
+                "minor_version": 9,
                 "os_name": "CentOS"
             },
             "modulestream_maps": [],
@@ -83317,7 +83265,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -83353,7 +83300,7 @@
                             null
                         ],
                         "name": "dovecot-devel",
-                        "repository": "ol8-appstream"
+                        "repository": "ol8-crb"
                     }
                 ],
                 "set_id": 3995
@@ -83553,7 +83500,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -83589,7 +83535,7 @@
                             null
                         ],
                         "name": "gpgme-devel",
-                        "repository": "ol8-baseos"
+                        "repository": "ol8-crb"
                     }
                 ],
                 "set_id": 4007
@@ -85433,7 +85379,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -85469,7 +85414,7 @@
                             null
                         ],
                         "name": "uuid-devel",
-                        "repository": "ol8-appstream"
+                        "repository": "ol8-crb"
                     }
                 ],
                 "set_id": 4097
@@ -115861,9 +115806,7 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 3208,
@@ -115897,7 +115840,7 @@
                             null
                         ],
                         "name": "devhelp-devel",
-                        "repository": "ol8-appstream"
+                        "repository": "ol8-crb"
                     }
                 ],
                 "set_id": 5300
@@ -115911,9 +115854,6 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 3209,
@@ -115945,9 +115885,7 @@
         {
             "action": 7,
             "architectures": [
-                "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 3210,
@@ -115995,7 +115933,6 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -116029,7 +115966,6 @@
         {
             "action": 7,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -116079,9 +116015,7 @@
         {
             "action": 7,
             "architectures": [
-                "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 3213,
@@ -116129,7 +116063,6 @@
         {
             "action": 7,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -116179,9 +116112,7 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 3215,
@@ -116215,7 +116146,7 @@
                             null
                         ],
                         "name": "yelp-devel",
-                        "repository": "ol8-appstream"
+                        "repository": "ol8-crb"
                     }
                 ],
                 "set_id": 5313
@@ -116229,7 +116160,6 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -241883,40 +241813,6 @@
                 "s390x",
                 "x86_64"
             ],
-            "id": 6711,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "librsvg-tools",
-                        "repository": "ol8-baseos"
-                    }
-                ],
-                "set_id": 10196
-            },
-            "initial_release": {
-                "major_version": 8,
-                "minor_version": 0,
-                "os_name": "OL"
-            },
-            "modulestream_maps": [],
-            "out_packageset": null,
-            "release": {
-                "major_version": 8,
-                "minor_version": 1,
-                "os_name": "OL"
-            }
-        },
-        {
-            "action": 0,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
             "id": 6712,
             "in_packageset": {
                 "package": [
@@ -242503,7 +242399,7 @@
                             null
                         ],
                         "name": "dovecot-pigeonhole",
-                        "repository": "ol8-baseos"
+                        "repository": "ol8-appstream"
                     }
                 ],
                 "set_id": 10219
@@ -242536,7 +242432,7 @@
                         "modulestreams": [
                             null
                         ],
-                        "name": "libxkbfile-1.1.0-1.el8",
+                        "name": "libxkbfile",
                         "repository": "ol8-appstream"
                     }
                 ],
@@ -242706,7 +242602,7 @@
                         "modulestreams": [
                             null
                         ],
-                        "name": "pipewire0.2",
+                        "name": "pipewire0.2-libs",
                         "repository": "ol8-appstream"
                     }
                 ],
@@ -247991,9 +247887,7 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 6935,
@@ -248060,8 +247954,6 @@
             "action": 1,
             "architectures": [
                 "aarch64",
-                "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 6937,
@@ -248130,9 +248022,7 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 6940,
@@ -248198,9 +248088,7 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 6942,
@@ -248580,7 +248468,6 @@
             "architectures": [
                 "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 6953,
@@ -248591,7 +248478,7 @@
                             null
                         ],
                         "name": "libraw1394",
-                        "repository": "baseos"
+                        "repository": "appstream"
                     }
                 ],
                 "set_id": 10540
@@ -261952,7 +261839,6 @@
             "architectures": [
                 "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 7739,
@@ -261986,7 +261872,6 @@
             "architectures": [
                 "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 7740,
@@ -273822,9 +273707,7 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 9001,
@@ -273856,9 +273739,7 @@
         {
             "action": 2,
             "architectures": [
-                "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 9002,
@@ -274026,9 +273907,7 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 9008,
@@ -274060,9 +273939,7 @@
         {
             "action": 2,
             "architectures": [
-                "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 9009,
@@ -274094,9 +273971,7 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 9010,
@@ -274128,9 +274003,7 @@
         {
             "action": 2,
             "architectures": [
-                "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 9011,
@@ -274162,9 +274035,7 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 9012,
@@ -274196,9 +274067,7 @@
         {
             "action": 2,
             "architectures": [
-                "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 9013,
@@ -274436,7 +274305,6 @@
             "architectures": [
                 "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 9020,
@@ -274470,7 +274338,6 @@
             "architectures": [
                 "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 9021,
@@ -275114,9 +274981,7 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 9040,
@@ -275148,9 +275013,7 @@
         {
             "action": 2,
             "architectures": [
-                "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 9041,
@@ -275182,9 +275045,7 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 9042,
@@ -275216,9 +275077,7 @@
         {
             "action": 2,
             "architectures": [
-                "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 9043,
@@ -275828,9 +275687,7 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 9062,
@@ -275841,7 +275698,7 @@
                             null
                         ],
                         "name": "gtkspell",
-                        "repository": "crb"
+                        "repository": "appstream"
                     }
                 ],
                 "set_id": 12745
@@ -276202,9 +276059,7 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 9073,
@@ -276298,40 +276153,6 @@
             "release": {
                 "major_version": 8,
                 "minor_version": 6,
-                "os_name": "OL"
-            }
-        },
-        {
-            "action": 1,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 9078,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "libmtp-devel",
-                        "repository": "crb"
-                    }
-                ],
-                "set_id": 12762
-            },
-            "initial_release": {
-                "major_version": 8,
-                "minor_version": 6,
-                "os_name": "OL"
-            },
-            "modulestream_maps": [],
-            "out_packageset": null,
-            "release": {
-                "major_version": 9,
-                "minor_version": 0,
                 "os_name": "OL"
             }
         },
@@ -277732,9 +277553,7 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 9136,
@@ -277745,7 +277564,7 @@
                             null
                         ],
                         "name": "file-roller-nautilus",
-                        "repository": "base"
+                        "repository": "ol8-appstream"
                     }
                 ],
                 "set_id": 12804
@@ -277812,7 +277631,7 @@
                             null
                         ],
                         "name": "tigervnc-server-applet",
-                        "repository": "base"
+                        "repository": "ol8-appstream"
                     }
                 ],
                 "set_id": 12805
@@ -277833,7 +277652,6 @@
         {
             "action": 2,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -277869,7 +277687,6 @@
             "architectures": [
                 "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 9140,
@@ -277880,7 +277697,7 @@
                             null
                         ],
                         "name": "gnome-software-editor",
-                        "repository": "base"
+                        "repository": "ol8-appstream"
                     }
                 ],
                 "set_id": 12806
@@ -277934,9 +277751,6 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 9142,
@@ -277968,9 +277782,6 @@
         {
             "action": 2,
             "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 9143,
@@ -278002,9 +277813,7 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 9144,
@@ -278015,7 +277824,7 @@
                             null
                         ],
                         "name": "gnome-shell-extension-alternate-tab",
-                        "repository": "base"
+                        "repository": "ol8-appstream"
                     }
                 ],
                 "set_id": 12808
@@ -278036,7 +277845,6 @@
         {
             "action": 2,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -305273,43 +305081,6 @@
                 "s390x",
                 "x86_64"
             ],
-            "id": 10577,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            {
-                                "name": "javapackages-tools",
-                                "stream": "201801"
-                            }
-                        ],
-                        "name": "antlr-C++",
-                        "repository": "crb"
-                    }
-                ],
-                "set_id": 14621
-            },
-            "initial_release": {
-                "major_version": 8,
-                "minor_version": 6,
-                "os_name": "OL"
-            },
-            "modulestream_maps": [],
-            "out_packageset": null,
-            "release": {
-                "major_version": 9,
-                "minor_version": 0,
-                "os_name": "OL"
-            }
-        },
-        {
-            "action": 1,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
             "id": 10578,
             "in_packageset": {
                 "package": [
@@ -311113,43 +310884,6 @@
                     }
                 ],
                 "set_id": 14919
-            },
-            "initial_release": {
-                "major_version": 8,
-                "minor_version": 6,
-                "os_name": "OL"
-            },
-            "modulestream_maps": [],
-            "out_packageset": null,
-            "release": {
-                "major_version": 9,
-                "minor_version": 0,
-                "os_name": "OL"
-            }
-        },
-        {
-            "action": 1,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 10826,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            {
-                                "name": "javapackages-tools",
-                                "stream": "201801"
-                            }
-                        ],
-                        "name": "plexus-containers-container-default",
-                        "repository": "crb"
-                    }
-                ],
-                "set_id": 14920
             },
             "initial_release": {
                 "major_version": 8,
@@ -340828,7 +340562,7 @@
             },
             "initial_release": {
                 "major_version": 8,
-                "minor_version": 1,
+                "minor_version": 10,
                 "os_name": "OL"
             },
             "modulestream_maps": [],
@@ -340869,14 +340603,14 @@
             },
             "initial_release": {
                 "major_version": 8,
-                "minor_version": 0,
+                "minor_version": 9,
                 "os_name": "OL"
             },
             "modulestream_maps": [],
             "out_packageset": null,
             "release": {
                 "major_version": 8,
-                "minor_version": 1,
+                "minor_version": 10,
                 "os_name": "OL"
             }
         },
@@ -384254,8 +383988,6 @@
             "action": 0,
             "architectures": [
                 "aarch64",
-                "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 17278,
@@ -384421,6 +384153,1411 @@
             }
         },
         {
+            "action": 6,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17436,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "python39-devel",
+                                "stream": "3.9"
+                            }
+                        ],
+                        "name": "python39-pybind11",
+                        "repository": "ol8-crb"
+                    }
+                ],
+                "set_id": 23986
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 8,
+                "os_name": "OL"
+            },
+            "modulestream_maps": [
+                {
+                    "in_modulestream": {
+                        "name": "python39-devel",
+                        "stream": "3.9"
+                    },
+                    "out_modulestream": {
+                        "name": "python39-devel",
+                        "stream": "3.9"
+                    }
+                }
+            ],
+            "out_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "python39-devel",
+                                "stream": "3.9"
+                            }
+                        ],
+                        "name": "python39-pybind11",
+                        "repository": "ol8-appstream"
+                    }
+                ],
+                "set_id": 23987
+            },
+            "release": {
+                "major_version": 8,
+                "minor_version": 9,
+                "os_name": "OL"
+            }
+        },
+        {
+            "action": 6,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17437,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "python39-devel",
+                                "stream": "3.9"
+                            }
+                        ],
+                        "name": "python39-pybind11-devel",
+                        "repository": "ol8-crb"
+                    }
+                ],
+                "set_id": 23988
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 8,
+                "os_name": "OL"
+            },
+            "modulestream_maps": [
+                {
+                    "in_modulestream": {
+                        "name": "python39-devel",
+                        "stream": "3.9"
+                    },
+                    "out_modulestream": {
+                        "name": "python39-devel",
+                        "stream": "3.9"
+                    }
+                }
+            ],
+            "out_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "python39-devel",
+                                "stream": "3.9"
+                            }
+                        ],
+                        "name": "python39-pybind11-devel",
+                        "repository": "ol8-appstream"
+                    }
+                ],
+                "set_id": 23989
+            },
+            "release": {
+                "major_version": 8,
+                "minor_version": 9,
+                "os_name": "OL"
+            }
+        },
+        {
+            "action": 6,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17438,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "python39-devel",
+                                "stream": "3.9"
+                            }
+                        ],
+                        "name": "python39-pybind11",
+                        "repository": "ol8-appstream"
+                    }
+                ],
+                "set_id": 23990
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 9,
+                "os_name": "OL"
+            },
+            "modulestream_maps": [
+                {
+                    "in_modulestream": {
+                        "name": "python39-devel",
+                        "stream": "3.9"
+                    },
+                    "out_modulestream": {
+                        "name": "python39-devel",
+                        "stream": "3.9"
+                    }
+                }
+            ],
+            "out_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "python39-devel",
+                                "stream": "3.9"
+                            }
+                        ],
+                        "name": "python39-pybind11",
+                        "repository": "ol8-crb"
+                    }
+                ],
+                "set_id": 23991
+            },
+            "release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "OL"
+            }
+        },
+        {
+            "action": 6,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17439,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "python39-devel",
+                                "stream": "3.9"
+                            }
+                        ],
+                        "name": "python39-pybind11-devel",
+                        "repository": "ol8-appstream"
+                    }
+                ],
+                "set_id": 23992
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 9,
+                "os_name": "OL"
+            },
+            "modulestream_maps": [
+                {
+                    "in_modulestream": {
+                        "name": "python39-devel",
+                        "stream": "3.9"
+                    },
+                    "out_modulestream": {
+                        "name": "python39-devel",
+                        "stream": "3.9"
+                    }
+                }
+            ],
+            "out_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "python39-devel",
+                                "stream": "3.9"
+                            }
+                        ],
+                        "name": "python39-pybind11-devel",
+                        "repository": "ol8-crb"
+                    }
+                ],
+                "set_id": 23993
+            },
+            "release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "OL"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17480,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "libraw1394",
+                        "repository": "ol8-appstream"
+                    }
+                ],
+                "set_id": 24045
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 9,
+                "os_name": "OL"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "OL"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17481,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "cdrdao",
+                        "repository": "ol8-appstream"
+                    }
+                ],
+                "set_id": 24046
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 9,
+                "os_name": "OL"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "OL"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17587,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "rust-std-static-wasm32-wasi",
+                        "repository": "ol8-appstream"
+                    }
+                ],
+                "set_id": 24157
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 9,
+                "os_name": "OL"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "OL"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17602,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "nodejs",
+                                "stream": "22"
+                            }
+                        ],
+                        "name": "nodejs",
+                        "repository": "ol8-appstream"
+                    }
+                ],
+                "set_id": 24174
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 9,
+                "os_name": "OL"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "OL"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17603,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "nodejs",
+                                "stream": "22"
+                            }
+                        ],
+                        "name": "nodejs-devel",
+                        "repository": "ol8-appstream"
+                    }
+                ],
+                "set_id": 24175
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 9,
+                "os_name": "OL"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "OL"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17604,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "nodejs",
+                                "stream": "22"
+                            }
+                        ],
+                        "name": "nodejs-docs",
+                        "repository": "ol8-appstream"
+                    }
+                ],
+                "set_id": 24176
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 9,
+                "os_name": "OL"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "OL"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17605,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "nodejs",
+                                "stream": "22"
+                            }
+                        ],
+                        "name": "nodejs-full-i18n",
+                        "repository": "ol8-appstream"
+                    }
+                ],
+                "set_id": 24177
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 9,
+                "os_name": "OL"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "OL"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17606,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "nodejs",
+                                "stream": "22"
+                            }
+                        ],
+                        "name": "nodejs-libs",
+                        "repository": "ol8-appstream"
+                    }
+                ],
+                "set_id": 24178
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 9,
+                "os_name": "OL"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "OL"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17607,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "nodejs",
+                                "stream": "22"
+                            }
+                        ],
+                        "name": "nodejs-nodemon",
+                        "repository": "ol8-appstream"
+                    }
+                ],
+                "set_id": 24179
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 9,
+                "os_name": "OL"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "OL"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17608,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "nodejs",
+                                "stream": "22"
+                            }
+                        ],
+                        "name": "nodejs-packaging",
+                        "repository": "ol8-appstream"
+                    }
+                ],
+                "set_id": 24180
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 9,
+                "os_name": "OL"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "OL"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17609,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "nodejs",
+                                "stream": "22"
+                            }
+                        ],
+                        "name": "nodejs-packaging-bundler",
+                        "repository": "ol8-appstream"
+                    }
+                ],
+                "set_id": 24181
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 9,
+                "os_name": "OL"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "OL"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17610,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "nodejs",
+                                "stream": "22"
+                            }
+                        ],
+                        "name": "npm",
+                        "repository": "ol8-appstream"
+                    }
+                ],
+                "set_id": 24182
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 9,
+                "os_name": "OL"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "OL"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17611,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "nodejs",
+                                "stream": "22"
+                            }
+                        ],
+                        "name": "v8-12.4-devel",
+                        "repository": "ol8-appstream"
+                    }
+                ],
+                "set_id": 24183
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 9,
+                "os_name": "OL"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "OL"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17614,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "leapp",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24187
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "OL"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 0,
+                "os_name": "OL"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17615,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "leapp-deps",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24188
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "OL"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 0,
+                "os_name": "OL"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17616,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "python3-leapp",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24189
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "OL"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 0,
+                "os_name": "OL"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17617,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "snactor",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24190
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "OL"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 0,
+                "os_name": "OL"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17618,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "leapp-upgrade-el8toel9",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24191
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "OL"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 0,
+                "os_name": "OL"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17619,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "leapp-upgrade-el8toel9-deps",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24192
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "OL"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 0,
+                "os_name": "OL"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17620,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "cockpit-leapp",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24193
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "OL"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 0,
+                "os_name": "OL"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17630,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "pidgin-sipe",
+                        "repository": "ol8-appstream"
+                    }
+                ],
+                "set_id": 24205
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 9,
+                "os_name": "OL"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "OL"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17631,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "pidgin",
+                        "repository": "ol8-appstream"
+                    }
+                ],
+                "set_id": 24206
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 9,
+                "os_name": "OL"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "OL"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17632,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "gtkspell",
+                        "repository": "ol8-appstream"
+                    }
+                ],
+                "set_id": 24207
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 9,
+                "os_name": "OL"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "OL"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17633,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "gvfs-afc",
+                        "repository": "ol8-appstream"
+                    }
+                ],
+                "set_id": 24208
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 9,
+                "os_name": "OL"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "OL"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17634,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "dleyna-renderer",
+                        "repository": "ol8-appstream"
+                    }
+                ],
+                "set_id": 24209
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 9,
+                "os_name": "OL"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "OL"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17635,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "dleyna-server",
+                        "repository": "ol8-appstream"
+                    }
+                ],
+                "set_id": 24210
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 9,
+                "os_name": "OL"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "OL"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17636,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "dleyna-connector-dbus",
+                        "repository": "ol8-appstream"
+                    }
+                ],
+                "set_id": 24211
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 9,
+                "os_name": "OL"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "OL"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "x86_64"
+            ],
+            "id": 17679,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "gnome-boxes",
+                        "repository": "ol8-appstream"
+                    }
+                ],
+                "set_id": 24254
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 9,
+                "os_name": "OL"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "OL"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17680,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "dleyna-core",
+                        "repository": "ol8-appstream"
+                    }
+                ],
+                "set_id": 24255
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 9,
+                "os_name": "OL"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "OL"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17681,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "redhat-menus",
+                        "repository": "ol8-appstream"
+                    }
+                ],
+                "set_id": 24256
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 9,
+                "os_name": "OL"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "OL"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "x86_64"
+            ],
+            "id": 17682,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "dbxtool",
+                        "repository": "ol8-baseos"
+                    }
+                ],
+                "set_id": 24257
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 9,
+                "os_name": "OL"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "OL"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17683,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "gnome-online-miners",
+                        "repository": "ol8-appstream"
+                    }
+                ],
+                "set_id": 24258
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 9,
+                "os_name": "OL"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "OL"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17684,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "gfbgraph",
+                        "repository": "ol8-appstream"
+                    }
+                ],
+                "set_id": 24259
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 9,
+                "os_name": "OL"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "OL"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17685,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "webkitgtk3",
+                        "repository": "base"
+                    }
+                ],
+                "set_id": 24260
+            },
+            "initial_release": {
+                "major_version": 7,
+                "minor_version": 8,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 7,
+                "minor_version": 9,
+                "os_name": "CentOS"
+            }
+        },
+        {
             "action": 3,
             "architectures": [
                 "x86_64",
@@ -384428,7 +385565,7 @@
                 "ppc64le",
                 "s390x"
             ],
-            "id": 17283,
+            "id": 17686,
             "in_packageset": {
                 "package": [
                     {
@@ -384439,7 +385576,7 @@
                         "repository": "base"
                     }
                 ],
-                "set_id": 23603
+                "set_id": 24262
             },
             "initial_release": {
                 "major_version": 7,
@@ -384464,7 +385601,7 @@
                         "repository": "ol8-baseos"
                     }
                 ],
-                "set_id": 23602
+                "set_id": 24261
             },
             "release": {
                 "major_version": 8,
@@ -384482,7 +385619,7 @@
                 "ppc64le",
                 "s390x"
             ],
-            "id": 17284,
+            "id": 17687,
             "in_packageset": {
                 "package": [
                     {
@@ -384493,7 +385630,7 @@
                         "repository": "base"
                     }
                 ],
-                "set_id": 23604
+                "set_id": 24263
             },
             "initial_release": {
                 "major_version": 7,
@@ -384516,7 +385653,7 @@
                 "ppc64le",
                 "s390x"
             ],
-            "id": 17285,
+            "id": 17688,
             "in_packageset": {
                 "package": [
                     {
@@ -384527,7 +385664,7 @@
                         "repository": "base"
                     }
                 ],
-                "set_id": 23606
+                "set_id": 24265
             },
             "initial_release": {
                 "major_version": 7,
@@ -384552,7 +385689,7 @@
                         "repository": "ol8-baseos"
                     }
                 ],
-                "set_id": 23605
+                "set_id": 24264
             },
             "release": {
                 "major_version": 8,
@@ -384570,7 +385707,7 @@
                 "ppc64le",
                 "s390x"
             ],
-            "id": 17286,
+            "id": 17689,
             "in_packageset": {
                 "package": [
                     {
@@ -384581,7 +385718,7 @@
                         "repository": "base"
                     }
                 ],
-                "set_id": 23608
+                "set_id": 24267
             },
             "initial_release": {
                 "major_version": 7,
@@ -384606,7 +385743,7 @@
                         "repository": "ol8-baseos"
                     }
                 ],
-                "set_id": 23607
+                "set_id": 24266
             },
             "release": {
                 "major_version": 8,
@@ -384624,7 +385761,7 @@
                 "ppc64le",
                 "s390x"
             ],
-            "id": 17287,
+            "id": 17690,
             "in_packageset": {
                 "package": [
                     {
@@ -384635,7 +385772,7 @@
                         "repository": "base"
                     }
                 ],
-                "set_id": 23610
+                "set_id": 24269
             },
             "initial_release": {
                 "major_version": 7,
@@ -384660,7 +385797,7 @@
                         "repository": "ol8-baseos"
                     }
                 ],
-                "set_id": 23609
+                "set_id": 24268
             },
             "release": {
                 "major_version": 8,
@@ -384678,7 +385815,7 @@
                 "ppc64le",
                 "s390x"
             ],
-            "id": 17288,
+            "id": 17691,
             "in_packageset": {
                 "package": [
                     {
@@ -384689,7 +385826,7 @@
                         "repository": "powertools"
                     }
                 ],
-                "set_id": 23611
+                "set_id": 24270
             },
             "initial_release": {
                 "major_version": 8,
@@ -384721,7 +385858,7 @@
                 "ppc64le",
                 "s390x"
             ],
-            "id": 17289,
+            "id": 17692,
             "in_packageset": {
                 "package": [
                     {
@@ -384732,7 +385869,7 @@
                         "repository": "ol8_appstream"
                     }
                 ],
-                "set_id": 23612
+                "set_id": 24271
             },
             "initial_release": {
                 "major_version": 8,
@@ -384764,7 +385901,7 @@
                 "ppc64le",
                 "s390x"
             ],
-            "id": 17290,
+            "id": 17693,
             "in_packageset": {
                 "package": [
                     {
@@ -384775,7 +385912,7 @@
                         "repository": "ol8_appstream"
                     }
                 ],
-                "set_id": 23613
+                "set_id": 24272
             },
             "initial_release": {
                 "major_version": 8,
@@ -384807,7 +385944,7 @@
                 "ppc64le",
                 "s390x"
             ],
-            "id": 17291,
+            "id": 17694,
             "in_packageset": {
                 "package": [
                     {
@@ -384818,7 +385955,7 @@
                         "repository": "ol8_baseos_latest"
                     }
                 ],
-                "set_id": 23614
+                "set_id": 24273
             },
             "initial_release": {
                 "major_version": 8,
@@ -384850,7 +385987,7 @@
                 "ppc64le",
                 "s390x"
             ],
-            "id": 17292,
+            "id": 17695,
             "in_packageset": {
                 "package": [
                     {
@@ -384861,7 +385998,7 @@
                         "repository": "ol8_appstream"
                     }
                 ],
-                "set_id": 23615
+                "set_id": 24274
             },
             "initial_release": {
                 "major_version": 8,
@@ -384893,7 +386030,7 @@
                 "ppc64le",
                 "s390x"
             ],
-            "id": 17293,
+            "id": 17696,
             "in_packageset": {
                 "package": [
                     {
@@ -384904,7 +386041,7 @@
                         "repository": "ol8_appstream"
                     }
                 ],
-                "set_id": 23616
+                "set_id": 24275
             },
             "initial_release": {
                 "major_version": 8,
@@ -384936,7 +386073,7 @@
                 "ppc64le",
                 "s390x"
             ],
-            "id": 17294,
+            "id": 17697,
             "in_packageset": {
                 "package": [
                     {
@@ -384947,7 +386084,7 @@
                         "repository": "ol8_baseos_latest"
                     }
                 ],
-                "set_id": 23617
+                "set_id": 24276
             },
             "initial_release": {
                 "major_version": 8,
@@ -384979,7 +386116,7 @@
                 "ppc64le",
                 "s390x"
             ],
-            "id": 17295,
+            "id": 17698,
             "in_packageset": {
                 "package": [
                     {
@@ -384990,7 +386127,7 @@
                         "repository": "ol8_baseos_latest"
                     }
                 ],
-                "set_id": 23618
+                "set_id": 24277
             },
             "initial_release": {
                 "major_version": 8,
@@ -385022,7 +386159,7 @@
                 "ppc64le",
                 "s390x"
             ],
-            "id": 17296,
+            "id": 17699,
             "in_packageset": {
                 "package": [
                     {
@@ -385033,7 +386170,7 @@
                         "repository": "ol8_appstream"
                     }
                 ],
-                "set_id": 23619
+                "set_id": 24278
             },
             "initial_release": {
                 "major_version": 8,
@@ -385065,7 +386202,7 @@
                 "ppc64le",
                 "s390x"
             ],
-            "id": 17297,
+            "id": 17700,
             "in_packageset": {
                 "package": [
                     {
@@ -385076,7 +386213,7 @@
                         "repository": "ol8_appstream"
                     }
                 ],
-                "set_id": 23620
+                "set_id": 24279
             },
             "initial_release": {
                 "major_version": 8,
@@ -385108,7 +386245,7 @@
                 "ppc64le",
                 "s390x"
             ],
-            "id": 17298,
+            "id": 17701,
             "in_packageset": {
                 "package": [
                     {
@@ -385119,7 +386256,7 @@
                         "repository": "ol8_appstream"
                     }
                 ],
-                "set_id": 23621
+                "set_id": 24280
             },
             "initial_release": {
                 "major_version": 8,
@@ -385151,7 +386288,7 @@
                 "ppc64le",
                 "s390x"
             ],
-            "id": 17299,
+            "id": 17702,
             "in_packageset": {
                 "package": [
                     {
@@ -385162,7 +386299,7 @@
                         "repository": "ol8_appstream"
                     }
                 ],
-                "set_id": 23622
+                "set_id": 24281
             },
             "initial_release": {
                 "major_version": 8,
@@ -385194,7 +386331,7 @@
                 "ppc64le",
                 "s390x"
             ],
-            "id": 17300,
+            "id": 17703,
             "in_packageset": {
                 "package": [
                     {
@@ -385205,7 +386342,7 @@
                         "repository": "ol8_appstream"
                     }
                 ],
-                "set_id": 23623
+                "set_id": 24282
             },
             "initial_release": {
                 "major_version": 8,
@@ -385237,7 +386374,7 @@
                 "ppc64le",
                 "s390x"
             ],
-            "id": 17301,
+            "id": 17704,
             "in_packageset": {
                 "package": [
                     {
@@ -385248,7 +386385,7 @@
                         "repository": "ol8_appstream"
                     }
                 ],
-                "set_id": 23624
+                "set_id": 24283
             },
             "initial_release": {
                 "major_version": 8,
@@ -385280,7 +386417,7 @@
                 "ppc64le",
                 "s390x"
             ],
-            "id": 17302,
+            "id": 17705,
             "in_packageset": {
                 "package": [
                     {
@@ -385291,7 +386428,7 @@
                         "repository": "ol8_appstream"
                     }
                 ],
-                "set_id": 23625
+                "set_id": 24284
             },
             "initial_release": {
                 "major_version": 8,
@@ -385323,7 +386460,7 @@
                 "ppc64le",
                 "s390x"
             ],
-            "id": 17303,
+            "id": 17706,
             "in_packageset": {
                 "package": [
                     {
@@ -385334,7 +386471,7 @@
                         "repository": "ol8_appstream"
                     }
                 ],
-                "set_id": 23626
+                "set_id": 24285
             },
             "initial_release": {
                 "major_version": 8,

--- a/files/rocky/config.json
+++ b/files/rocky/config.json
@@ -301,6 +301,31 @@
             "name": "redhat-cloud-client-configuration",
             "initial_release": 8,
             "target_release": 9
+        },
+        {
+            "name": "libreport-rhel-anaconda-bugzilla",
+            "initial_release": 9,
+            "target_release": 9
+        },
+        {
+            "name": "libreport-rhel-anaconda-bugzilla",
+            "initial_release": 9,
+            "target_release": 10
+        },
+        {
+            "name": "redhat-flatpak-preinstall-firefox",
+            "initial_release": 9,
+            "target_release": 10
+        },
+        {
+            "name": "redhat-flatpak-preinstall-thunderbird",
+            "initial_release": 9,
+            "target_release": 10
+        },
+        {
+            "name": "redhat-flatpak-repo",
+            "initial_release": 9,
+            "target_release": 10
         }
     ],
 

--- a/files/rocky/device_driver_deprecation_data.json
+++ b/files/rocky/device_driver_deprecation_data.json
@@ -1557,7 +1557,7 @@
       "device_id": "",
       "device_name": "",
       "device_type": "pci",
-      "driver_name": "3w-9xxx",
+      "driver_name": "3w_9xxx",
       "maintained_in_rhel": []
     },
     {
@@ -1568,7 +1568,7 @@
       "device_id": "",
       "device_name": "",
       "device_type": "pci",
-      "driver_name": "3w-sas",
+      "driver_name": "3w_sas",
       "maintained_in_rhel": []
     },
     {
@@ -2429,7 +2429,7 @@
       "device_id": "",
       "device_name": "",
       "device_type": "pci",
-      "driver_name": "acard-ahci",
+      "driver_name": "acard_ahci",
       "maintained_in_rhel": []
     },
     {
@@ -2444,6 +2444,42 @@
       "device_name": "PF_KEY sockets",
       "device_type": "pci",
       "driver_name": "af_key",
+      "maintained_in_rhel": [
+        7,
+        8,
+        9
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7,
+        8,
+        9,
+        10
+      ],
+      "deprecation_announced": "",
+      "device_id": "",
+      "device_name": "Seattle AHCI SATA platform driver",
+      "device_type": "pci",
+      "driver_name": "ahci_seattle",
+      "maintained_in_rhel": [
+        7,
+        8,
+        9
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7,
+        8,
+        9,
+        10
+      ],
+      "deprecation_announced": "",
+      "device_id": "",
+      "device_name": "APM X-Gene AHCI SATA driver",
+      "device_type": "pci",
+      "driver_name": "ahci_xgene",
       "maintained_in_rhel": [
         7,
         8,
@@ -2891,7 +2927,7 @@
       "device_id": "",
       "device_name": "",
       "device_type": "pci",
-      "driver_name": "firewire-core",
+      "driver_name": "firewire_core",
       "maintained_in_rhel": [
         7,
         8,
@@ -2940,7 +2976,8 @@
       "available_in_rhel": [
         7,
         8,
-        9
+        9,
+        10
       ],
       "deprecation_announced": "",
       "device_id": "",
@@ -2949,7 +2986,27 @@
       "driver_name": "hfi1",
       "maintained_in_rhel": [
         7,
-        8
+        8,
+        9,
+        10
+      ]
+    },
+    {
+      "available_in_rhel": [
+        7,
+        8,
+        9,
+        10
+      ],
+      "deprecation_announced": "",
+      "device_id": "",
+      "device_name": "HISILICON SAS controller driver",
+      "device_type": "pci",
+      "driver_name": "hisi_sas_main",
+      "maintained_in_rhel": [
+        7,
+        8,
+        9
       ]
     },
     {
@@ -4265,6 +4322,30 @@
     },
     {
       "available_in_rhel": [
+        9,
+        10
+      ],
+      "deprecation_announced": "",
+      "device_id": "0x15B3:0x1023",
+      "device_name": "ConnectX-8",
+      "device_type": "pci",
+      "driver_name": "mlx5",
+      "maintained_in_rhel": [
+        9,
+        10
+      ]
+    },
+    {
+      "available_in_rhel": [],
+      "deprecation_announced": "",
+      "device_id": "0x15B3:0x1025",
+      "device_name": "ConnectX-9",
+      "device_type": "pci",
+      "driver_name": "mlx5",
+      "maintained_in_rhel": []
+    },
+    {
+      "available_in_rhel": [
         7,
         8,
         9,
@@ -4276,7 +4357,9 @@
       "device_type": "pci",
       "driver_name": "mlx5",
       "maintained_in_rhel": [
-        7
+        7,
+        9,
+        10
       ]
     },
     {
@@ -4828,7 +4911,7 @@
       "device_id": "",
       "device_name": "",
       "device_type": "pci",
-      "driver_name": "nvmet-fc",
+      "driver_name": "nvmet_fc",
       "maintained_in_rhel": [
         7
       ]
@@ -4844,7 +4927,7 @@
       "device_id": "",
       "device_name": "",
       "device_type": "pci",
-      "driver_name": "nvmet-tcp",
+      "driver_name": "nvmet_tcp",
       "maintained_in_rhel": [
         7
       ]

--- a/files/rocky/pes-events.json
+++ b/files/rocky/pes-events.json
@@ -1,5 +1,5 @@
 {
-    "timestamp": "202411121506Z",
+    "timestamp": "202502132105Z",
     "provided_data_streams": [
         "3.0",
         "3.1",
@@ -10024,7 +10024,14 @@
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "postgresql",
+                                "stream": "10"
+                            },
+                            {
+                                "name": "postgresql",
+                                "stream": "9.6"
+                            }
                         ],
                         "name": "postgresql-test-rpm-macros",
                         "repository": "rocky8-appstream"
@@ -10032,7 +10039,11 @@
                 ],
                 "set_id": 391
             },
-            "initial_release": null,
+            "initial_release": {
+                "major_version": 7,
+                "minor_version": 9,
+                "os_name": "CentOS"
+            },
             "modulestream_maps": [],
             "out_packageset": null,
             "release": {
@@ -10782,7 +10793,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -10818,7 +10828,7 @@
                             null
                         ],
                         "name": "libjpeg-turbo-utils",
-                        "repository": "rocky8-baseos"
+                        "repository": "rocky8-appstream"
                     }
                 ],
                 "set_id": 432
@@ -10981,9 +10991,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 337,
@@ -65010,7 +65017,6 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -65044,7 +65050,6 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -65078,7 +65083,6 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -65112,7 +65116,6 @@
         {
             "action": 7,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -65260,9 +65263,6 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 1645,
@@ -65294,9 +65294,6 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 1646,
@@ -65328,9 +65325,6 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 1647,
@@ -65362,9 +65356,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 1648,
@@ -65398,7 +65389,7 @@
                             null
                         ],
                         "name": "libappindicator-gtk3-devel",
-                        "repository": "rocky8-appstream"
+                        "repository": "rocky8-powertools"
                     }
                 ],
                 "set_id": 5296
@@ -65412,9 +65403,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 1649,
@@ -65448,7 +65436,7 @@
                             null
                         ],
                         "name": "libdbusmenu-devel",
-                        "repository": "rocky8-appstream"
+                        "repository": "rocky8-powertools"
                     }
                 ],
                 "set_id": 5298
@@ -65462,9 +65450,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 1650,
@@ -65512,9 +65497,6 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 1651,
@@ -65546,9 +65528,6 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 1652,
@@ -65580,9 +65559,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 1653,
@@ -65630,9 +65606,6 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 1654,
@@ -65664,9 +65637,6 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 1655,
@@ -65698,9 +65668,6 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 1656,
@@ -65732,9 +65699,6 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 1657,
@@ -65766,9 +65730,6 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 1658,
@@ -65800,9 +65761,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 1659,
@@ -65850,9 +65808,6 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 1660,
@@ -65884,9 +65839,6 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 1661,
@@ -71210,7 +71162,6 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -71230,7 +71181,7 @@
             },
             "initial_release": {
                 "major_version": 7,
-                "minor_version": 7,
+                "minor_version": 9,
                 "os_name": "CentOS"
             },
             "modulestream_maps": [],
@@ -71362,9 +71313,6 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 2136,
@@ -71382,7 +71330,7 @@
             },
             "initial_release": {
                 "major_version": 7,
-                "minor_version": 7,
+                "minor_version": 9,
                 "os_name": "CentOS"
             },
             "modulestream_maps": [],
@@ -83317,7 +83265,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -83353,7 +83300,7 @@
                             null
                         ],
                         "name": "dovecot-devel",
-                        "repository": "rocky8-appstream"
+                        "repository": "rocky8-powertools"
                     }
                 ],
                 "set_id": 3995
@@ -83553,7 +83500,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -83589,7 +83535,7 @@
                             null
                         ],
                         "name": "gpgme-devel",
-                        "repository": "rocky8-baseos"
+                        "repository": "rocky8-powertools"
                     }
                 ],
                 "set_id": 4007
@@ -85433,7 +85379,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -85469,7 +85414,7 @@
                             null
                         ],
                         "name": "uuid-devel",
-                        "repository": "rocky8-appstream"
+                        "repository": "rocky8-powertools"
                     }
                 ],
                 "set_id": 4097
@@ -115861,9 +115806,7 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 3208,
@@ -115897,7 +115840,7 @@
                             null
                         ],
                         "name": "devhelp-devel",
-                        "repository": "rocky8-appstream"
+                        "repository": "rocky8-powertools"
                     }
                 ],
                 "set_id": 5300
@@ -115911,9 +115854,6 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 3209,
@@ -115945,9 +115885,7 @@
         {
             "action": 7,
             "architectures": [
-                "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 3210,
@@ -115995,7 +115933,6 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -116029,7 +115966,6 @@
         {
             "action": 7,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -116079,9 +116015,7 @@
         {
             "action": 7,
             "architectures": [
-                "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 3213,
@@ -116129,7 +116063,6 @@
         {
             "action": 7,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -116179,9 +116112,7 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 3215,
@@ -116215,7 +116146,7 @@
                             null
                         ],
                         "name": "yelp-devel",
-                        "repository": "rocky8-appstream"
+                        "repository": "rocky8-powertools"
                     }
                 ],
                 "set_id": 5313
@@ -116229,7 +116160,6 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -242213,40 +242143,6 @@
                 "s390x",
                 "x86_64"
             ],
-            "id": 6711,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "librsvg-tools",
-                        "repository": "rocky8-baseos"
-                    }
-                ],
-                "set_id": 10196
-            },
-            "initial_release": {
-                "major_version": 8,
-                "minor_version": 0,
-                "os_name": "Rocky"
-            },
-            "modulestream_maps": [],
-            "out_packageset": null,
-            "release": {
-                "major_version": 8,
-                "minor_version": 1,
-                "os_name": "Rocky"
-            }
-        },
-        {
-            "action": 0,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
             "id": 6712,
             "in_packageset": {
                 "package": [
@@ -242833,7 +242729,7 @@
                             null
                         ],
                         "name": "dovecot-pigeonhole",
-                        "repository": "rocky8-baseos"
+                        "repository": "rocky8-appstream"
                     }
                 ],
                 "set_id": 10219
@@ -242866,7 +242762,7 @@
                         "modulestreams": [
                             null
                         ],
-                        "name": "libxkbfile-1.1.0-1.el8",
+                        "name": "libxkbfile",
                         "repository": "rocky8-appstream"
                     }
                 ],
@@ -243036,7 +242932,7 @@
                         "modulestreams": [
                             null
                         ],
-                        "name": "pipewire0.2",
+                        "name": "pipewire0.2-libs",
                         "repository": "rocky8-appstream"
                     }
                 ],
@@ -248787,9 +248683,7 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 6935,
@@ -248856,8 +248750,6 @@
             "action": 1,
             "architectures": [
                 "aarch64",
-                "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 6937,
@@ -248926,9 +248818,7 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 6940,
@@ -248994,9 +248884,7 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 6942,
@@ -249376,7 +249264,6 @@
             "architectures": [
                 "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 6953,
@@ -249387,7 +249274,7 @@
                             null
                         ],
                         "name": "libraw1394",
-                        "repository": "baseos"
+                        "repository": "appstream"
                     }
                 ],
                 "set_id": 10540
@@ -256478,7 +256365,7 @@
                             null
                         ],
                         "name": "jakarta-mail",
-                        "repository": "rocky9-crb"
+                        "repository": "rocky9-appstream"
                     }
                 ],
                 "set_id": 10706
@@ -272478,7 +272365,6 @@
             "architectures": [
                 "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 7739,
@@ -272512,7 +272398,6 @@
             "architectures": [
                 "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 7740,
@@ -314698,56 +314583,6 @@
                 "s390x",
                 "x86_64"
             ],
-            "id": 8982,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "python3-gobject-base",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 12693
-            },
-            "initial_release": {
-                "major_version": 8,
-                "minor_version": 6,
-                "os_name": "Rocky"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "python3-gobject-base",
-                        "repository": "rocky9-crb"
-                    }
-                ],
-                "set_id": 12694
-            },
-            "release": {
-                "major_version": 9,
-                "minor_version": 0,
-                "os_name": "Rocky"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
             "id": 8983,
             "in_packageset": {
                 "package": [
@@ -315419,9 +315254,7 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 9001,
@@ -315453,9 +315286,7 @@
         {
             "action": 2,
             "architectures": [
-                "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 9002,
@@ -315623,9 +315454,7 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 9008,
@@ -315657,9 +315486,7 @@
         {
             "action": 2,
             "architectures": [
-                "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 9009,
@@ -315691,9 +315518,7 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 9010,
@@ -315725,9 +315550,7 @@
         {
             "action": 2,
             "architectures": [
-                "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 9011,
@@ -315759,9 +315582,7 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 9012,
@@ -315793,9 +315614,7 @@
         {
             "action": 2,
             "architectures": [
-                "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 9013,
@@ -316033,7 +315852,6 @@
             "architectures": [
                 "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 9020,
@@ -316067,7 +315885,6 @@
             "architectures": [
                 "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 9021,
@@ -316711,9 +316528,7 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 9040,
@@ -316745,9 +316560,7 @@
         {
             "action": 2,
             "architectures": [
-                "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 9041,
@@ -316779,9 +316592,7 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 9042,
@@ -316813,9 +316624,7 @@
         {
             "action": 2,
             "architectures": [
-                "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 9043,
@@ -317425,9 +317234,7 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 9062,
@@ -317438,7 +317245,7 @@
                             null
                         ],
                         "name": "gtkspell",
-                        "repository": "powertools"
+                        "repository": "appstream"
                     }
                 ],
                 "set_id": 12745
@@ -317799,9 +317606,7 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 9073,
@@ -317918,40 +317723,6 @@
                     }
                 ],
                 "set_id": 12761
-            },
-            "initial_release": {
-                "major_version": 8,
-                "minor_version": 6,
-                "os_name": "Rocky"
-            },
-            "modulestream_maps": [],
-            "out_packageset": null,
-            "release": {
-                "major_version": 9,
-                "minor_version": 0,
-                "os_name": "Rocky"
-            }
-        },
-        {
-            "action": 1,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 9078,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "libmtp-devel",
-                        "repository": "powertools"
-                    }
-                ],
-                "set_id": 12762
             },
             "initial_release": {
                 "major_version": 8,
@@ -319413,9 +319184,7 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 9136,
@@ -319426,7 +319195,7 @@
                             null
                         ],
                         "name": "file-roller-nautilus",
-                        "repository": "base"
+                        "repository": "rocky8-appstream"
                     }
                 ],
                 "set_id": 12804
@@ -319493,7 +319262,7 @@
                             null
                         ],
                         "name": "tigervnc-server-applet",
-                        "repository": "base"
+                        "repository": "rocky8-appstream"
                     }
                 ],
                 "set_id": 12805
@@ -319514,7 +319283,6 @@
         {
             "action": 2,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -319550,7 +319318,6 @@
             "architectures": [
                 "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 9140,
@@ -319561,7 +319328,7 @@
                             null
                         ],
                         "name": "gnome-software-editor",
-                        "repository": "base"
+                        "repository": "rocky8-appstream"
                     }
                 ],
                 "set_id": 12806
@@ -319615,9 +319382,6 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 9142,
@@ -319649,9 +319413,6 @@
         {
             "action": 2,
             "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 9143,
@@ -319683,9 +319444,7 @@
         {
             "action": 1,
             "architectures": [
-                "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 9144,
@@ -319696,7 +319455,7 @@
                             null
                         ],
                         "name": "gnome-shell-extension-alternate-tab",
-                        "repository": "base"
+                        "repository": "rocky8-appstream"
                     }
                 ],
                 "set_id": 12808
@@ -319717,7 +319476,6 @@
         {
             "action": 2,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -371842,43 +371600,6 @@
                 "s390x",
                 "x86_64"
             ],
-            "id": 10577,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            {
-                                "name": "javapackages-tools",
-                                "stream": "201801"
-                            }
-                        ],
-                        "name": "antlr-C++",
-                        "repository": "powertools"
-                    }
-                ],
-                "set_id": 14621
-            },
-            "initial_release": {
-                "major_version": 8,
-                "minor_version": 6,
-                "os_name": "Rocky"
-            },
-            "modulestream_maps": [],
-            "out_packageset": null,
-            "release": {
-                "major_version": 9,
-                "minor_version": 0,
-                "os_name": "Rocky"
-            }
-        },
-        {
-            "action": 1,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
             "id": 10578,
             "in_packageset": {
                 "package": [
@@ -382132,7 +381853,7 @@
             }
         },
         {
-            "action": 1,
+            "action": 6,
             "architectures": [
                 "aarch64",
                 "ppc64le",
@@ -382160,8 +381881,27 @@
                 "minor_version": 6,
                 "os_name": "Rocky"
             },
-            "modulestream_maps": [],
-            "out_packageset": null,
+            "modulestream_maps": [
+                {
+                    "in_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    },
+                    "out_modulestream": null
+                }
+            ],
+            "out_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "plexus-containers-container-default",
+                        "repository": "rocky9-crb"
+                    }
+                ],
+                "set_id": 23983
+            },
             "release": {
                 "major_version": 9,
                 "minor_version": 0,
@@ -439750,7 +439490,7 @@
             },
             "initial_release": {
                 "major_version": 8,
-                "minor_version": 1,
+                "minor_version": 10,
                 "os_name": "Rocky"
             },
             "modulestream_maps": [],
@@ -439791,14 +439531,14 @@
             },
             "initial_release": {
                 "major_version": 8,
-                "minor_version": 0,
+                "minor_version": 9,
                 "os_name": "Rocky"
             },
             "modulestream_maps": [],
             "out_packageset": null,
             "release": {
                 "major_version": 8,
-                "minor_version": 1,
+                "minor_version": 10,
                 "os_name": "Rocky"
             }
         },
@@ -512063,43 +511803,6 @@
             }
         },
         {
-            "action": 1,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 14345,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            {
-                                "name": "nodejs",
-                                "stream": "18"
-                            }
-                        ],
-                        "name": "nodejs",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 20190
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 5,
-                "os_name": "Rocky"
-            },
-            "modulestream_maps": [],
-            "out_packageset": null,
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "Rocky"
-            }
-        },
-        {
             "action": 6,
             "architectures": [
                 "aarch64",
@@ -512112,6 +511815,10 @@
                 "package": [
                     {
                         "modulestreams": [
+                            {
+                                "name": "nodejs",
+                                "stream": "18"
+                            },
                             {
                                 "name": "nodejs",
                                 "stream": "20"
@@ -512144,6 +511851,13 @@
                     "in_modulestream": {
                         "name": "nodejs",
                         "stream": "22"
+                    },
+                    "out_modulestream": null
+                },
+                {
+                    "in_modulestream": {
+                        "name": "nodejs",
+                        "stream": "18"
                     },
                     "out_modulestream": null
                 }
@@ -536509,7 +536223,7 @@
             }
         },
         {
-            "action": 6,
+            "action": 4,
             "architectures": [
                 "aarch64",
                 "ppc64le",
@@ -536553,6 +536267,13 @@
                             null
                         ],
                         "name": "mariadb",
+                        "repository": "rocky10-appstream"
+                    },
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "mariadb-client-utils",
                         "repository": "rocky10-appstream"
                     }
                 ],
@@ -537069,7 +536790,7 @@
             }
         },
         {
-            "action": 6,
+            "action": 7,
             "architectures": [
                 "aarch64",
                 "ppc64le",
@@ -537106,7 +536827,7 @@
                         "modulestreams": [
                             null
                         ],
-                        "name": "mysql-libs",
+                        "name": "mysql8.4-libs",
                         "repository": "rocky10-appstream"
                     }
                 ],
@@ -558676,9 +558397,7 @@
         {
             "action": 2,
             "architectures": [
-                "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 15647,
@@ -558912,9 +558631,7 @@
         {
             "action": 2,
             "architectures": [
-                "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 15654,
@@ -559794,9 +559511,7 @@
         {
             "action": 2,
             "architectures": [
-                "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 15680,
@@ -559860,9 +559575,7 @@
         {
             "action": 2,
             "architectures": [
-                "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 15682,
@@ -560776,9 +560489,7 @@
         {
             "action": 2,
             "architectures": [
-                "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 15709,
@@ -597068,7 +596779,7 @@
             }
         },
         {
-            "action": 1,
+            "action": 3,
             "architectures": [
                 "aarch64",
                 "ppc64le",
@@ -597093,8 +596804,24 @@
                 "minor_version": 5,
                 "os_name": "Rocky"
             },
-            "modulestream_maps": [],
-            "out_packageset": null,
+            "modulestream_maps": [
+                {
+                    "in_modulestream": null,
+                    "out_modulestream": null
+                }
+            ],
+            "out_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "papers",
+                        "repository": "rocky10-appstream"
+                    }
+                ],
+                "set_id": 24002
+            },
             "release": {
                 "major_version": 10,
                 "minor_version": 0,
@@ -597136,7 +596863,7 @@
             }
         },
         {
-            "action": 1,
+            "action": 3,
             "architectures": [
                 "aarch64",
                 "ppc64le",
@@ -597161,8 +596888,24 @@
                 "minor_version": 5,
                 "os_name": "Rocky"
             },
-            "modulestream_maps": [],
-            "out_packageset": null,
+            "modulestream_maps": [
+                {
+                    "in_modulestream": null,
+                    "out_modulestream": null
+                }
+            ],
+            "out_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "papers-libs",
+                        "repository": "rocky10-appstream"
+                    }
+                ],
+                "set_id": 24001
+            },
             "release": {
                 "major_version": 10,
                 "minor_version": 0,
@@ -597204,7 +596947,7 @@
             }
         },
         {
-            "action": 1,
+            "action": 3,
             "architectures": [
                 "aarch64",
                 "ppc64le",
@@ -597229,8 +596972,24 @@
                 "minor_version": 5,
                 "os_name": "Rocky"
             },
-            "modulestream_maps": [],
-            "out_packageset": null,
+            "modulestream_maps": [
+                {
+                    "in_modulestream": null,
+                    "out_modulestream": null
+                }
+            ],
+            "out_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "papers-nautilus",
+                        "repository": "rocky10-appstream"
+                    }
+                ],
+                "set_id": 24000
+            },
             "release": {
                 "major_version": 10,
                 "minor_version": 0,
@@ -597272,7 +597031,7 @@
             }
         },
         {
-            "action": 1,
+            "action": 3,
             "architectures": [
                 "aarch64",
                 "ppc64le",
@@ -597297,8 +597056,24 @@
                 "minor_version": 5,
                 "os_name": "Rocky"
             },
-            "modulestream_maps": [],
-            "out_packageset": null,
+            "modulestream_maps": [
+                {
+                    "in_modulestream": null,
+                    "out_modulestream": null
+                }
+            ],
+            "out_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "papers-previewer",
+                        "repository": "rocky10-appstream"
+                    }
+                ],
+                "set_id": 23999
+            },
             "release": {
                 "major_version": 10,
                 "minor_version": 0,
@@ -597340,7 +597115,7 @@
             }
         },
         {
-            "action": 1,
+            "action": 3,
             "architectures": [
                 "aarch64",
                 "ppc64le",
@@ -597365,8 +597140,24 @@
                 "minor_version": 5,
                 "os_name": "Rocky"
             },
-            "modulestream_maps": [],
-            "out_packageset": null,
+            "modulestream_maps": [
+                {
+                    "in_modulestream": null,
+                    "out_modulestream": null
+                }
+            ],
+            "out_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "papers-thumbnailer",
+                        "repository": "rocky10-appstream"
+                    }
+                ],
+                "set_id": 23998
+            },
             "release": {
                 "major_version": 10,
                 "minor_version": 0,
@@ -604454,14 +604245,14 @@
                         "modulestreams": [
                             null
                         ],
-                        "name": "mysql-test",
+                        "name": "mysql8.4-test",
                         "repository": "rocky10-crb"
                     },
                     {
                         "modulestreams": [
                             null
                         ],
-                        "name": "mysql-test-data",
+                        "name": "mysql8.4-test-data",
                         "repository": "rocky10-crb"
                     }
                 ],
@@ -611403,7 +611194,7 @@
             }
         },
         {
-            "action": 1,
+            "action": 7,
             "architectures": [
                 "aarch64",
                 "ppc64le",
@@ -611428,8 +611219,24 @@
                 "minor_version": 5,
                 "os_name": "Rocky"
             },
-            "modulestream_maps": [],
-            "out_packageset": null,
+            "modulestream_maps": [
+                {
+                    "in_modulestream": null,
+                    "out_modulestream": null
+                }
+            ],
+            "out_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "python-PyMySQL+rsa",
+                        "repository": "rocky10-crb"
+                    }
+                ],
+                "set_id": 24283
+            },
             "release": {
                 "major_version": 10,
                 "minor_version": 0,
@@ -614957,8 +614764,6 @@
             "action": 0,
             "architectures": [
                 "aarch64",
-                "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 17278,
@@ -618049,2856 +617854,6 @@
             }
         },
         {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17360,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-libs",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23847
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "Rocky"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-libs",
-                        "repository": "rocky10-baseos"
-                    }
-                ],
-                "set_id": 23848
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "Rocky"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17361,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-AutoLoader",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23849
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "Rocky"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-AutoLoader",
-                        "repository": "rocky10-baseos"
-                    }
-                ],
-                "set_id": 23850
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "Rocky"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17362,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-B",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23851
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "Rocky"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-B",
-                        "repository": "rocky10-baseos"
-                    }
-                ],
-                "set_id": 23852
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "Rocky"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17363,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Carp",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23853
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "Rocky"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Carp",
-                        "repository": "rocky10-baseos"
-                    }
-                ],
-                "set_id": 23854
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "Rocky"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17364,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Class-Struct",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23855
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "Rocky"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Class-Struct",
-                        "repository": "rocky10-baseos"
-                    }
-                ],
-                "set_id": 23856
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "Rocky"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17365,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Data-Dumper",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23857
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "Rocky"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Data-Dumper",
-                        "repository": "rocky10-baseos"
-                    }
-                ],
-                "set_id": 23858
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "Rocky"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17366,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Digest",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23859
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "Rocky"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Digest",
-                        "repository": "rocky10-baseos"
-                    }
-                ],
-                "set_id": 23860
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "Rocky"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17367,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Digest-MD5",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23861
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "Rocky"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Digest-MD5",
-                        "repository": "rocky10-baseos"
-                    }
-                ],
-                "set_id": 23862
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "Rocky"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17368,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-DynaLoader",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23863
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "Rocky"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-DynaLoader",
-                        "repository": "rocky10-baseos"
-                    }
-                ],
-                "set_id": 23864
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "Rocky"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17369,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Encode",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23865
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "Rocky"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Encode",
-                        "repository": "rocky10-baseos"
-                    }
-                ],
-                "set_id": 23866
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "Rocky"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17370,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Errno",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23867
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "Rocky"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Errno",
-                        "repository": "rocky10-baseos"
-                    }
-                ],
-                "set_id": 23868
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "Rocky"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17371,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Exporter",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23869
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "Rocky"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Exporter",
-                        "repository": "rocky10-baseos"
-                    }
-                ],
-                "set_id": 23870
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "Rocky"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17372,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Fcntl",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23871
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "Rocky"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Fcntl",
-                        "repository": "rocky10-baseos"
-                    }
-                ],
-                "set_id": 23872
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "Rocky"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17373,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-File-Basename",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23873
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "Rocky"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-File-Basename",
-                        "repository": "rocky10-baseos"
-                    }
-                ],
-                "set_id": 23874
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "Rocky"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17374,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-File-Path",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23875
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "Rocky"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-File-Path",
-                        "repository": "rocky10-baseos"
-                    }
-                ],
-                "set_id": 23876
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "Rocky"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17375,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-File-Temp",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23877
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "Rocky"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-File-Temp",
-                        "repository": "rocky10-baseos"
-                    }
-                ],
-                "set_id": 23878
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "Rocky"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17376,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-File-stat",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23879
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "Rocky"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-File-stat",
-                        "repository": "rocky10-baseos"
-                    }
-                ],
-                "set_id": 23880
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "Rocky"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17377,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-FileHandle",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23881
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "Rocky"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-FileHandle",
-                        "repository": "rocky10-baseos"
-                    }
-                ],
-                "set_id": 23882
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "Rocky"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17378,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Getopt-Long",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23883
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "Rocky"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Getopt-Long",
-                        "repository": "rocky10-baseos"
-                    }
-                ],
-                "set_id": 23884
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "Rocky"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17379,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Getopt-Std",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23885
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "Rocky"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Getopt-Std",
-                        "repository": "rocky10-baseos"
-                    }
-                ],
-                "set_id": 23886
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "Rocky"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17380,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-HTTP-Tiny",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23887
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "Rocky"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-HTTP-Tiny",
-                        "repository": "rocky10-baseos"
-                    }
-                ],
-                "set_id": 23888
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "Rocky"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17381,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-IO",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23889
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "Rocky"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-IO",
-                        "repository": "rocky10-baseos"
-                    }
-                ],
-                "set_id": 23890
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "Rocky"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17382,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-IO-Socket-IP",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23891
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "Rocky"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-IO-Socket-IP",
-                        "repository": "rocky10-baseos"
-                    }
-                ],
-                "set_id": 23892
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "Rocky"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17383,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-IO-Socket-SSL",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23893
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "Rocky"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-IO-Socket-SSL",
-                        "repository": "rocky10-baseos"
-                    }
-                ],
-                "set_id": 23894
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "Rocky"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17384,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-IPC-Open3",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23895
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "Rocky"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-IPC-Open3",
-                        "repository": "rocky10-baseos"
-                    }
-                ],
-                "set_id": 23896
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "Rocky"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17385,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-MIME-Base64",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23897
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "Rocky"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-MIME-Base64",
-                        "repository": "rocky10-baseos"
-                    }
-                ],
-                "set_id": 23898
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "Rocky"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17386,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Mozilla-CA",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23899
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "Rocky"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Mozilla-CA",
-                        "repository": "rocky10-baseos"
-                    }
-                ],
-                "set_id": 23900
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "Rocky"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17387,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Net-SSLeay",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23901
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "Rocky"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Net-SSLeay",
-                        "repository": "rocky10-baseos"
-                    }
-                ],
-                "set_id": 23902
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "Rocky"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17388,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-POSIX",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23903
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "Rocky"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-POSIX",
-                        "repository": "rocky10-baseos"
-                    }
-                ],
-                "set_id": 23904
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "Rocky"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17389,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-PathTools",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23905
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "Rocky"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-PathTools",
-                        "repository": "rocky10-baseos"
-                    }
-                ],
-                "set_id": 23906
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "Rocky"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17390,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Pod-Escapes",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23907
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "Rocky"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Pod-Escapes",
-                        "repository": "rocky10-baseos"
-                    }
-                ],
-                "set_id": 23908
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "Rocky"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17391,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Pod-Perldoc",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23909
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "Rocky"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Pod-Perldoc",
-                        "repository": "rocky10-baseos"
-                    }
-                ],
-                "set_id": 23910
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "Rocky"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17392,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Pod-Simple",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23911
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "Rocky"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Pod-Simple",
-                        "repository": "rocky10-baseos"
-                    }
-                ],
-                "set_id": 23912
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "Rocky"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17393,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Pod-Usage",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23913
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "Rocky"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Pod-Usage",
-                        "repository": "rocky10-baseos"
-                    }
-                ],
-                "set_id": 23914
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "Rocky"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17394,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Scalar-List-Utils",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23915
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "Rocky"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Scalar-List-Utils",
-                        "repository": "rocky10-baseos"
-                    }
-                ],
-                "set_id": 23916
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "Rocky"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17395,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-SelectSaver",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23917
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "Rocky"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-SelectSaver",
-                        "repository": "rocky10-baseos"
-                    }
-                ],
-                "set_id": 23918
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "Rocky"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17396,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Socket",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23919
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "Rocky"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Socket",
-                        "repository": "rocky10-baseos"
-                    }
-                ],
-                "set_id": 23920
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "Rocky"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17397,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Storable",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23921
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "Rocky"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Storable",
-                        "repository": "rocky10-baseos"
-                    }
-                ],
-                "set_id": 23922
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "Rocky"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17398,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Symbol",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23923
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "Rocky"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Symbol",
-                        "repository": "rocky10-baseos"
-                    }
-                ],
-                "set_id": 23924
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "Rocky"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17399,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Term-ANSIColor",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23925
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "Rocky"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Term-ANSIColor",
-                        "repository": "rocky10-baseos"
-                    }
-                ],
-                "set_id": 23926
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "Rocky"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17400,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Term-Cap",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23927
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "Rocky"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Term-Cap",
-                        "repository": "rocky10-baseos"
-                    }
-                ],
-                "set_id": 23928
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "Rocky"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17401,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Text-ParseWords",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23929
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "Rocky"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Text-ParseWords",
-                        "repository": "rocky10-baseos"
-                    }
-                ],
-                "set_id": 23930
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "Rocky"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17402,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Text-Tabs+Wrap",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23931
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "Rocky"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Text-Tabs+Wrap",
-                        "repository": "rocky10-baseos"
-                    }
-                ],
-                "set_id": 23932
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "Rocky"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17403,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Time-Local",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23933
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "Rocky"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-Time-Local",
-                        "repository": "rocky10-baseos"
-                    }
-                ],
-                "set_id": 23934
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "Rocky"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17404,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-URI",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23935
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "Rocky"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-URI",
-                        "repository": "rocky10-baseos"
-                    }
-                ],
-                "set_id": 23936
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "Rocky"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17405,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-base",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23937
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "Rocky"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-base",
-                        "repository": "rocky10-baseos"
-                    }
-                ],
-                "set_id": 23938
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "Rocky"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17406,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-constant",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23939
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "Rocky"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-constant",
-                        "repository": "rocky10-baseos"
-                    }
-                ],
-                "set_id": 23940
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "Rocky"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17407,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-if",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23941
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "Rocky"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-if",
-                        "repository": "rocky10-baseos"
-                    }
-                ],
-                "set_id": 23942
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "Rocky"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17408,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-interpreter",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23943
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "Rocky"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-interpreter",
-                        "repository": "rocky10-baseos"
-                    }
-                ],
-                "set_id": 23944
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "Rocky"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17409,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-libnet",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23945
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "Rocky"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-libnet",
-                        "repository": "rocky10-baseos"
-                    }
-                ],
-                "set_id": 23946
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "Rocky"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17410,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-locale",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23947
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "Rocky"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-locale",
-                        "repository": "rocky10-baseos"
-                    }
-                ],
-                "set_id": 23948
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "Rocky"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17411,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-mro",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23949
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "Rocky"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-mro",
-                        "repository": "rocky10-baseos"
-                    }
-                ],
-                "set_id": 23950
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "Rocky"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17412,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-overload",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23951
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "Rocky"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-overload",
-                        "repository": "rocky10-baseos"
-                    }
-                ],
-                "set_id": 23952
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "Rocky"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17413,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-overloading",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23953
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "Rocky"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-overloading",
-                        "repository": "rocky10-baseos"
-                    }
-                ],
-                "set_id": 23954
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "Rocky"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17414,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-parent",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23955
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "Rocky"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-parent",
-                        "repository": "rocky10-baseos"
-                    }
-                ],
-                "set_id": 23956
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "Rocky"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17415,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-podlators",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23957
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "Rocky"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-podlators",
-                        "repository": "rocky10-baseos"
-                    }
-                ],
-                "set_id": 23958
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "Rocky"
-            }
-        },
-        {
-            "action": 6,
-            "architectures": [
-                "aarch64",
-                "ppc64le",
-                "s390x",
-                "x86_64"
-            ],
-            "id": 17416,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-vars",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 23959
-            },
-            "initial_release": {
-                "major_version": 9,
-                "minor_version": 6,
-                "os_name": "Rocky"
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "perl-vars",
-                        "repository": "rocky10-baseos"
-                    }
-                ],
-                "set_id": 23960
-            },
-            "release": {
-                "major_version": 10,
-                "minor_version": 0,
-                "os_name": "Rocky"
-            }
-        },
-        {
             "action": 0,
             "architectures": [
                 "aarch64",
@@ -621324,6 +618279,9747 @@
             }
         },
         {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17430,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "usermode-gtk",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 23978
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17431,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "usermode-gtk",
+                        "repository": "rocky9-appstream"
+                    }
+                ],
+                "set_id": 23979
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17432,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "gdisk",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 23980
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17433,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "gdisk",
+                        "repository": "rocky9-appstream"
+                    }
+                ],
+                "set_id": 23981
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17434,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "gcc-toolset-14",
+                        "repository": "rocky10-appstream"
+                    }
+                ],
+                "set_id": 23982
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 6,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17435,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
+                        ],
+                        "name": "antlr-C++",
+                        "repository": "powertools"
+                    }
+                ],
+                "set_id": 23984
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [
+                {
+                    "in_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    },
+                    "out_modulestream": null
+                }
+            ],
+            "out_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "antlr-C++",
+                        "repository": "rocky9-crb"
+                    }
+                ],
+                "set_id": 23985
+            },
+            "release": {
+                "major_version": 9,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 6,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17436,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "python39-devel",
+                                "stream": "3.9"
+                            }
+                        ],
+                        "name": "python39-pybind11",
+                        "repository": "rocky8-powertools"
+                    }
+                ],
+                "set_id": 23986
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 8,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [
+                {
+                    "in_modulestream": {
+                        "name": "python39-devel",
+                        "stream": "3.9"
+                    },
+                    "out_modulestream": {
+                        "name": "python39-devel",
+                        "stream": "3.9"
+                    }
+                }
+            ],
+            "out_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "python39-devel",
+                                "stream": "3.9"
+                            }
+                        ],
+                        "name": "python39-pybind11",
+                        "repository": "rocky8-appstream"
+                    }
+                ],
+                "set_id": 23987
+            },
+            "release": {
+                "major_version": 8,
+                "minor_version": 9,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 6,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17437,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "python39-devel",
+                                "stream": "3.9"
+                            }
+                        ],
+                        "name": "python39-pybind11-devel",
+                        "repository": "rocky8-powertools"
+                    }
+                ],
+                "set_id": 23988
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 8,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [
+                {
+                    "in_modulestream": {
+                        "name": "python39-devel",
+                        "stream": "3.9"
+                    },
+                    "out_modulestream": {
+                        "name": "python39-devel",
+                        "stream": "3.9"
+                    }
+                }
+            ],
+            "out_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "python39-devel",
+                                "stream": "3.9"
+                            }
+                        ],
+                        "name": "python39-pybind11-devel",
+                        "repository": "rocky8-appstream"
+                    }
+                ],
+                "set_id": 23989
+            },
+            "release": {
+                "major_version": 8,
+                "minor_version": 9,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 6,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17438,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "python39-devel",
+                                "stream": "3.9"
+                            }
+                        ],
+                        "name": "python39-pybind11",
+                        "repository": "rocky8-appstream"
+                    }
+                ],
+                "set_id": 23990
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 9,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [
+                {
+                    "in_modulestream": {
+                        "name": "python39-devel",
+                        "stream": "3.9"
+                    },
+                    "out_modulestream": {
+                        "name": "python39-devel",
+                        "stream": "3.9"
+                    }
+                }
+            ],
+            "out_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "python39-devel",
+                                "stream": "3.9"
+                            }
+                        ],
+                        "name": "python39-pybind11",
+                        "repository": "rocky8-powertools"
+                    }
+                ],
+                "set_id": 23991
+            },
+            "release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 6,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17439,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "python39-devel",
+                                "stream": "3.9"
+                            }
+                        ],
+                        "name": "python39-pybind11-devel",
+                        "repository": "rocky8-appstream"
+                    }
+                ],
+                "set_id": 23992
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 9,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [
+                {
+                    "in_modulestream": {
+                        "name": "python39-devel",
+                        "stream": "3.9"
+                    },
+                    "out_modulestream": {
+                        "name": "python39-devel",
+                        "stream": "3.9"
+                    }
+                }
+            ],
+            "out_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "python39-devel",
+                                "stream": "3.9"
+                            }
+                        ],
+                        "name": "python39-pybind11-devel",
+                        "repository": "rocky8-powertools"
+                    }
+                ],
+                "set_id": 23993
+            },
+            "release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 5,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17440,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "cockpit-bridge",
+                        "repository": "baseos"
+                    },
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "cockpit-pcp",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 23996
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [
+                {
+                    "in_modulestream": null,
+                    "out_modulestream": null
+                }
+            ],
+            "out_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "cockpit-bridge",
+                        "repository": "rocky10-baseos"
+                    }
+                ],
+                "set_id": 23997
+            },
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17442,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "papers-devel",
+                        "repository": "rocky10-crb"
+                    }
+                ],
+                "set_id": 24004
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17443,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "xmlrpc-c",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24006
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17444,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "xmlrpc-c-c++",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24007
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17445,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "xmlrpc-c-client",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24008
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17446,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "xmlrpc-c-client++",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24009
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17447,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "xmlrpc-c-devel",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24010
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17448,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "satyr",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24011
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17449,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "satyr",
+                        "repository": "rocky9-appstream"
+                    }
+                ],
+                "set_id": 24012
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17450,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "xmlrpc-c",
+                        "repository": "rocky9-appstream"
+                    }
+                ],
+                "set_id": 24013
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17451,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "libreport",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24014
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17452,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "libreport",
+                        "repository": "rocky9-appstream"
+                    }
+                ],
+                "set_id": 24015
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17453,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "libreport-anaconda",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24016
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17454,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "libreport-anaconda",
+                        "repository": "rocky9-appstream"
+                    }
+                ],
+                "set_id": 24017
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17455,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "libreport-cli",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24018
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17456,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "libreport-cli",
+                        "repository": "rocky9-appstream"
+                    }
+                ],
+                "set_id": 24019
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17457,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "libreport-filesystem",
+                        "repository": "baseos"
+                    }
+                ],
+                "set_id": 24020
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17458,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "libreport-filesystem",
+                        "repository": "rocky9-baseos"
+                    }
+                ],
+                "set_id": 24021
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17459,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "libreport-gtk",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24022
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17460,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "libreport-gtk",
+                        "repository": "rocky9-appstream"
+                    }
+                ],
+                "set_id": 24023
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17461,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "libreport-plugin-bugzilla",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24024
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17462,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "libreport-plugin-bugzilla",
+                        "repository": "rocky9-appstream"
+                    }
+                ],
+                "set_id": 24025
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17463,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "libreport-plugin-reportuploader",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24026
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17464,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "libreport-plugin-reportuploader",
+                        "repository": "rocky9-appstream"
+                    }
+                ],
+                "set_id": 24027
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17467,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "libreport-web",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24030
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17468,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "libreport-web",
+                        "repository": "rocky9-appstream"
+                    }
+                ],
+                "set_id": 24031
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17469,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "python3-libreport",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24032
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17470,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "python3-libreport",
+                        "repository": "rocky9-appstream"
+                    }
+                ],
+                "set_id": 24033
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17471,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "texlive-xdvi",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24034
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17472,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "texlive-xdvi",
+                        "repository": "rocky9-appstream"
+                    }
+                ],
+                "set_id": 24035
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17473,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "totem-pl-parser",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24038
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17474,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "totem-pl-parser",
+                        "repository": "rocky9-appstream"
+                    }
+                ],
+                "set_id": 24039
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17475,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "perl-libxml-perl",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24040
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17476,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "perltidy",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24041
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17477,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "perl-YAML-LibYAML",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24042
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17478,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "perl-Syntax-Keyword-Try",
+                        "repository": "rocky10-crb"
+                    }
+                ],
+                "set_id": 24043
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17479,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "perl-XS-Parse-Keyword",
+                        "repository": "rocky10-crb"
+                    }
+                ],
+                "set_id": 24044
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17480,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "libraw1394",
+                        "repository": "rocky8-appstream"
+                    }
+                ],
+                "set_id": 24045
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 9,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17481,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "cdrdao",
+                        "repository": "rocky8-appstream"
+                    }
+                ],
+                "set_id": 24046
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 9,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17482,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "perl-Net-DNS-Nameserver",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24047
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "x86_64"
+            ],
+            "id": 17483,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "command-line-assistant",
+                        "repository": "rocky10-appstream"
+                    }
+                ],
+                "set_id": 24048
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17487,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "flatpak-rpm-macros",
+                        "repository": "rocky9-crb"
+                    }
+                ],
+                "set_id": 24052
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17488,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "flatpak-runtime-config",
+                        "repository": "rocky9-crb"
+                    }
+                ],
+                "set_id": 24053
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 7,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17489,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "mysql",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24054
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [
+                {
+                    "in_modulestream": null,
+                    "out_modulestream": null
+                }
+            ],
+            "out_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "mysql8.4",
+                        "repository": "rocky10-appstream"
+                    }
+                ],
+                "set_id": 24055
+            },
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 7,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17490,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "mysql-server",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24056
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [
+                {
+                    "in_modulestream": null,
+                    "out_modulestream": null
+                }
+            ],
+            "out_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "mysql8.4-server",
+                        "repository": "rocky10-appstream"
+                    }
+                ],
+                "set_id": 24057
+            },
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 7,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17491,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "mysql-errmsg",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24058
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [
+                {
+                    "in_modulestream": null,
+                    "out_modulestream": null
+                }
+            ],
+            "out_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "mysql8.4-errmsg",
+                        "repository": "rocky10-appstream"
+                    }
+                ],
+                "set_id": 24059
+            },
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 7,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17492,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "mysql-devel",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24060
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [
+                {
+                    "in_modulestream": null,
+                    "out_modulestream": null
+                }
+            ],
+            "out_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "mysql8.4-devel",
+                        "repository": "rocky10-crb"
+                    }
+                ],
+                "set_id": 24061
+            },
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17493,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-11-openjdk",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24062
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17494,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-11-openjdk",
+                        "repository": "rocky9-appstream"
+                    }
+                ],
+                "set_id": 24063
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 4,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17495,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-11-openjdk-demo",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24064
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17496,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-11-openjdk-demo",
+                        "repository": "rocky9-appstream"
+                    }
+                ],
+                "set_id": 24065
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 4,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17497,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-11-openjdk-devel",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24066
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17498,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-11-openjdk-devel",
+                        "repository": "rocky9-appstream"
+                    }
+                ],
+                "set_id": 24067
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 4,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17499,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-11-openjdk-headless",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24068
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17500,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-11-openjdk-headless",
+                        "repository": "rocky9-appstream"
+                    }
+                ],
+                "set_id": 24069
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 4,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17501,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-11-openjdk-javadoc",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24070
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17502,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-11-openjdk-javadoc",
+                        "repository": "rocky9-appstream"
+                    }
+                ],
+                "set_id": 24071
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 4,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17503,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-11-openjdk-javadoc-zip",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24072
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17504,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-11-openjdk-javadoc-zip",
+                        "repository": "rocky9-appstream"
+                    }
+                ],
+                "set_id": 24073
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 4,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17505,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-11-openjdk-jmods",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24074
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17506,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-11-openjdk-jmods",
+                        "repository": "rocky9-appstream"
+                    }
+                ],
+                "set_id": 24075
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 4,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17507,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-11-openjdk-src",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24076
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17508,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-11-openjdk-src",
+                        "repository": "rocky9-appstream"
+                    }
+                ],
+                "set_id": 24077
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 4,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17509,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-11-openjdk-static-libs",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24078
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17510,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-11-openjdk-static-libs",
+                        "repository": "rocky9-appstream"
+                    }
+                ],
+                "set_id": 24079
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 4,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17511,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-11-openjdk-demo-fastdebug",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24080
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17512,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-11-openjdk-demo-slowdebug",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24081
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17513,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-11-openjdk-devel-fastdebug",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24082
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17514,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-11-openjdk-devel-slowdebug",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24083
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17515,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-11-openjdk-fastdebug",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24084
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17516,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-11-openjdk-headless-fastdebug",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24085
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17517,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-11-openjdk-headless-slowdebug",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24086
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17518,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-11-openjdk-jmods-fastdebug",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24087
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17519,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-11-openjdk-jmods-slowdebug",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24088
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17520,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-11-openjdk-slowdebug",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24089
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17521,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-11-openjdk-src-fastdebug",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24090
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17522,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-11-openjdk-src-slowdebug",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24091
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17523,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-11-openjdk-static-libs-fastdebug",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24092
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17524,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-11-openjdk-static-libs-slowdebug",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24093
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17525,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-17-openjdk",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24094
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17526,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-17-openjdk",
+                        "repository": "rocky9-appstream"
+                    }
+                ],
+                "set_id": 24095
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17527,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-17-openjdk-demo",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24096
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17528,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-17-openjdk-demo",
+                        "repository": "rocky9-appstream"
+                    }
+                ],
+                "set_id": 24097
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17529,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-17-openjdk-devel",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24098
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17530,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-17-openjdk-devel",
+                        "repository": "rocky9-appstream"
+                    }
+                ],
+                "set_id": 24099
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17531,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-17-openjdk-headless",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24100
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17532,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-17-openjdk-headless",
+                        "repository": "rocky9-appstream"
+                    }
+                ],
+                "set_id": 24101
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17533,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-17-openjdk-javadoc",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24102
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17534,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-17-openjdk-javadoc",
+                        "repository": "rocky9-appstream"
+                    }
+                ],
+                "set_id": 24103
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17535,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-17-openjdk-javadoc-zip",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24104
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17536,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-17-openjdk-javadoc-zip",
+                        "repository": "rocky9-appstream"
+                    }
+                ],
+                "set_id": 24105
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17537,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-17-openjdk-jmods",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24106
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17538,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-17-openjdk-jmods",
+                        "repository": "rocky9-appstream"
+                    }
+                ],
+                "set_id": 24107
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17539,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-17-openjdk-src",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24108
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17540,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-17-openjdk-src",
+                        "repository": "rocky9-appstream"
+                    }
+                ],
+                "set_id": 24109
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17541,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-17-openjdk-static-libs",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24110
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17542,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-17-openjdk-static-libs",
+                        "repository": "rocky9-appstream"
+                    }
+                ],
+                "set_id": 24111
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17543,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-17-openjdk-demo-fastdebug",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24112
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17544,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-17-openjdk-demo-slowdebug",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24113
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17545,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-17-openjdk-devel-fastdebug",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24114
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17546,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-17-openjdk-devel-slowdebug",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24115
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17547,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-17-openjdk-fastdebug",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24116
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17548,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-17-openjdk-headless-fastdebug",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24117
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17549,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-17-openjdk-headless-slowdebug",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24118
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17550,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-17-openjdk-jmods-fastdebug",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24119
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17551,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-17-openjdk-jmods-slowdebug",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24120
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17552,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-17-openjdk-slowdebug",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24121
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17553,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-17-openjdk-src-fastdebug",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24122
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17554,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-17-openjdk-src-slowdebug",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24123
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17555,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-17-openjdk-static-libs-fastdebug",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24124
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17556,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-17-openjdk-static-libs-slowdebug",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24125
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17557,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-1.8.0-openjdk",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24126
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17558,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-1.8.0-openjdk",
+                        "repository": "rocky9-appstream"
+                    }
+                ],
+                "set_id": 24127
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17559,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-1.8.0-openjdk-demo",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24128
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17560,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-1.8.0-openjdk-demo",
+                        "repository": "rocky9-appstream"
+                    }
+                ],
+                "set_id": 24129
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17561,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-1.8.0-openjdk-devel",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24130
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17562,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-1.8.0-openjdk-devel",
+                        "repository": "rocky9-appstream"
+                    }
+                ],
+                "set_id": 24131
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17563,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-1.8.0-openjdk-headless",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24132
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17564,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-1.8.0-openjdk-headless",
+                        "repository": "rocky9-appstream"
+                    }
+                ],
+                "set_id": 24133
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17565,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-1.8.0-openjdk-javadoc",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24134
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17566,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-1.8.0-openjdk-javadoc",
+                        "repository": "rocky9-appstream"
+                    }
+                ],
+                "set_id": 24135
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17567,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-1.8.0-openjdk-javadoc-zip",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24136
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17568,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-1.8.0-openjdk-javadoc-zip",
+                        "repository": "rocky9-appstream"
+                    }
+                ],
+                "set_id": 24137
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17569,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-1.8.0-openjdk-src",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24138
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17570,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-1.8.0-openjdk-src",
+                        "repository": "rocky9-appstream"
+                    }
+                ],
+                "set_id": 24139
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17571,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-1.8.0-openjdk-demo-fastdebug",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24140
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17572,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-1.8.0-openjdk-demo-slowdebug",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24141
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17573,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-1.8.0-openjdk-devel-fastdebug",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24142
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17574,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-1.8.0-openjdk-devel-slowdebug",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24143
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17575,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-1.8.0-openjdk-fastdebug",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24144
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17576,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-1.8.0-openjdk-headless-fastdebug",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24145
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17577,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-1.8.0-openjdk-headless-slowdebug",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24146
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17578,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-1.8.0-openjdk-slowdebug",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24147
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17579,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-1.8.0-openjdk-src-fastdebug",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24148
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17580,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "java-1.8.0-openjdk-src-slowdebug",
+                        "repository": "crb"
+                    }
+                ],
+                "set_id": 24149
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17581,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "jigawatts",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24150
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17582,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "jigawatts",
+                        "repository": "rocky9-appstream"
+                    }
+                ],
+                "set_id": 24151
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17583,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "jigawatts-javadoc",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24152
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17584,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "jigawatts-javadoc",
+                        "repository": "rocky9-appstream"
+                    }
+                ],
+                "set_id": 24153
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17586,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "rust-std-static-wasm32-wasi",
+                        "repository": "rocky9-appstream"
+                    }
+                ],
+                "set_id": 24156
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17587,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "rust-std-static-wasm32-wasi",
+                        "repository": "rocky8-appstream"
+                    }
+                ],
+                "set_id": 24157
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 9,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "x86_64"
+            ],
+            "id": 17588,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "command-line-assistant-selinux",
+                        "repository": "rocky10-appstream"
+                    }
+                ],
+                "set_id": 24158
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17589,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "python3-snapm",
+                        "repository": "rocky9-appstream"
+                    }
+                ],
+                "set_id": 24159
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17590,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "python3-snapm-doc",
+                        "repository": "rocky9-appstream"
+                    }
+                ],
+                "set_id": 24160
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17591,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "snapm",
+                        "repository": "rocky9-appstream"
+                    }
+                ],
+                "set_id": 24161
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17592,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "snapm",
+                        "repository": "rocky10-appstream"
+                    }
+                ],
+                "set_id": 24162
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17593,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "python3-snapm",
+                        "repository": "rocky10-appstream"
+                    }
+                ],
+                "set_id": 24163
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17594,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "python3-snapm-doc",
+                        "repository": "rocky10-appstream"
+                    }
+                ],
+                "set_id": 24164
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 7,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17595,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "mysql",
+                                "stream": "8.4"
+                            }
+                        ],
+                        "name": "mysql-test",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24165
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [
+                {
+                    "in_modulestream": {
+                        "name": "mysql",
+                        "stream": "8.4"
+                    },
+                    "out_modulestream": null
+                }
+            ],
+            "out_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "mysql8.4-test",
+                        "repository": "rocky10-crb"
+                    }
+                ],
+                "set_id": 24166
+            },
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 7,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17596,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "mysql",
+                                "stream": "8.4"
+                            }
+                        ],
+                        "name": "mysql-test-data",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24167
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [
+                {
+                    "in_modulestream": {
+                        "name": "mysql",
+                        "stream": "8.4"
+                    },
+                    "out_modulestream": null
+                }
+            ],
+            "out_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "mysql8.4-test-data",
+                        "repository": "rocky10-crb"
+                    }
+                ],
+                "set_id": 24168
+            },
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "x86_64"
+            ],
+            "id": 17597,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "qat-zstd-plugin",
+                        "repository": "rocky9-appstream"
+                    }
+                ],
+                "set_id": 24169
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "x86_64"
+            ],
+            "id": 17598,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "qat-zstd-plugin-devel",
+                        "repository": "rocky9-appstream"
+                    }
+                ],
+                "set_id": 24170
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "x86_64"
+            ],
+            "id": 17599,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "qat-zstd-plugin-static",
+                        "repository": "rocky9-crb"
+                    }
+                ],
+                "set_id": 24171
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17600,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "legacy-printer-app",
+                        "repository": "rocky10-appstream"
+                    }
+                ],
+                "set_id": 24172
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17601,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "pappl-retrofit",
+                        "repository": "rocky10-appstream"
+                    }
+                ],
+                "set_id": 24173
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17602,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "nodejs",
+                                "stream": "22"
+                            }
+                        ],
+                        "name": "nodejs",
+                        "repository": "rocky8-appstream"
+                    }
+                ],
+                "set_id": 24174
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 9,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17603,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "nodejs",
+                                "stream": "22"
+                            }
+                        ],
+                        "name": "nodejs-devel",
+                        "repository": "rocky8-appstream"
+                    }
+                ],
+                "set_id": 24175
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 9,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17604,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "nodejs",
+                                "stream": "22"
+                            }
+                        ],
+                        "name": "nodejs-docs",
+                        "repository": "rocky8-appstream"
+                    }
+                ],
+                "set_id": 24176
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 9,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17605,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "nodejs",
+                                "stream": "22"
+                            }
+                        ],
+                        "name": "nodejs-full-i18n",
+                        "repository": "rocky8-appstream"
+                    }
+                ],
+                "set_id": 24177
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 9,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17606,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "nodejs",
+                                "stream": "22"
+                            }
+                        ],
+                        "name": "nodejs-libs",
+                        "repository": "rocky8-appstream"
+                    }
+                ],
+                "set_id": 24178
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 9,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17607,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "nodejs",
+                                "stream": "22"
+                            }
+                        ],
+                        "name": "nodejs-nodemon",
+                        "repository": "rocky8-appstream"
+                    }
+                ],
+                "set_id": 24179
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 9,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17608,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "nodejs",
+                                "stream": "22"
+                            }
+                        ],
+                        "name": "nodejs-packaging",
+                        "repository": "rocky8-appstream"
+                    }
+                ],
+                "set_id": 24180
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 9,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17609,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "nodejs",
+                                "stream": "22"
+                            }
+                        ],
+                        "name": "nodejs-packaging-bundler",
+                        "repository": "rocky8-appstream"
+                    }
+                ],
+                "set_id": 24181
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 9,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17610,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "nodejs",
+                                "stream": "22"
+                            }
+                        ],
+                        "name": "npm",
+                        "repository": "rocky8-appstream"
+                    }
+                ],
+                "set_id": 24182
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 9,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17611,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "nodejs",
+                                "stream": "22"
+                            }
+                        ],
+                        "name": "v8-12.4-devel",
+                        "repository": "rocky8-appstream"
+                    }
+                ],
+                "set_id": 24183
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 9,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 4,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17612,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "opensc",
+                        "repository": "baseos"
+                    }
+                ],
+                "set_id": 24184
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [
+                {
+                    "in_modulestream": null,
+                    "out_modulestream": null
+                }
+            ],
+            "out_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "opensc",
+                        "repository": "rocky10-baseos"
+                    },
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "opensc-libs",
+                        "repository": "rocky10-baseos"
+                    }
+                ],
+                "set_id": 24185
+            },
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17613,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "copy-jdk-configs",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24186
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17614,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "leapp",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24187
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17615,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "leapp-deps",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24188
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17616,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "python3-leapp",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24189
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17617,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "snactor",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24190
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17618,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "leapp-upgrade-el8toel9",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24191
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17619,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "leapp-upgrade-el8toel9-deps",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24192
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17620,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "cockpit-leapp",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24193
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17621,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "leapp",
+                        "repository": "rocky9-appstream"
+                    }
+                ],
+                "set_id": 24194
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17622,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "leapp-deps",
+                        "repository": "rocky9-appstream"
+                    }
+                ],
+                "set_id": 24195
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17623,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "python3-leapp",
+                        "repository": "rocky9-appstream"
+                    }
+                ],
+                "set_id": 24196
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17624,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "snactor",
+                        "repository": "rocky9-crb"
+                    }
+                ],
+                "set_id": 24197
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17625,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "leapp-upgrade-el9toel10",
+                        "repository": "rocky9-appstream"
+                    }
+                ],
+                "set_id": 24198
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17626,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "leapp-upgrade-el9toel10-deps",
+                        "repository": "rocky9-appstream"
+                    }
+                ],
+                "set_id": 24199
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17627,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "cockpit-leapp",
+                        "repository": "rocky9-appstream"
+                    }
+                ],
+                "set_id": 24200
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17628,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "libportal-qt6",
+                        "repository": "rocky10-appstream"
+                    }
+                ],
+                "set_id": 24201
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 7,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17629,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "libportal-qt6-devel",
+                        "repository": "rocky10-crb"
+                    }
+                ],
+                "set_id": 24202
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 7,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17630,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "pidgin-sipe",
+                        "repository": "rocky8-appstream"
+                    }
+                ],
+                "set_id": 24205
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 9,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17631,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "pidgin",
+                        "repository": "rocky8-appstream"
+                    }
+                ],
+                "set_id": 24206
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 9,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17632,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "gtkspell",
+                        "repository": "rocky8-appstream"
+                    }
+                ],
+                "set_id": 24207
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 9,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17633,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "gvfs-afc",
+                        "repository": "rocky8-appstream"
+                    }
+                ],
+                "set_id": 24208
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 9,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17634,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "dleyna-renderer",
+                        "repository": "rocky8-appstream"
+                    }
+                ],
+                "set_id": 24209
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 9,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17635,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "dleyna-server",
+                        "repository": "rocky8-appstream"
+                    }
+                ],
+                "set_id": 24210
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 9,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17636,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "dleyna-connector-dbus",
+                        "repository": "rocky8-appstream"
+                    }
+                ],
+                "set_id": 24211
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 9,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17637,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "php",
+                                "stream": "8.3"
+                            }
+                        ],
+                        "name": "apcu-panel",
+                        "repository": "rocky9-appstream"
+                    }
+                ],
+                "set_id": 24212
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17638,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "php",
+                                "stream": "8.3"
+                            }
+                        ],
+                        "name": "php",
+                        "repository": "rocky9-appstream"
+                    }
+                ],
+                "set_id": 24213
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17639,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "php",
+                                "stream": "8.3"
+                            }
+                        ],
+                        "name": "php-bcmath",
+                        "repository": "rocky9-appstream"
+                    }
+                ],
+                "set_id": 24214
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17640,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "php",
+                                "stream": "8.3"
+                            }
+                        ],
+                        "name": "php-cli",
+                        "repository": "rocky9-appstream"
+                    }
+                ],
+                "set_id": 24215
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17641,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "php",
+                                "stream": "8.3"
+                            }
+                        ],
+                        "name": "php-common",
+                        "repository": "rocky9-appstream"
+                    }
+                ],
+                "set_id": 24216
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17642,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "php",
+                                "stream": "8.3"
+                            }
+                        ],
+                        "name": "php-dba",
+                        "repository": "rocky9-appstream"
+                    }
+                ],
+                "set_id": 24217
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17643,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "php",
+                                "stream": "8.3"
+                            }
+                        ],
+                        "name": "php-dbg",
+                        "repository": "rocky9-appstream"
+                    }
+                ],
+                "set_id": 24218
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17644,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "php",
+                                "stream": "8.3"
+                            }
+                        ],
+                        "name": "php-devel",
+                        "repository": "rocky9-appstream"
+                    }
+                ],
+                "set_id": 24219
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17645,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "php",
+                                "stream": "8.3"
+                            }
+                        ],
+                        "name": "php-embedded",
+                        "repository": "rocky9-appstream"
+                    }
+                ],
+                "set_id": 24220
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17646,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "php",
+                                "stream": "8.3"
+                            }
+                        ],
+                        "name": "php-enchant",
+                        "repository": "rocky9-appstream"
+                    }
+                ],
+                "set_id": 24221
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17647,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "php",
+                                "stream": "8.3"
+                            }
+                        ],
+                        "name": "php-ffi",
+                        "repository": "rocky9-appstream"
+                    }
+                ],
+                "set_id": 24222
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17648,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "php",
+                                "stream": "8.3"
+                            }
+                        ],
+                        "name": "php-fpm",
+                        "repository": "rocky9-appstream"
+                    }
+                ],
+                "set_id": 24223
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17649,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "php",
+                                "stream": "8.3"
+                            }
+                        ],
+                        "name": "php-gd",
+                        "repository": "rocky9-appstream"
+                    }
+                ],
+                "set_id": 24224
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17650,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "php",
+                                "stream": "8.3"
+                            }
+                        ],
+                        "name": "php-gmp",
+                        "repository": "rocky9-appstream"
+                    }
+                ],
+                "set_id": 24225
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17651,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "php",
+                                "stream": "8.3"
+                            }
+                        ],
+                        "name": "php-intl",
+                        "repository": "rocky9-appstream"
+                    }
+                ],
+                "set_id": 24226
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17652,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "php",
+                                "stream": "8.3"
+                            }
+                        ],
+                        "name": "php-ldap",
+                        "repository": "rocky9-appstream"
+                    }
+                ],
+                "set_id": 24227
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17653,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "php",
+                                "stream": "8.3"
+                            }
+                        ],
+                        "name": "php-mbstring",
+                        "repository": "rocky9-appstream"
+                    }
+                ],
+                "set_id": 24228
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17654,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "php",
+                                "stream": "8.3"
+                            }
+                        ],
+                        "name": "php-mysqlnd",
+                        "repository": "rocky9-appstream"
+                    }
+                ],
+                "set_id": 24229
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17655,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "php",
+                                "stream": "8.3"
+                            }
+                        ],
+                        "name": "php-odbc",
+                        "repository": "rocky9-appstream"
+                    }
+                ],
+                "set_id": 24230
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17656,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "php",
+                                "stream": "8.3"
+                            }
+                        ],
+                        "name": "php-opcache",
+                        "repository": "rocky9-appstream"
+                    }
+                ],
+                "set_id": 24231
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17657,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "php",
+                                "stream": "8.3"
+                            }
+                        ],
+                        "name": "php-pdo",
+                        "repository": "rocky9-appstream"
+                    }
+                ],
+                "set_id": 24232
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17658,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "php",
+                                "stream": "8.3"
+                            }
+                        ],
+                        "name": "php-pecl-apcu",
+                        "repository": "rocky9-appstream"
+                    }
+                ],
+                "set_id": 24233
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17659,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "php",
+                                "stream": "8.3"
+                            }
+                        ],
+                        "name": "php-pecl-apcu-devel",
+                        "repository": "rocky9-appstream"
+                    }
+                ],
+                "set_id": 24234
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17660,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "php",
+                                "stream": "8.3"
+                            }
+                        ],
+                        "name": "php-pecl-redis6",
+                        "repository": "rocky9-appstream"
+                    }
+                ],
+                "set_id": 24235
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17661,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "php",
+                                "stream": "8.3"
+                            }
+                        ],
+                        "name": "php-pecl-rrd",
+                        "repository": "rocky9-appstream"
+                    }
+                ],
+                "set_id": 24236
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17662,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "php",
+                                "stream": "8.3"
+                            }
+                        ],
+                        "name": "php-pecl-xdebug3",
+                        "repository": "rocky9-appstream"
+                    }
+                ],
+                "set_id": 24237
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17663,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "php",
+                                "stream": "8.3"
+                            }
+                        ],
+                        "name": "php-pecl-zip",
+                        "repository": "rocky9-appstream"
+                    }
+                ],
+                "set_id": 24238
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17664,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "php",
+                                "stream": "8.3"
+                            }
+                        ],
+                        "name": "php-pgsql",
+                        "repository": "rocky9-appstream"
+                    }
+                ],
+                "set_id": 24239
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17665,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "php",
+                                "stream": "8.3"
+                            }
+                        ],
+                        "name": "php-process",
+                        "repository": "rocky9-appstream"
+                    }
+                ],
+                "set_id": 24240
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17666,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "php",
+                                "stream": "8.3"
+                            }
+                        ],
+                        "name": "php-snmp",
+                        "repository": "rocky9-appstream"
+                    }
+                ],
+                "set_id": 24241
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17667,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "php",
+                                "stream": "8.3"
+                            }
+                        ],
+                        "name": "php-soap",
+                        "repository": "rocky9-appstream"
+                    }
+                ],
+                "set_id": 24242
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17668,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "php",
+                                "stream": "8.3"
+                            }
+                        ],
+                        "name": "php-xml",
+                        "repository": "rocky9-appstream"
+                    }
+                ],
+                "set_id": 24243
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17669,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "nginx",
+                                "stream": "1.26"
+                            }
+                        ],
+                        "name": "nginx",
+                        "repository": "rocky9-appstream"
+                    }
+                ],
+                "set_id": 24244
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17670,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "nginx",
+                                "stream": "1.26"
+                            }
+                        ],
+                        "name": "nginx-all-modules",
+                        "repository": "rocky9-appstream"
+                    }
+                ],
+                "set_id": 24245
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17671,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "nginx",
+                                "stream": "1.26"
+                            }
+                        ],
+                        "name": "nginx-core",
+                        "repository": "rocky9-appstream"
+                    }
+                ],
+                "set_id": 24246
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17672,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "nginx",
+                                "stream": "1.26"
+                            }
+                        ],
+                        "name": "nginx-filesystem",
+                        "repository": "rocky9-appstream"
+                    }
+                ],
+                "set_id": 24247
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17673,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "nginx",
+                                "stream": "1.26"
+                            }
+                        ],
+                        "name": "nginx-mod-devel",
+                        "repository": "rocky9-appstream"
+                    }
+                ],
+                "set_id": 24248
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17674,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "nginx",
+                                "stream": "1.26"
+                            }
+                        ],
+                        "name": "nginx-mod-http-image-filter",
+                        "repository": "rocky9-appstream"
+                    }
+                ],
+                "set_id": 24249
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17675,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "nginx",
+                                "stream": "1.26"
+                            }
+                        ],
+                        "name": "nginx-mod-http-perl",
+                        "repository": "rocky9-appstream"
+                    }
+                ],
+                "set_id": 24250
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17676,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "nginx",
+                                "stream": "1.26"
+                            }
+                        ],
+                        "name": "nginx-mod-http-xslt-filter",
+                        "repository": "rocky9-appstream"
+                    }
+                ],
+                "set_id": 24251
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17677,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "nginx",
+                                "stream": "1.26"
+                            }
+                        ],
+                        "name": "nginx-mod-mail",
+                        "repository": "rocky9-appstream"
+                    }
+                ],
+                "set_id": 24252
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17678,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "nginx",
+                                "stream": "1.26"
+                            }
+                        ],
+                        "name": "nginx-mod-stream",
+                        "repository": "rocky9-appstream"
+                    }
+                ],
+                "set_id": 24253
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "x86_64"
+            ],
+            "id": 17679,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "gnome-boxes",
+                        "repository": "rocky8-appstream"
+                    }
+                ],
+                "set_id": 24254
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 9,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17680,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "dleyna-core",
+                        "repository": "rocky8-appstream"
+                    }
+                ],
+                "set_id": 24255
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 9,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17681,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "redhat-menus",
+                        "repository": "rocky8-appstream"
+                    }
+                ],
+                "set_id": 24256
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 9,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "x86_64"
+            ],
+            "id": 17682,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "dbxtool",
+                        "repository": "rocky8-baseos"
+                    }
+                ],
+                "set_id": 24257
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 9,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17683,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "gnome-online-miners",
+                        "repository": "rocky8-appstream"
+                    }
+                ],
+                "set_id": 24258
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 9,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 17684,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "gfbgraph",
+                        "repository": "rocky8-appstream"
+                    }
+                ],
+                "set_id": 24259
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 9,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 8,
+                "minor_version": 10,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17685,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "webkitgtk3",
+                        "repository": "base"
+                    }
+                ],
+                "set_id": 24260
+            },
+            "initial_release": {
+                "major_version": 7,
+                "minor_version": 8,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 7,
+                "minor_version": 9,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 6,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17686,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "php",
+                                "stream": "8.3"
+                            }
+                        ],
+                        "name": "php-pecl-redis6",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24261
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 7,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [
+                {
+                    "in_modulestream": {
+                        "name": "php",
+                        "stream": "8.3"
+                    },
+                    "out_modulestream": null
+                }
+            ],
+            "out_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "php-pecl-redis6",
+                        "repository": "rocky10-appstream"
+                    }
+                ],
+                "set_id": 24262
+            },
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17687,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "nginx",
+                                "stream": "1.26"
+                            }
+                        ],
+                        "name": "nginx",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24263
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 7,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17688,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            {
+                                "name": "nginx",
+                                "stream": "1.26"
+                            }
+                        ],
+                        "name": "nginx",
+                        "repository": "rocky9-appstream"
+                    }
+                ],
+                "set_id": 24264
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 7,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "x86_64"
+            ],
+            "id": 17689,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "trustee-guest-components",
+                        "repository": "rocky9-appstream"
+                    }
+                ],
+                "set_id": 24265
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "x86_64"
+            ],
+            "id": 17690,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "python3-libcpuid",
+                        "repository": "rocky10-baseos"
+                    }
+                ],
+                "set_id": 24266
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 7,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "x86_64"
+            ],
+            "id": 17691,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "libcamera",
+                        "repository": "rocky10-appstream"
+                    }
+                ],
+                "set_id": 24267
+            },
+            "initial_release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 1,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17692,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "gnome-settings-daemon-server-defaults",
+                        "repository": "rocky10-appstream"
+                    }
+                ],
+                "set_id": 24268
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 7,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 6,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17693,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "bpftool",
+                        "repository": "rocky9-baseos"
+                    }
+                ],
+                "set_id": 24269
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [
+                {
+                    "in_modulestream": null,
+                    "out_modulestream": null
+                }
+            ],
+            "out_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "bpftool",
+                        "repository": "rocky9-appstream"
+                    }
+                ],
+                "set_id": 24270
+            },
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17694,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "tomcat-jakartaee-migration",
+                        "repository": "rocky10-appstream"
+                    }
+                ],
+                "set_id": 24271
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17695,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "unbound-dracut",
+                        "repository": "rocky10-appstream"
+                    }
+                ],
+                "set_id": 24272
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 7,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17696,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "unbound-dracut",
+                        "repository": "rocky9-appstream"
+                    }
+                ],
+                "set_id": 24273
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17697,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "bpftool",
+                        "repository": "rocky10-appstream"
+                    }
+                ],
+                "set_id": 24274
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 7,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17698,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "libspelling",
+                        "repository": "rocky10-appstream"
+                    }
+                ],
+                "set_id": 24275
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 7,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17699,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "libspelling-devel",
+                        "repository": "rocky10-crb"
+                    }
+                ],
+                "set_id": 24276
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 7,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 3,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17700,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "tomcat-el-3.0-api",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24277
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 7,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [
+                {
+                    "in_modulestream": null,
+                    "out_modulestream": null
+                }
+            ],
+            "out_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "tomcat-el-5.0-api",
+                        "repository": "rocky10-appstream"
+                    }
+                ],
+                "set_id": 24278
+            },
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 3,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17701,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "tomcat-servlet-4.0-api",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24279
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 7,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [
+                {
+                    "in_modulestream": null,
+                    "out_modulestream": null
+                }
+            ],
+            "out_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "tomcat-servlet-6.0-api",
+                        "repository": "rocky10-appstream"
+                    }
+                ],
+                "set_id": 24280
+            },
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 3,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17702,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "tomcat-jsp-2.3-api",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24281
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 7,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [
+                {
+                    "in_modulestream": null,
+                    "out_modulestream": null
+                }
+            ],
+            "out_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "tomcat-jsp-3.1-api",
+                        "repository": "rocky10-appstream"
+                    }
+                ],
+                "set_id": 24282
+            },
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17703,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "perl-DBD-MariaDB",
+                        "repository": "rocky10-appstream"
+                    }
+                ],
+                "set_id": 24284
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 7,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17704,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "perl-DBD-MySQL",
+                        "repository": "rocky10-appstream"
+                    }
+                ],
+                "set_id": 24285
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 7,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 3,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17705,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "cockpit-composer",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24286
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 7,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [
+                {
+                    "in_modulestream": null,
+                    "out_modulestream": null
+                }
+            ],
+            "out_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "cockpit-image-builder",
+                        "repository": "rocky10-appstream"
+                    }
+                ],
+                "set_id": 24287
+            },
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 2,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17706,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "cockpit-composer",
+                        "repository": "rocky9-appstream"
+                    }
+                ],
+                "set_id": 24288
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "x86_64"
+            ],
+            "id": 17707,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "trustee-guest-components",
+                        "repository": "rocky10-appstream"
+                    }
+                ],
+                "set_id": 24289
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 7,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 4,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17708,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "rsync",
+                        "repository": "rocky9-baseos"
+                    }
+                ],
+                "set_id": 24290
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 5,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [
+                {
+                    "in_modulestream": null,
+                    "out_modulestream": null
+                }
+            ],
+            "out_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "rsync",
+                        "repository": "rocky9-baseos"
+                    },
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "rsync-rrsync",
+                        "repository": "rocky9-appstream"
+                    }
+                ],
+                "set_id": 24291
+            },
+            "release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "Rocky"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17709,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "dnsconfd-micro",
+                        "repository": "rocky10-appstream"
+                    }
+                ],
+                "set_id": 24292
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 7,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
+        },
+        {
             "action": 3,
             "architectures": [
                 "x86_64",
@@ -621331,7 +628027,7 @@
                 "ppc64le",
                 "s390x"
             ],
-            "id": 17430,
+            "id": 17710,
             "in_packageset": {
                 "package": [
                     {
@@ -621342,7 +628038,7 @@
                         "repository": "base"
                     }
                 ],
-                "set_id": 23979
+                "set_id": 24294
             },
             "initial_release": {
                 "major_version": 7,
@@ -621367,7 +628063,7 @@
                         "repository": "rocky8-baseos"
                     }
                 ],
-                "set_id": 23978
+                "set_id": 24293
             },
             "release": {
                 "major_version": 8,
@@ -621385,7 +628081,7 @@
                 "ppc64le",
                 "s390x"
             ],
-            "id": 17431,
+            "id": 17711,
             "in_packageset": {
                 "package": [
                     {
@@ -621396,7 +628092,7 @@
                         "repository": "baseos"
                     }
                 ],
-                "set_id": 23981
+                "set_id": 24296
             },
             "initial_release": {
                 "major_version": 8,
@@ -621416,7 +628112,7 @@
                         "repository": "rocky9-baseos"
                     }
                 ],
-                "set_id": 23980
+                "set_id": 24295
             },
             "release": {
                 "major_version": 9,
@@ -621434,7 +628130,7 @@
                 "ppc64le",
                 "s390x"
             ],
-            "id": 17432,
+            "id": 17712,
             "in_packageset": {
                 "package": [
                     {
@@ -621445,7 +628141,7 @@
                         "repository": "base"
                     }
                 ],
-                "set_id": 23983
+                "set_id": 24298
             },
             "initial_release": {
                 "major_version": 7,
@@ -621470,7 +628166,7 @@
                         "repository": "rocky8-baseos"
                     }
                 ],
-                "set_id": 23982
+                "set_id": 24297
             },
             "release": {
                 "major_version": 8,
@@ -621488,7 +628184,7 @@
                 "ppc64le",
                 "s390x"
             ],
-            "id": 17433,
+            "id": 17713,
             "in_packageset": {
                 "package": [
                     {
@@ -621499,7 +628195,7 @@
                         "repository": "base"
                     }
                 ],
-                "set_id": 23985
+                "set_id": 24300
             },
             "initial_release": {
                 "major_version": 7,
@@ -621524,7 +628220,7 @@
                         "repository": "rocky8-baseos"
                     }
                 ],
-                "set_id": 23984
+                "set_id": 24299
             },
             "release": {
                 "major_version": 8,
@@ -621542,7 +628238,7 @@
                 "ppc64le",
                 "s390x"
             ],
-            "id": 17434,
+            "id": 17714,
             "in_packageset": {
                 "package": [
                     {
@@ -621553,7 +628249,7 @@
                         "repository": "base"
                     }
                 ],
-                "set_id": 23987
+                "set_id": 24302
             },
             "initial_release": {
                 "major_version": 7,
@@ -621578,7 +628274,7 @@
                         "repository": "rocky8-baseos"
                     }
                 ],
-                "set_id": 23986
+                "set_id": 24301
             },
             "release": {
                 "major_version": 8,
@@ -621596,7 +628292,7 @@
                 "ppc64le",
                 "s390x"
             ],
-            "id": 17435,
+            "id": 17715,
             "in_packageset": {
                 "package": [
                     {
@@ -621607,7 +628303,7 @@
                         "repository": "powertools"
                     }
                 ],
-                "set_id": 23988
+                "set_id": 24303
             },
             "initial_release": {
                 "major_version": 8,
@@ -621639,7 +628335,7 @@
                 "ppc64le",
                 "s390x"
             ],
-            "id": 17436,
+            "id": 17716,
             "in_packageset": {
                 "package": [
                     {
@@ -621650,7 +628346,7 @@
                         "repository": "appstream"
                     }
                 ],
-                "set_id": 23989
+                "set_id": 24304
             },
             "initial_release": {
                 "major_version": 8,
@@ -621682,7 +628378,7 @@
                 "ppc64le",
                 "s390x"
             ],
-            "id": 17437,
+            "id": 17717,
             "in_packageset": {
                 "package": [
                     {
@@ -621693,7 +628389,7 @@
                         "repository": "appstream"
                     }
                 ],
-                "set_id": 23990
+                "set_id": 24305
             },
             "initial_release": {
                 "major_version": 8,
@@ -621725,7 +628421,7 @@
                 "ppc64le",
                 "s390x"
             ],
-            "id": 17438,
+            "id": 17718,
             "in_packageset": {
                 "package": [
                     {
@@ -621736,7 +628432,7 @@
                         "repository": "baseos"
                     }
                 ],
-                "set_id": 23991
+                "set_id": 24306
             },
             "initial_release": {
                 "major_version": 8,
@@ -621768,7 +628464,7 @@
                 "ppc64le",
                 "s390x"
             ],
-            "id": 17439,
+            "id": 17719,
             "in_packageset": {
                 "package": [
                     {
@@ -621779,7 +628475,7 @@
                         "repository": "appstream"
                     }
                 ],
-                "set_id": 23992
+                "set_id": 24307
             },
             "initial_release": {
                 "major_version": 8,
@@ -621811,7 +628507,7 @@
                 "ppc64le",
                 "s390x"
             ],
-            "id": 17440,
+            "id": 17720,
             "in_packageset": {
                 "package": [
                     {
@@ -621822,7 +628518,7 @@
                         "repository": "appstream"
                     }
                 ],
-                "set_id": 23993
+                "set_id": 24308
             },
             "initial_release": {
                 "major_version": 8,
@@ -621854,7 +628550,7 @@
                 "ppc64le",
                 "s390x"
             ],
-            "id": 17441,
+            "id": 17721,
             "in_packageset": {
                 "package": [
                     {
@@ -621865,7 +628561,7 @@
                         "repository": "baseos"
                     }
                 ],
-                "set_id": 23994
+                "set_id": 24309
             },
             "initial_release": {
                 "major_version": 8,
@@ -621897,7 +628593,7 @@
                 "ppc64le",
                 "s390x"
             ],
-            "id": 17442,
+            "id": 17722,
             "in_packageset": {
                 "package": [
                     {
@@ -621908,7 +628604,7 @@
                         "repository": "baseos"
                     }
                 ],
-                "set_id": 23995
+                "set_id": 24310
             },
             "initial_release": {
                 "major_version": 8,
@@ -621940,7 +628636,7 @@
                 "ppc64le",
                 "s390x"
             ],
-            "id": 17443,
+            "id": 17723,
             "in_packageset": {
                 "package": [
                     {
@@ -621951,7 +628647,7 @@
                         "repository": "appstream"
                     }
                 ],
-                "set_id": 23996
+                "set_id": 24311
             },
             "initial_release": {
                 "major_version": 8,
@@ -621983,7 +628679,7 @@
                 "ppc64le",
                 "s390x"
             ],
-            "id": 17444,
+            "id": 17724,
             "in_packageset": {
                 "package": [
                     {
@@ -621994,7 +628690,7 @@
                         "repository": "appstream"
                     }
                 ],
-                "set_id": 23997
+                "set_id": 24312
             },
             "initial_release": {
                 "major_version": 8,
@@ -622026,7 +628722,7 @@
                 "ppc64le",
                 "s390x"
             ],
-            "id": 17445,
+            "id": 17725,
             "in_packageset": {
                 "package": [
                     {
@@ -622037,7 +628733,7 @@
                         "repository": "appstream"
                     }
                 ],
-                "set_id": 23998
+                "set_id": 24313
             },
             "initial_release": {
                 "major_version": 8,
@@ -622069,7 +628765,7 @@
                 "ppc64le",
                 "s390x"
             ],
-            "id": 17446,
+            "id": 17726,
             "in_packageset": {
                 "package": [
                     {
@@ -622080,7 +628776,7 @@
                         "repository": "appstream"
                     }
                 ],
-                "set_id": 23999
+                "set_id": 24314
             },
             "initial_release": {
                 "major_version": 8,
@@ -622112,7 +628808,7 @@
                 "ppc64le",
                 "s390x"
             ],
-            "id": 17447,
+            "id": 17727,
             "in_packageset": {
                 "package": [
                     {
@@ -622123,7 +628819,7 @@
                         "repository": "appstream"
                     }
                 ],
-                "set_id": 24000
+                "set_id": 24315
             },
             "initial_release": {
                 "major_version": 8,
@@ -622155,7 +628851,7 @@
                 "ppc64le",
                 "s390x"
             ],
-            "id": 17448,
+            "id": 17728,
             "in_packageset": {
                 "package": [
                     {
@@ -622166,7 +628862,7 @@
                         "repository": "appstream"
                     }
                 ],
-                "set_id": 24001
+                "set_id": 24316
             },
             "initial_release": {
                 "major_version": 8,
@@ -622198,7 +628894,7 @@
                 "ppc64le",
                 "s390x"
             ],
-            "id": 17449,
+            "id": 17729,
             "in_packageset": {
                 "package": [
                     {
@@ -622209,7 +628905,7 @@
                         "repository": "appstream"
                     }
                 ],
-                "set_id": 24002
+                "set_id": 24317
             },
             "initial_release": {
                 "major_version": 8,
@@ -622241,7 +628937,7 @@
                 "ppc64le",
                 "s390x"
             ],
-            "id": 17450,
+            "id": 17730,
             "in_packageset": {
                 "package": [
                     {
@@ -622252,7 +628948,7 @@
                         "repository": "appstream"
                     }
                 ],
-                "set_id": 24003
+                "set_id": 24318
             },
             "initial_release": {
                 "major_version": 8,

--- a/leapp-data.spec
+++ b/leapp-data.spec
@@ -1,4 +1,4 @@
-%global pes_events_build_date 20241127
+%global pes_events_build_date 20250228
 
 %define repositorydir %{_datadir}/leapp-repository/repositories
 
@@ -51,8 +51,8 @@
 %bcond_without check
 
 Name:		leapp-data-%{dist_name}
-Version:	0.6
-Release:	2%{?dist}.%{pes_events_build_date}
+Version:	0.7
+Release:	1%{?dist}.%{pes_events_build_date}
 Summary:	data for migrating tool
 Group:		Applications/Databases
 License:	ASL 2.0
@@ -177,6 +177,11 @@ python3 tests/check_debranding.py %{buildroot}%{_sysconfdir}/leapp/files/pes-eve
 
 
 %changelog
+* Fri Feb 28 2025 Yuriy Kohut <ykohut@almalinux.org> - 0.7-1.20250228
+- Update data to the upstream most recent state:
+ - Device driver deprecation data:
+  - leapp-repository sha 518722058ca53e94c8efa8958ca8fd7cac40dca7
+
 * Wed Jan 15 2025 Yuriy Kohut <ykohut@almalinux.org> - 0.6-2.20241127
 - ELevate to CentOS Stream release 10
 

--- a/leapp-data.spec
+++ b/leapp-data.spec
@@ -182,6 +182,14 @@ python3 tests/check_debranding.py %{buildroot}%{_sysconfdir}/leapp/files/pes-eve
  - Device driver deprecation data:
   - leapp-repository sha 518722058ca53e94c8efa8958ca8fd7cac40dca7
 
+ - PES data:
+  - pes-events.json: upstream state 518722058ca53e94c8efa8958ca8fd7cac40dca7
+  - config.json (all distros):
+   - add libreport-rhel-anaconda-bugzilla (except centos) to the removable packages list, with scenarios: 9to9, 9to10
+   - add redhat-flatpak-repo, redhat-flatpak-preinstall-firefox, redhat-flatpak-preinstall-thunderbird to the removable packages list, with scenarios: 9to10
+  - epel_pes.json_template:
+   - remove duplicated id and set_id
+
 * Wed Jan 15 2025 Yuriy Kohut <ykohut@almalinux.org> - 0.6-2.20241127
 - ELevate to CentOS Stream release 10
 

--- a/tools/device_driver_deprecation_data-update.sh
+++ b/tools/device_driver_deprecation_data-update.sh
@@ -25,7 +25,7 @@ release_notes_sha=master
 # Upstream leapp-repository GitHub URL, device driver deprecation data (in JSON format) file name, and Git SHA
 leapp_repository_url=https://raw.githubusercontent.com/oamg/leapp-repository
 device_driver_deprecation_data_json="device_driver_deprecation_data.json"
-leapp_repository_sha=2dc7efa41ccf7206e0e33d687d7931846f3e4390
+leapp_repository_sha=518722058ca53e94c8efa8958ca8fd7cac40dca7
 
 printf "\nDownload %s at %s\n" ${device_driver_deprecation_data_json} ${leapp_repository_sha}
 curl -s -o ${device_driver_deprecation_data_json} ${leapp_repository_url}/${leapp_repository_sha}/etc/leapp/files/${device_driver_deprecation_data_json} || exit 1

--- a/tools/update_pes-events.py
+++ b/tools/update_pes-events.py
@@ -1,7 +1,7 @@
 import json
 import requests
 
-specific_commit = '2dc7efa41ccf7206e0e33d687d7931846f3e4390'
+specific_commit = '518722058ca53e94c8efa8958ca8fd7cac40dca7'
 
 
 def download_pes_events(session, url):

--- a/vendors.d/epel_pes.json_template
+++ b/vendors.d/epel_pes.json_template
@@ -162663,7 +162663,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17473,
+            "id": 33655,
             "in_packageset": {
                 "package": [
                     {
@@ -162698,7 +162698,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17474,
+            "id": 33656,
             "in_packageset": {
                 "package": [
                     {
@@ -162733,7 +162733,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17475,
+            "id": 33657,
             "in_packageset": {
                 "package": [
                     {
@@ -162768,7 +162768,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17476,
+            "id": 33658,
             "in_packageset": {
                 "package": [
                     {
@@ -162803,7 +162803,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17477,
+            "id": 33659,
             "in_packageset": {
                 "package": [
                     {
@@ -162838,7 +162838,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17478,
+            "id": 33660,
             "in_packageset": {
                 "package": [
                     {
@@ -162873,7 +162873,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17479,
+            "id": 33661,
             "in_packageset": {
                 "package": [
                     {
@@ -162908,7 +162908,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17480,
+            "id": 33662,
             "in_packageset": {
                 "package": [
                     {
@@ -162943,7 +162943,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17481,
+            "id": 33663,
             "in_packageset": {
                 "package": [
                     {
@@ -162978,7 +162978,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17482,
+            "id": 33664,
             "in_packageset": {
                 "package": [
                     {
@@ -163013,7 +163013,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17483,
+            "id": 33665,
             "in_packageset": {
                 "package": [
                     {
@@ -163048,7 +163048,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17484,
+            "id": 33931,
             "in_packageset": {
                 "package": [
                     {
@@ -163083,7 +163083,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17485,
+            "id": 33932,
             "in_packageset": {
                 "package": [
                     {
@@ -163118,7 +163118,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17486,
+            "id": 33933,
             "in_packageset": {
                 "package": [
                     {
@@ -163153,7 +163153,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17487,
+            "id": 33666,
             "in_packageset": {
                 "package": [
                     {
@@ -163188,7 +163188,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17488,
+            "id": 33667,
             "in_packageset": {
                 "package": [
                     {
@@ -163223,7 +163223,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17489,
+            "id": 33668,
             "in_packageset": {
                 "package": [
                     {
@@ -163258,7 +163258,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17490,
+            "id": 33669,
             "in_packageset": {
                 "package": [
                     {
@@ -163293,7 +163293,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17491,
+            "id": 33670,
             "in_packageset": {
                 "package": [
                     {
@@ -163328,7 +163328,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17492,
+            "id": 33671,
             "in_packageset": {
                 "package": [
                     {
@@ -163363,7 +163363,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17493,
+            "id": 33672,
             "in_packageset": {
                 "package": [
                     {
@@ -163398,7 +163398,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17494,
+            "id": 33673,
             "in_packageset": {
                 "package": [
                     {
@@ -163433,7 +163433,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17495,
+            "id": 33674,
             "in_packageset": {
                 "package": [
                     {
@@ -163503,7 +163503,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17496,
+            "id": 33675,
             "in_packageset": {
                 "package": [
                     {
@@ -163538,7 +163538,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17497,
+            "id": 33676,
             "in_packageset": {
                 "package": [
                     {
@@ -163573,7 +163573,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17498,
+            "id": 33677,
             "in_packageset": {
                 "package": [
                     {
@@ -163608,7 +163608,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17499,
+            "id": 33678,
             "in_packageset": {
                 "package": [
                     {
@@ -163643,7 +163643,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17500,
+            "id": 33679,
             "in_packageset": {
                 "package": [
                     {
@@ -163678,7 +163678,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17501,
+            "id": 33680,
             "in_packageset": {
                 "package": [
                     {
@@ -163713,7 +163713,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17502,
+            "id": 33681,
             "in_packageset": {
                 "package": [
                     {
@@ -163748,7 +163748,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17503,
+            "id": 33682,
             "in_packageset": {
                 "package": [
                     {
@@ -163783,7 +163783,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17504,
+            "id": 33683,
             "in_packageset": {
                 "package": [
                     {
@@ -163818,7 +163818,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17505,
+            "id": 33684,
             "in_packageset": {
                 "package": [
                     {
@@ -163853,7 +163853,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17506,
+            "id": 33685,
             "in_packageset": {
                 "package": [
                     {
@@ -163888,7 +163888,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17507,
+            "id": 33686,
             "in_packageset": {
                 "package": [
                     {
@@ -163923,7 +163923,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17508,
+            "id": 33687,
             "in_packageset": {
                 "package": [
                     {
@@ -163958,7 +163958,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17509,
+            "id": 33688,
             "in_packageset": {
                 "package": [
                     {
@@ -164028,7 +164028,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17510,
+            "id": 33689,
             "in_packageset": {
                 "package": [
                     {
@@ -164063,7 +164063,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17511,
+            "id": 33690,
             "in_packageset": {
                 "package": [
                     {
@@ -164098,7 +164098,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17512,
+            "id": 33691,
             "in_packageset": {
                 "package": [
                     {
@@ -164133,7 +164133,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17513,
+            "id": 33692,
             "in_packageset": {
                 "package": [
                     {
@@ -164168,7 +164168,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17514,
+            "id": 33693,
             "in_packageset": {
                 "package": [
                     {
@@ -164203,7 +164203,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17515,
+            "id": 33694,
             "in_packageset": {
                 "package": [
                     {
@@ -164238,7 +164238,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17516,
+            "id": 33695,
             "in_packageset": {
                 "package": [
                     {
@@ -164273,7 +164273,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17517,
+            "id": 33696,
             "in_packageset": {
                 "package": [
                     {
@@ -164308,7 +164308,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17518,
+            "id": 33697,
             "in_packageset": {
                 "package": [
                     {
@@ -164343,7 +164343,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17519,
+            "id": 33698,
             "in_packageset": {
                 "package": [
                     {
@@ -164378,7 +164378,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17520,
+            "id": 33699,
             "in_packageset": {
                 "package": [
                     {
@@ -164413,7 +164413,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17521,
+            "id": 33700,
             "in_packageset": {
                 "package": [
                     {
@@ -164448,7 +164448,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17522,
+            "id": 33701,
             "in_packageset": {
                 "package": [
                     {
@@ -164483,7 +164483,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17523,
+            "id": 33702,
             "in_packageset": {
                 "package": [
                     {
@@ -164518,7 +164518,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17524,
+            "id": 33703,
             "in_packageset": {
                 "package": [
                     {
@@ -164553,7 +164553,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17525,
+            "id": 33704,
             "in_packageset": {
                 "package": [
                     {
@@ -164588,7 +164588,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17526,
+            "id": 33705,
             "in_packageset": {
                 "package": [
                     {
@@ -164623,7 +164623,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17527,
+            "id": 33706,
             "in_packageset": {
                 "package": [
                     {
@@ -164693,7 +164693,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17528,
+            "id": 33707,
             "in_packageset": {
                 "package": [
                     {
@@ -164728,7 +164728,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17529,
+            "id": 33708,
             "in_packageset": {
                 "package": [
                     {
@@ -164763,7 +164763,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17530,
+            "id": 33709,
             "in_packageset": {
                 "package": [
                     {
@@ -164798,7 +164798,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17531,
+            "id": 33710,
             "in_packageset": {
                 "package": [
                     {
@@ -164833,7 +164833,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17532,
+            "id": 33711,
             "in_packageset": {
                 "package": [
                     {
@@ -164868,7 +164868,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17533,
+            "id": 33712,
             "in_packageset": {
                 "package": [
                     {
@@ -164903,7 +164903,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17534,
+            "id": 33713,
             "in_packageset": {
                 "package": [
                     {
@@ -164938,7 +164938,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17535,
+            "id": 33714,
             "in_packageset": {
                 "package": [
                     {
@@ -164973,7 +164973,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17536,
+            "id": 33715,
             "in_packageset": {
                 "package": [
                     {
@@ -165008,7 +165008,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17537,
+            "id": 33716,
             "in_packageset": {
                 "package": [
                     {
@@ -165043,7 +165043,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17538,
+            "id": 33717,
             "in_packageset": {
                 "package": [
                     {
@@ -165078,7 +165078,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17539,
+            "id": 33718,
             "in_packageset": {
                 "package": [
                     {
@@ -165113,7 +165113,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17540,
+            "id": 33719,
             "in_packageset": {
                 "package": [
                     {
@@ -165148,7 +165148,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17541,
+            "id": 33720,
             "in_packageset": {
                 "package": [
                     {
@@ -165183,7 +165183,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17542,
+            "id": 33721,
             "in_packageset": {
                 "package": [
                     {
@@ -165218,7 +165218,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17543,
+            "id": 33722,
             "in_packageset": {
                 "package": [
                     {
@@ -165288,7 +165288,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17544,
+            "id": 33723,
             "in_packageset": {
                 "package": [
                     {
@@ -165358,7 +165358,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17545,
+            "id": 33724,
             "in_packageset": {
                 "package": [
                     {
@@ -165393,7 +165393,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17546,
+            "id": 33725,
             "in_packageset": {
                 "package": [
                     {
@@ -165568,7 +165568,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17547,
+            "id": 33726,
             "in_packageset": {
                 "package": [
                     {
@@ -165603,7 +165603,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17548,
+            "id": 33727,
             "in_packageset": {
                 "package": [
                     {
@@ -165638,7 +165638,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17549,
+            "id": 33728,
             "in_packageset": {
                 "package": [
                     {
@@ -165673,7 +165673,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17550,
+            "id": 33729,
             "in_packageset": {
                 "package": [
                     {
@@ -165708,7 +165708,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17551,
+            "id": 33730,
             "in_packageset": {
                 "package": [
                     {
@@ -165743,7 +165743,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17552,
+            "id": 33731,
             "in_packageset": {
                 "package": [
                     {
@@ -165778,7 +165778,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17553,
+            "id": 33732,
             "in_packageset": {
                 "package": [
                     {
@@ -165813,7 +165813,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17554,
+            "id": 33733,
             "in_packageset": {
                 "package": [
                     {
@@ -165848,7 +165848,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17555,
+            "id": 33734,
             "in_packageset": {
                 "package": [
                     {
@@ -165883,7 +165883,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17556,
+            "id": 33735,
             "in_packageset": {
                 "package": [
                     {
@@ -165918,7 +165918,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17557,
+            "id": 33736,
             "in_packageset": {
                 "package": [
                     {
@@ -165953,7 +165953,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17558,
+            "id": 33737,
             "in_packageset": {
                 "package": [
                     {
@@ -165988,7 +165988,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17559,
+            "id": 33738,
             "in_packageset": {
                 "package": [
                     {
@@ -166023,7 +166023,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17560,
+            "id": 33739,
             "in_packageset": {
                 "package": [
                     {
@@ -166058,7 +166058,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17561,
+            "id": 33740,
             "in_packageset": {
                 "package": [
                     {
@@ -166093,7 +166093,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17562,
+            "id": 33741,
             "in_packageset": {
                 "package": [
                     {
@@ -166128,7 +166128,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17563,
+            "id": 33742,
             "in_packageset": {
                 "package": [
                     {
@@ -166163,7 +166163,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17564,
+            "id": 33743,
             "in_packageset": {
                 "package": [
                     {
@@ -166268,7 +166268,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17565,
+            "id": 33744,
             "in_packageset": {
                 "package": [
                     {
@@ -166303,7 +166303,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17566,
+            "id": 33745,
             "in_packageset": {
                 "package": [
                     {
@@ -166338,7 +166338,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17567,
+            "id": 33746,
             "in_packageset": {
                 "package": [
                     {
@@ -166373,7 +166373,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17568,
+            "id": 33747,
             "in_packageset": {
                 "package": [
                     {
@@ -166443,7 +166443,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17569,
+            "id": 33748,
             "in_packageset": {
                 "package": [
                     {
@@ -166478,7 +166478,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17570,
+            "id": 33749,
             "in_packageset": {
                 "package": [
                     {
@@ -166513,7 +166513,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17571,
+            "id": 33750,
             "in_packageset": {
                 "package": [
                     {
@@ -166548,7 +166548,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17572,
+            "id": 33751,
             "in_packageset": {
                 "package": [
                     {
@@ -166583,7 +166583,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17573,
+            "id": 33752,
             "in_packageset": {
                 "package": [
                     {
@@ -166618,7 +166618,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17574,
+            "id": 33753,
             "in_packageset": {
                 "package": [
                     {
@@ -166653,7 +166653,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17575,
+            "id": 33754,
             "in_packageset": {
                 "package": [
                     {
@@ -166688,7 +166688,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17576,
+            "id": 33755,
             "in_packageset": {
                 "package": [
                     {
@@ -166723,7 +166723,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17577,
+            "id": 33756,
             "in_packageset": {
                 "package": [
                     {
@@ -166758,7 +166758,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17578,
+            "id": 33757,
             "in_packageset": {
                 "package": [
                     {
@@ -166793,7 +166793,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17579,
+            "id": 33758,
             "in_packageset": {
                 "package": [
                     {
@@ -166828,7 +166828,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17580,
+            "id": 33759,
             "in_packageset": {
                 "package": [
                     {
@@ -166863,7 +166863,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17581,
+            "id": 33760,
             "in_packageset": {
                 "package": [
                     {
@@ -166898,7 +166898,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17582,
+            "id": 33761,
             "in_packageset": {
                 "package": [
                     {
@@ -166933,7 +166933,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17583,
+            "id": 33762,
             "in_packageset": {
                 "package": [
                     {
@@ -166968,7 +166968,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17584,
+            "id": 33763,
             "in_packageset": {
                 "package": [
                     {
@@ -167038,7 +167038,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17586,
+            "id": 33764,
             "in_packageset": {
                 "package": [
                     {
@@ -167073,7 +167073,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17587,
+            "id": 33765,
             "in_packageset": {
                 "package": [
                     {
@@ -167108,7 +167108,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17588,
+            "id": 33766,
             "in_packageset": {
                 "package": [
                     {
@@ -167143,7 +167143,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17589,
+            "id": 33767,
             "in_packageset": {
                 "package": [
                     {
@@ -167178,7 +167178,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17590,
+            "id": 33768,
             "in_packageset": {
                 "package": [
                     {
@@ -167213,7 +167213,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17591,
+            "id": 33769,
             "in_packageset": {
                 "package": [
                     {
@@ -167248,7 +167248,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17592,
+            "id": 33770,
             "in_packageset": {
                 "package": [
                     {
@@ -167283,7 +167283,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17593,
+            "id": 33771,
             "in_packageset": {
                 "package": [
                     {
@@ -167318,7 +167318,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17594,
+            "id": 33772,
             "in_packageset": {
                 "package": [
                     {
@@ -167353,7 +167353,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17595,
+            "id": 33773,
             "in_packageset": {
                 "package": [
                     {
@@ -167388,7 +167388,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17596,
+            "id": 33774,
             "in_packageset": {
                 "package": [
                     {
@@ -167423,7 +167423,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17597,
+            "id": 33775,
             "in_packageset": {
                 "package": [
                     {
@@ -167458,7 +167458,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17598,
+            "id": 33776,
             "in_packageset": {
                 "package": [
                     {
@@ -167493,7 +167493,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17599,
+            "id": 33777,
             "in_packageset": {
                 "package": [
                     {
@@ -167528,7 +167528,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17600,
+            "id": 33778,
             "in_packageset": {
                 "package": [
                     {
@@ -167563,7 +167563,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17601,
+            "id": 33779,
             "in_packageset": {
                 "package": [
                     {
@@ -167598,7 +167598,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17602,
+            "id": 33780,
             "in_packageset": {
                 "package": [
                     {
@@ -167633,7 +167633,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17603,
+            "id": 33781,
             "in_packageset": {
                 "package": [
                     {
@@ -167668,7 +167668,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17604,
+            "id": 33782,
             "in_packageset": {
                 "package": [
                     {
@@ -167703,7 +167703,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17605,
+            "id": 33783,
             "in_packageset": {
                 "package": [
                     {
@@ -167738,7 +167738,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17606,
+            "id": 33784,
             "in_packageset": {
                 "package": [
                     {
@@ -167773,7 +167773,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17607,
+            "id": 33785,
             "in_packageset": {
                 "package": [
                     {
@@ -167808,7 +167808,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17608,
+            "id": 33786,
             "in_packageset": {
                 "package": [
                     {
@@ -167843,7 +167843,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17609,
+            "id": 33787,
             "in_packageset": {
                 "package": [
                     {
@@ -167878,7 +167878,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17610,
+            "id": 33788,
             "in_packageset": {
                 "package": [
                     {
@@ -167913,7 +167913,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17611,
+            "id": 33789,
             "in_packageset": {
                 "package": [
                     {
@@ -167983,7 +167983,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17612,
+            "id": 33790,
             "in_packageset": {
                 "package": [
                     {
@@ -168018,7 +168018,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17613,
+            "id": 33791,
             "in_packageset": {
                 "package": [
                     {
@@ -168053,7 +168053,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17614,
+            "id": 33792,
             "in_packageset": {
                 "package": [
                     {
@@ -168088,7 +168088,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17615,
+            "id": 33793,
             "in_packageset": {
                 "package": [
                     {
@@ -168123,7 +168123,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17616,
+            "id": 33794,
             "in_packageset": {
                 "package": [
                     {
@@ -168158,7 +168158,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17617,
+            "id": 33795,
             "in_packageset": {
                 "package": [
                     {
@@ -168193,7 +168193,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17618,
+            "id": 33796,
             "in_packageset": {
                 "package": [
                     {
@@ -168228,7 +168228,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17619,
+            "id": 33797,
             "in_packageset": {
                 "package": [
                     {
@@ -168263,7 +168263,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17620,
+            "id": 33798,
             "in_packageset": {
                 "package": [
                     {
@@ -168298,7 +168298,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17621,
+            "id": 33799,
             "in_packageset": {
                 "package": [
                     {
@@ -168333,7 +168333,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17622,
+            "id": 33800,
             "in_packageset": {
                 "package": [
                     {
@@ -168368,7 +168368,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17623,
+            "id": 33801,
             "in_packageset": {
                 "package": [
                     {
@@ -168403,7 +168403,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17624,
+            "id": 33802,
             "in_packageset": {
                 "package": [
                     {
@@ -168438,7 +168438,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17625,
+            "id": 33803,
             "in_packageset": {
                 "package": [
                     {
@@ -168473,7 +168473,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17626,
+            "id": 33804,
             "in_packageset": {
                 "package": [
                     {
@@ -168508,7 +168508,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17627,
+            "id": 33805,
             "in_packageset": {
                 "package": [
                     {
@@ -168543,7 +168543,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17628,
+            "id": 33806,
             "in_packageset": {
                 "package": [
                     {
@@ -168578,7 +168578,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17629,
+            "id": 33807,
             "in_packageset": {
                 "package": [
                     {
@@ -168613,7 +168613,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17630,
+            "id": 33808,
             "in_packageset": {
                 "package": [
                     {
@@ -168648,7 +168648,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17631,
+            "id": 33809,
             "in_packageset": {
                 "package": [
                     {
@@ -168683,7 +168683,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17632,
+            "id": 33810,
             "in_packageset": {
                 "package": [
                     {
@@ -168718,7 +168718,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17633,
+            "id": 33811,
             "in_packageset": {
                 "package": [
                     {
@@ -168753,7 +168753,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17634,
+            "id": 33812,
             "in_packageset": {
                 "package": [
                     {
@@ -168788,7 +168788,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17635,
+            "id": 33813,
             "in_packageset": {
                 "package": [
                     {
@@ -168823,7 +168823,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17636,
+            "id": 33814,
             "in_packageset": {
                 "package": [
                     {
@@ -168858,7 +168858,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17637,
+            "id": 33815,
             "in_packageset": {
                 "package": [
                     {
@@ -168893,7 +168893,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17638,
+            "id": 33816,
             "in_packageset": {
                 "package": [
                     {
@@ -168928,7 +168928,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17639,
+            "id": 33817,
             "in_packageset": {
                 "package": [
                     {
@@ -168963,7 +168963,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17640,
+            "id": 33818,
             "in_packageset": {
                 "package": [
                     {
@@ -168998,7 +168998,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17641,
+            "id": 33819,
             "in_packageset": {
                 "package": [
                     {
@@ -169033,7 +169033,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17642,
+            "id": 33820,
             "in_packageset": {
                 "package": [
                     {
@@ -169068,7 +169068,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17643,
+            "id": 33821,
             "in_packageset": {
                 "package": [
                     {
@@ -169103,7 +169103,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17644,
+            "id": 33822,
             "in_packageset": {
                 "package": [
                     {
@@ -169138,7 +169138,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17645,
+            "id": 33823,
             "in_packageset": {
                 "package": [
                     {
@@ -169173,7 +169173,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17646,
+            "id": 33824,
             "in_packageset": {
                 "package": [
                     {
@@ -169208,7 +169208,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17647,
+            "id": 33825,
             "in_packageset": {
                 "package": [
                     {
@@ -169243,7 +169243,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17648,
+            "id": 33826,
             "in_packageset": {
                 "package": [
                     {
@@ -169278,7 +169278,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17649,
+            "id": 33827,
             "in_packageset": {
                 "package": [
                     {
@@ -169313,7 +169313,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17650,
+            "id": 33828,
             "in_packageset": {
                 "package": [
                     {
@@ -169348,7 +169348,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17651,
+            "id": 33829,
             "in_packageset": {
                 "package": [
                     {
@@ -169383,7 +169383,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17652,
+            "id": 33830,
             "in_packageset": {
                 "package": [
                     {
@@ -169418,7 +169418,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17653,
+            "id": 33831,
             "in_packageset": {
                 "package": [
                     {
@@ -169453,7 +169453,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17654,
+            "id": 33832,
             "in_packageset": {
                 "package": [
                     {
@@ -169488,7 +169488,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17655,
+            "id": 33833,
             "in_packageset": {
                 "package": [
                     {
@@ -169523,7 +169523,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17656,
+            "id": 33834,
             "in_packageset": {
                 "package": [
                     {
@@ -169558,7 +169558,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17657,
+            "id": 33835,
             "in_packageset": {
                 "package": [
                     {
@@ -169593,7 +169593,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17658,
+            "id": 33836,
             "in_packageset": {
                 "package": [
                     {
@@ -169628,7 +169628,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17659,
+            "id": 33837,
             "in_packageset": {
                 "package": [
                     {
@@ -169663,7 +169663,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17660,
+            "id": 33838,
             "in_packageset": {
                 "package": [
                     {
@@ -169698,7 +169698,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17661,
+            "id": 33839,
             "in_packageset": {
                 "package": [
                     {
@@ -169733,7 +169733,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17662,
+            "id": 33840,
             "in_packageset": {
                 "package": [
                     {
@@ -169768,7 +169768,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17663,
+            "id": 33841,
             "in_packageset": {
                 "package": [
                     {
@@ -169803,7 +169803,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17664,
+            "id": 33842,
             "in_packageset": {
                 "package": [
                     {
@@ -169838,7 +169838,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17665,
+            "id": 33843,
             "in_packageset": {
                 "package": [
                     {
@@ -169873,7 +169873,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17666,
+            "id": 33844,
             "in_packageset": {
                 "package": [
                     {
@@ -169908,7 +169908,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17667,
+            "id": 33845,
             "in_packageset": {
                 "package": [
                     {
@@ -169943,7 +169943,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17668,
+            "id": 33846,
             "in_packageset": {
                 "package": [
                     {
@@ -169978,7 +169978,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17669,
+            "id": 33847,
             "in_packageset": {
                 "package": [
                     {
@@ -170013,7 +170013,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17670,
+            "id": 33848,
             "in_packageset": {
                 "package": [
                     {
@@ -170048,7 +170048,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17671,
+            "id": 33849,
             "in_packageset": {
                 "package": [
                     {
@@ -170083,7 +170083,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17672,
+            "id": 33850,
             "in_packageset": {
                 "package": [
                     {
@@ -170118,7 +170118,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17673,
+            "id": 33851,
             "in_packageset": {
                 "package": [
                     {
@@ -170153,7 +170153,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17674,
+            "id": 33852,
             "in_packageset": {
                 "package": [
                     {
@@ -170188,7 +170188,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17675,
+            "id": 33853,
             "in_packageset": {
                 "package": [
                     {
@@ -170223,7 +170223,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17676,
+            "id": 33854,
             "in_packageset": {
                 "package": [
                     {
@@ -170293,7 +170293,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17677,
+            "id": 33855,
             "in_packageset": {
                 "package": [
                     {
@@ -170328,7 +170328,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17678,
+            "id": 33856,
             "in_packageset": {
                 "package": [
                     {
@@ -170363,7 +170363,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17679,
+            "id": 33857,
             "in_packageset": {
                 "package": [
                     {
@@ -170398,7 +170398,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17680,
+            "id": 33858,
             "in_packageset": {
                 "package": [
                     {
@@ -170433,7 +170433,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17681,
+            "id": 33859,
             "in_packageset": {
                 "package": [
                     {
@@ -170468,7 +170468,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17682,
+            "id": 33860,
             "in_packageset": {
                 "package": [
                     {
@@ -170503,7 +170503,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17683,
+            "id": 33861,
             "in_packageset": {
                 "package": [
                     {
@@ -170538,7 +170538,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17684,
+            "id": 33862,
             "in_packageset": {
                 "package": [
                     {
@@ -170573,7 +170573,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17685,
+            "id": 33863,
             "in_packageset": {
                 "package": [
                     {
@@ -170608,7 +170608,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17686,
+            "id": 33864,
             "in_packageset": {
                 "package": [
                     {
@@ -170643,7 +170643,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17687,
+            "id": 33865,
             "in_packageset": {
                 "package": [
                     {
@@ -170678,7 +170678,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17688,
+            "id": 33866,
             "in_packageset": {
                 "package": [
                     {
@@ -170713,7 +170713,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17689,
+            "id": 33867,
             "in_packageset": {
                 "package": [
                     {
@@ -170748,7 +170748,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17690,
+            "id": 33868,
             "in_packageset": {
                 "package": [
                     {
@@ -170783,7 +170783,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17691,
+            "id": 33869,
             "in_packageset": {
                 "package": [
                     {
@@ -170818,7 +170818,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17692,
+            "id": 33870,
             "in_packageset": {
                 "package": [
                     {
@@ -170853,7 +170853,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17693,
+            "id": 33871,
             "in_packageset": {
                 "package": [
                     {
@@ -170888,7 +170888,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17694,
+            "id": 33872,
             "in_packageset": {
                 "package": [
                     {
@@ -170923,7 +170923,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17695,
+            "id": 33873,
             "in_packageset": {
                 "package": [
                     {
@@ -171063,7 +171063,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17696,
+            "id": 33874,
             "in_packageset": {
                 "package": [
                     {
@@ -171203,7 +171203,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17697,
+            "id": 33875,
             "in_packageset": {
                 "package": [
                     {
@@ -171273,7 +171273,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17698,
+            "id": 33876,
             "in_packageset": {
                 "package": [
                     {
@@ -171308,7 +171308,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17699,
+            "id": 33877,
             "in_packageset": {
                 "package": [
                     {
@@ -171343,7 +171343,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17700,
+            "id": 33878,
             "in_packageset": {
                 "package": [
                     {
@@ -171378,7 +171378,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17701,
+            "id": 33879,
             "in_packageset": {
                 "package": [
                     {
@@ -171413,7 +171413,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17702,
+            "id": 33880,
             "in_packageset": {
                 "package": [
                     {
@@ -171448,7 +171448,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17703,
+            "id": 33881,
             "in_packageset": {
                 "package": [
                     {
@@ -171518,7 +171518,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17704,
+            "id": 33882,
             "in_packageset": {
                 "package": [
                     {
@@ -171553,7 +171553,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17705,
+            "id": 33883,
             "in_packageset": {
                 "package": [
                     {
@@ -171588,7 +171588,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17706,
+            "id": 33884,
             "in_packageset": {
                 "package": [
                     {
@@ -171623,7 +171623,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17707,
+            "id": 33885,
             "in_packageset": {
                 "package": [
                     {
@@ -171658,7 +171658,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17708,
+            "id": 33886,
             "in_packageset": {
                 "package": [
                     {
@@ -171693,7 +171693,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17709,
+            "id": 33887,
             "in_packageset": {
                 "package": [
                     {
@@ -171728,7 +171728,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17710,
+            "id": 33888,
             "in_packageset": {
                 "package": [
                     {
@@ -171763,7 +171763,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17711,
+            "id": 33889,
             "in_packageset": {
                 "package": [
                     {
@@ -171798,7 +171798,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17712,
+            "id": 33890,
             "in_packageset": {
                 "package": [
                     {
@@ -171833,7 +171833,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17713,
+            "id": 33891,
             "in_packageset": {
                 "package": [
                     {
@@ -171868,7 +171868,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17714,
+            "id": 33892,
             "in_packageset": {
                 "package": [
                     {
@@ -171903,7 +171903,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17715,
+            "id": 33893,
             "in_packageset": {
                 "package": [
                     {
@@ -171938,7 +171938,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17716,
+            "id": 33894,
             "in_packageset": {
                 "package": [
                     {
@@ -171973,7 +171973,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17717,
+            "id": 33895,
             "in_packageset": {
                 "package": [
                     {
@@ -172288,7 +172288,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17718,
+            "id": 33896,
             "in_packageset": {
                 "package": [
                     {
@@ -172323,7 +172323,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17719,
+            "id": 33897,
             "in_packageset": {
                 "package": [
                     {
@@ -172358,7 +172358,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17720,
+            "id": 33898,
             "in_packageset": {
                 "package": [
                     {
@@ -172393,7 +172393,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17721,
+            "id": 33899,
             "in_packageset": {
                 "package": [
                     {
@@ -172428,7 +172428,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17722,
+            "id": 33900,
             "in_packageset": {
                 "package": [
                     {
@@ -172463,7 +172463,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17723,
+            "id": 33901,
             "in_packageset": {
                 "package": [
                     {
@@ -172498,7 +172498,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17724,
+            "id": 33902,
             "in_packageset": {
                 "package": [
                     {
@@ -172533,7 +172533,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17725,
+            "id": 33903,
             "in_packageset": {
                 "package": [
                     {
@@ -172568,7 +172568,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17726,
+            "id": 33904,
             "in_packageset": {
                 "package": [
                     {
@@ -172603,7 +172603,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17727,
+            "id": 33905,
             "in_packageset": {
                 "package": [
                     {
@@ -172638,7 +172638,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17728,
+            "id": 33906,
             "in_packageset": {
                 "package": [
                     {
@@ -172673,7 +172673,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17729,
+            "id": 33907,
             "in_packageset": {
                 "package": [
                     {
@@ -172743,7 +172743,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17730,
+            "id": 33908,
             "in_packageset": {
                 "package": [
                     {
@@ -172848,7 +172848,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17731,
+            "id": 33909,
             "in_packageset": {
                 "package": [
                     {
@@ -172883,7 +172883,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17732,
+            "id": 33910,
             "in_packageset": {
                 "package": [
                     {
@@ -173058,7 +173058,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17733,
+            "id": 33911,
             "in_packageset": {
                 "package": [
                     {
@@ -173093,7 +173093,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17734,
+            "id": 33912,
             "in_packageset": {
                 "package": [
                     {
@@ -173128,7 +173128,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17735,
+            "id": 33913,
             "in_packageset": {
                 "package": [
                     {
@@ -173163,7 +173163,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17736,
+            "id": 33914,
             "in_packageset": {
                 "package": [
                     {
@@ -173268,7 +173268,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17737,
+            "id": 33915,
             "in_packageset": {
                 "package": [
                     {
@@ -173303,7 +173303,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17738,
+            "id": 33916,
             "in_packageset": {
                 "package": [
                     {
@@ -173338,7 +173338,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17739,
+            "id": 33917,
             "in_packageset": {
                 "package": [
                     {
@@ -173373,7 +173373,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17740,
+            "id": 33918,
             "in_packageset": {
                 "package": [
                     {
@@ -173688,7 +173688,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17741,
+            "id": 33919,
             "in_packageset": {
                 "package": [
                     {
@@ -173723,7 +173723,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17742,
+            "id": 33920,
             "in_packageset": {
                 "package": [
                     {
@@ -173758,7 +173758,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17743,
+            "id": 33921,
             "in_packageset": {
                 "package": [
                     {
@@ -173968,7 +173968,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17744,
+            "id": 33922,
             "in_packageset": {
                 "package": [
                     {
@@ -174003,7 +174003,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17745,
+            "id": 33923,
             "in_packageset": {
                 "package": [
                     {
@@ -174038,7 +174038,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17746,
+            "id": 33924,
             "in_packageset": {
                 "package": [
                     {
@@ -174073,7 +174073,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17747,
+            "id": 33925,
             "in_packageset": {
                 "package": [
                     {
@@ -174108,7 +174108,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17748,
+            "id": 33926,
             "in_packageset": {
                 "package": [
                     {
@@ -174143,7 +174143,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17749,
+            "id": 33927,
             "in_packageset": {
                 "package": [
                     {
@@ -174178,7 +174178,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17750,
+            "id": 33928,
             "in_packageset": {
                 "package": [
                     {
@@ -174213,7 +174213,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17751,
+            "id": 33929,
             "in_packageset": {
                 "package": [
                     {
@@ -174248,7 +174248,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17752,
+            "id": 33930,
             "in_packageset": {
                 "package": [
                     {
@@ -227037,7 +227037,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24030
+                "set_id": 33869
             },
             "initial_release": {
                 "major_version": 7,
@@ -227072,7 +227072,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24031
+                "set_id": 33870
             },
             "initial_release": {
                 "major_version": 7,
@@ -227107,7 +227107,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24032
+                "set_id": 33871
             },
             "initial_release": {
                 "major_version": 7,
@@ -227142,7 +227142,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24033
+                "set_id": 33872
             },
             "initial_release": {
                 "major_version": 7,
@@ -227177,7 +227177,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24034
+                "set_id": 33873
             },
             "initial_release": {
                 "major_version": 7,
@@ -227212,7 +227212,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24035
+                "set_id": 33874
             },
             "initial_release": {
                 "major_version": 7,
@@ -227317,7 +227317,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24038
+                "set_id": 33875
             },
             "initial_release": {
                 "major_version": 7,
@@ -227352,7 +227352,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24039
+                "set_id": 33876
             },
             "initial_release": {
                 "major_version": 7,
@@ -227387,7 +227387,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24040
+                "set_id": 33877
             },
             "initial_release": {
                 "major_version": 7,
@@ -227422,7 +227422,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24041
+                "set_id": 33878
             },
             "initial_release": {
                 "major_version": 7,
@@ -227457,7 +227457,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24042
+                "set_id": 33879
             },
             "initial_release": {
                 "major_version": 7,
@@ -227492,7 +227492,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24043
+                "set_id": 33880
             },
             "initial_release": {
                 "major_version": 7,
@@ -227527,7 +227527,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24044
+                "set_id": 33881
             },
             "initial_release": {
                 "major_version": 7,
@@ -227562,7 +227562,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24045
+                "set_id": 33882
             },
             "initial_release": {
                 "major_version": 7,
@@ -227597,7 +227597,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24046
+                "set_id": 33883
             },
             "initial_release": {
                 "major_version": 7,
@@ -227632,7 +227632,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24047
+                "set_id": 33884
             },
             "initial_release": {
                 "major_version": 7,
@@ -227667,7 +227667,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24048
+                "set_id": 33885
             },
             "initial_release": {
                 "major_version": 7,
@@ -227702,7 +227702,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24049
+                "set_id": 34175
             },
             "initial_release": {
                 "major_version": 7,
@@ -227737,7 +227737,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24050
+                "set_id": 34176
             },
             "initial_release": {
                 "major_version": 7,
@@ -227772,7 +227772,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24051
+                "set_id": 34177
             },
             "initial_release": {
                 "major_version": 7,
@@ -227807,7 +227807,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24052
+                "set_id": 33886
             },
             "initial_release": {
                 "major_version": 7,
@@ -227842,7 +227842,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24053
+                "set_id": 33887
             },
             "initial_release": {
                 "major_version": 7,
@@ -227877,7 +227877,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24054
+                "set_id": 33888
             },
             "initial_release": {
                 "major_version": 7,
@@ -227912,7 +227912,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24055
+                "set_id": 33889
             },
             "initial_release": {
                 "major_version": 7,
@@ -227947,7 +227947,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24056
+                "set_id": 33890
             },
             "initial_release": {
                 "major_version": 7,
@@ -227982,7 +227982,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24057
+                "set_id": 33891
             },
             "initial_release": {
                 "major_version": 7,
@@ -228017,7 +228017,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24058
+                "set_id": 33892
             },
             "initial_release": {
                 "major_version": 7,
@@ -228052,7 +228052,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24059
+                "set_id": 33893
             },
             "initial_release": {
                 "major_version": 7,
@@ -228087,7 +228087,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24060
+                "set_id": 33894
             },
             "initial_release": {
                 "major_version": 7,
@@ -228122,7 +228122,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24061
+                "set_id": 33895
             },
             "initial_release": {
                 "major_version": 7,
@@ -228157,7 +228157,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24062
+                "set_id": 33896
             },
             "initial_release": {
                 "major_version": 7,
@@ -228192,7 +228192,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24063
+                "set_id": 33897
             },
             "initial_release": {
                 "major_version": 7,
@@ -228227,7 +228227,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24064
+                "set_id": 33898
             },
             "initial_release": {
                 "major_version": 7,
@@ -228262,7 +228262,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24065
+                "set_id": 33899
             },
             "initial_release": {
                 "major_version": 7,
@@ -228297,7 +228297,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24066
+                "set_id": 33900
             },
             "initial_release": {
                 "major_version": 7,
@@ -228332,7 +228332,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24067
+                "set_id": 33901
             },
             "initial_release": {
                 "major_version": 7,
@@ -228367,7 +228367,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24068
+                "set_id": 33902
             },
             "initial_release": {
                 "major_version": 7,
@@ -228402,7 +228402,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24069
+                "set_id": 33903
             },
             "initial_release": {
                 "major_version": 7,
@@ -228437,7 +228437,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24070
+                "set_id": 33904
             },
             "initial_release": {
                 "major_version": 7,
@@ -228472,7 +228472,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24071
+                "set_id": 33905
             },
             "initial_release": {
                 "major_version": 7,
@@ -228507,7 +228507,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24072
+                "set_id": 33906
             },
             "initial_release": {
                 "major_version": 7,
@@ -228542,7 +228542,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24073
+                "set_id": 33907
             },
             "initial_release": {
                 "major_version": 7,
@@ -228577,7 +228577,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24074
+                "set_id": 33908
             },
             "initial_release": {
                 "major_version": 7,
@@ -228612,7 +228612,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24075
+                "set_id": 33909
             },
             "initial_release": {
                 "major_version": 7,
@@ -228647,7 +228647,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24076
+                "set_id": 33910
             },
             "initial_release": {
                 "major_version": 7,
@@ -228682,7 +228682,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24077
+                "set_id": 33911
             },
             "initial_release": {
                 "major_version": 7,
@@ -228717,7 +228717,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24078
+                "set_id": 33912
             },
             "initial_release": {
                 "major_version": 7,
@@ -228752,7 +228752,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24079
+                "set_id": 33913
             },
             "initial_release": {
                 "major_version": 7,
@@ -228787,7 +228787,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24080
+                "set_id": 33914
             },
             "initial_release": {
                 "major_version": 7,
@@ -228822,7 +228822,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24081
+                "set_id": 33915
             },
             "initial_release": {
                 "major_version": 7,
@@ -228857,7 +228857,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24082
+                "set_id": 33916
             },
             "initial_release": {
                 "major_version": 7,
@@ -228892,7 +228892,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24083
+                "set_id": 33917
             },
             "initial_release": {
                 "major_version": 7,
@@ -228927,7 +228927,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24084
+                "set_id": 33918
             },
             "initial_release": {
                 "major_version": 7,
@@ -228962,7 +228962,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24085
+                "set_id": 33919
             },
             "initial_release": {
                 "major_version": 7,
@@ -228997,7 +228997,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24086
+                "set_id": 33920
             },
             "initial_release": {
                 "major_version": 7,
@@ -229032,7 +229032,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24087
+                "set_id": 33921
             },
             "initial_release": {
                 "major_version": 7,
@@ -229067,7 +229067,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24088
+                "set_id": 33922
             },
             "initial_release": {
                 "major_version": 7,
@@ -229102,7 +229102,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24089
+                "set_id": 33923
             },
             "initial_release": {
                 "major_version": 7,
@@ -229137,7 +229137,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24090
+                "set_id": 33924
             },
             "initial_release": {
                 "major_version": 7,
@@ -229172,7 +229172,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24091
+                "set_id": 33925
             },
             "initial_release": {
                 "major_version": 7,
@@ -229207,7 +229207,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24092
+                "set_id": 33926
             },
             "initial_release": {
                 "major_version": 7,
@@ -229242,7 +229242,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24093
+                "set_id": 33927
             },
             "initial_release": {
                 "major_version": 7,
@@ -229277,7 +229277,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24094
+                "set_id": 33928
             },
             "initial_release": {
                 "major_version": 7,
@@ -229312,7 +229312,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24095
+                "set_id": 33929
             },
             "initial_release": {
                 "major_version": 7,
@@ -229347,7 +229347,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24096
+                "set_id": 33930
             },
             "initial_release": {
                 "major_version": 7,
@@ -229382,7 +229382,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24097
+                "set_id": 33931
             },
             "initial_release": {
                 "major_version": 7,
@@ -229417,7 +229417,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24098
+                "set_id": 33932
             },
             "initial_release": {
                 "major_version": 7,
@@ -229452,7 +229452,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24099
+                "set_id": 33933
             },
             "initial_release": {
                 "major_version": 7,
@@ -229487,7 +229487,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24100
+                "set_id": 33934
             },
             "initial_release": {
                 "major_version": 7,
@@ -229522,7 +229522,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24101
+                "set_id": 33935
             },
             "initial_release": {
                 "major_version": 7,
@@ -229557,7 +229557,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24102
+                "set_id": 33936
             },
             "initial_release": {
                 "major_version": 7,
@@ -229592,7 +229592,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24103
+                "set_id": 33937
             },
             "initial_release": {
                 "major_version": 7,
@@ -229627,7 +229627,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24104
+                "set_id": 33938
             },
             "initial_release": {
                 "major_version": 7,
@@ -229662,7 +229662,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24105
+                "set_id": 33939
             },
             "initial_release": {
                 "major_version": 7,
@@ -229697,7 +229697,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24106
+                "set_id": 33940
             },
             "initial_release": {
                 "major_version": 7,
@@ -229732,7 +229732,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24107
+                "set_id": 33941
             },
             "initial_release": {
                 "major_version": 7,
@@ -229767,7 +229767,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24108
+                "set_id": 33942
             },
             "initial_release": {
                 "major_version": 7,
@@ -229802,7 +229802,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24109
+                "set_id": 33943
             },
             "initial_release": {
                 "major_version": 7,
@@ -229837,7 +229837,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24110
+                "set_id": 33944
             },
             "initial_release": {
                 "major_version": 7,
@@ -229872,7 +229872,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24111
+                "set_id": 33945
             },
             "initial_release": {
                 "major_version": 7,
@@ -229907,7 +229907,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24112
+                "set_id": 33946
             },
             "initial_release": {
                 "major_version": 7,
@@ -229942,7 +229942,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24113
+                "set_id": 33947
             },
             "initial_release": {
                 "major_version": 7,
@@ -229977,7 +229977,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24114
+                "set_id": 33948
             },
             "initial_release": {
                 "major_version": 7,
@@ -230012,7 +230012,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24115
+                "set_id": 33949
             },
             "initial_release": {
                 "major_version": 7,
@@ -230047,7 +230047,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24116
+                "set_id": 33950
             },
             "initial_release": {
                 "major_version": 7,
@@ -230082,7 +230082,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24117
+                "set_id": 33951
             },
             "initial_release": {
                 "major_version": 7,
@@ -230117,7 +230117,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24118
+                "set_id": 33952
             },
             "initial_release": {
                 "major_version": 7,
@@ -230152,7 +230152,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24119
+                "set_id": 33953
             },
             "initial_release": {
                 "major_version": 7,
@@ -230187,7 +230187,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24120
+                "set_id": 33954
             },
             "initial_release": {
                 "major_version": 7,
@@ -230222,7 +230222,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24121
+                "set_id": 33955
             },
             "initial_release": {
                 "major_version": 7,
@@ -230257,7 +230257,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24122
+                "set_id": 33956
             },
             "initial_release": {
                 "major_version": 7,
@@ -230292,7 +230292,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24123
+                "set_id": 33957
             },
             "initial_release": {
                 "major_version": 7,
@@ -230327,7 +230327,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24124
+                "set_id": 33958
             },
             "initial_release": {
                 "major_version": 7,
@@ -230362,7 +230362,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24125
+                "set_id": 33959
             },
             "initial_release": {
                 "major_version": 7,
@@ -230397,7 +230397,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24126
+                "set_id": 33960
             },
             "initial_release": {
                 "major_version": 7,
@@ -230432,7 +230432,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24127
+                "set_id": 33961
             },
             "initial_release": {
                 "major_version": 7,
@@ -230467,7 +230467,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24128
+                "set_id": 33962
             },
             "initial_release": {
                 "major_version": 7,
@@ -230502,7 +230502,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24129
+                "set_id": 33963
             },
             "initial_release": {
                 "major_version": 7,
@@ -230537,7 +230537,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24130
+                "set_id": 33964
             },
             "initial_release": {
                 "major_version": 7,
@@ -230572,7 +230572,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24131
+                "set_id": 33965
             },
             "initial_release": {
                 "major_version": 7,
@@ -230607,7 +230607,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24132
+                "set_id": 33966
             },
             "initial_release": {
                 "major_version": 7,
@@ -230642,7 +230642,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24133
+                "set_id": 33967
             },
             "initial_release": {
                 "major_version": 7,
@@ -230677,7 +230677,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24134
+                "set_id": 33968
             },
             "initial_release": {
                 "major_version": 7,
@@ -230712,7 +230712,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24135
+                "set_id": 33969
             },
             "initial_release": {
                 "major_version": 7,
@@ -230747,7 +230747,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24136
+                "set_id": 33970
             },
             "initial_release": {
                 "major_version": 7,
@@ -230782,7 +230782,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24137
+                "set_id": 33971
             },
             "initial_release": {
                 "major_version": 7,
@@ -230817,7 +230817,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24138
+                "set_id": 33972
             },
             "initial_release": {
                 "major_version": 7,
@@ -230852,7 +230852,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24139
+                "set_id": 33973
             },
             "initial_release": {
                 "major_version": 7,
@@ -230887,7 +230887,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24140
+                "set_id": 33974
             },
             "initial_release": {
                 "major_version": 7,
@@ -230922,7 +230922,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24141
+                "set_id": 33975
             },
             "initial_release": {
                 "major_version": 7,
@@ -230957,7 +230957,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24142
+                "set_id": 33976
             },
             "initial_release": {
                 "major_version": 7,
@@ -230992,7 +230992,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24143
+                "set_id": 33977
             },
             "initial_release": {
                 "major_version": 7,
@@ -231027,7 +231027,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24144
+                "set_id": 33978
             },
             "initial_release": {
                 "major_version": 7,
@@ -231062,7 +231062,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24145
+                "set_id": 33979
             },
             "initial_release": {
                 "major_version": 7,
@@ -231097,7 +231097,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24146
+                "set_id": 33980
             },
             "initial_release": {
                 "major_version": 7,
@@ -231132,7 +231132,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24147
+                "set_id": 33981
             },
             "initial_release": {
                 "major_version": 7,
@@ -231167,7 +231167,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24148
+                "set_id": 33982
             },
             "initial_release": {
                 "major_version": 7,
@@ -231202,7 +231202,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24149
+                "set_id": 33983
             },
             "initial_release": {
                 "major_version": 7,
@@ -231237,7 +231237,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24150
+                "set_id": 33984
             },
             "initial_release": {
                 "major_version": 7,
@@ -231272,7 +231272,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24151
+                "set_id": 33985
             },
             "initial_release": {
                 "major_version": 7,
@@ -231307,7 +231307,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24152
+                "set_id": 33986
             },
             "initial_release": {
                 "major_version": 7,
@@ -231342,7 +231342,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24153
+                "set_id": 33987
             },
             "initial_release": {
                 "major_version": 7,
@@ -231447,7 +231447,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24156
+                "set_id": 33988
             },
             "initial_release": {
                 "major_version": 7,
@@ -231482,7 +231482,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24157
+                "set_id": 33989
             },
             "initial_release": {
                 "major_version": 7,
@@ -231517,7 +231517,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24158
+                "set_id": 33990
             },
             "initial_release": {
                 "major_version": 7,
@@ -231552,7 +231552,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24159
+                "set_id": 33991
             },
             "initial_release": {
                 "major_version": 7,
@@ -231587,7 +231587,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24160
+                "set_id": 33992
             },
             "initial_release": {
                 "major_version": 7,
@@ -231622,7 +231622,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24161
+                "set_id": 33993
             },
             "initial_release": {
                 "major_version": 7,
@@ -231657,7 +231657,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24162
+                "set_id": 33994
             },
             "initial_release": {
                 "major_version": 7,
@@ -231692,7 +231692,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24163
+                "set_id": 33995
             },
             "initial_release": {
                 "major_version": 7,
@@ -231727,7 +231727,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24164
+                "set_id": 33996
             },
             "initial_release": {
                 "major_version": 7,
@@ -231762,7 +231762,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24165
+                "set_id": 33997
             },
             "initial_release": {
                 "major_version": 7,
@@ -231797,7 +231797,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24166
+                "set_id": 33998
             },
             "initial_release": {
                 "major_version": 7,
@@ -231832,7 +231832,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24167
+                "set_id": 33999
             },
             "initial_release": {
                 "major_version": 7,
@@ -231867,7 +231867,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24168
+                "set_id": 34000
             },
             "initial_release": {
                 "major_version": 7,
@@ -231902,7 +231902,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24169
+                "set_id": 34001
             },
             "initial_release": {
                 "major_version": 7,
@@ -231937,7 +231937,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24170
+                "set_id": 34002
             },
             "initial_release": {
                 "major_version": 7,
@@ -231972,7 +231972,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24171
+                "set_id": 34003
             },
             "initial_release": {
                 "major_version": 7,
@@ -232007,7 +232007,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24172
+                "set_id": 34004
             },
             "initial_release": {
                 "major_version": 7,
@@ -232042,7 +232042,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24173
+                "set_id": 34005
             },
             "initial_release": {
                 "major_version": 7,
@@ -232077,7 +232077,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24174
+                "set_id": 34006
             },
             "initial_release": {
                 "major_version": 7,
@@ -232112,7 +232112,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24175
+                "set_id": 34007
             },
             "initial_release": {
                 "major_version": 7,
@@ -232147,7 +232147,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24176
+                "set_id": 34008
             },
             "initial_release": {
                 "major_version": 7,
@@ -232182,7 +232182,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24177
+                "set_id": 34009
             },
             "initial_release": {
                 "major_version": 7,
@@ -232217,7 +232217,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24178
+                "set_id": 34010
             },
             "initial_release": {
                 "major_version": 7,
@@ -232252,7 +232252,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24179
+                "set_id": 34011
             },
             "initial_release": {
                 "major_version": 7,
@@ -232287,7 +232287,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24180
+                "set_id": 34012
             },
             "initial_release": {
                 "major_version": 7,
@@ -232322,7 +232322,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24181
+                "set_id": 34013
             },
             "initial_release": {
                 "major_version": 7,
@@ -232357,7 +232357,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24182
+                "set_id": 34014
             },
             "initial_release": {
                 "major_version": 7,
@@ -232392,7 +232392,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24183
+                "set_id": 34015
             },
             "initial_release": {
                 "major_version": 7,
@@ -232427,7 +232427,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24184
+                "set_id": 34016
             },
             "initial_release": {
                 "major_version": 7,
@@ -232462,7 +232462,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24185
+                "set_id": 34017
             },
             "initial_release": {
                 "major_version": 7,
@@ -232497,7 +232497,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24186
+                "set_id": 34018
             },
             "initial_release": {
                 "major_version": 7,
@@ -232532,7 +232532,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24187
+                "set_id": 34019
             },
             "initial_release": {
                 "major_version": 7,
@@ -232567,7 +232567,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24188
+                "set_id": 34020
             },
             "initial_release": {
                 "major_version": 7,
@@ -232602,7 +232602,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24189
+                "set_id": 34021
             },
             "initial_release": {
                 "major_version": 7,
@@ -232637,7 +232637,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24190
+                "set_id": 34022
             },
             "initial_release": {
                 "major_version": 7,
@@ -232672,7 +232672,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24191
+                "set_id": 34023
             },
             "initial_release": {
                 "major_version": 7,
@@ -232707,7 +232707,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24192
+                "set_id": 34024
             },
             "initial_release": {
                 "major_version": 7,
@@ -232742,7 +232742,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24193
+                "set_id": 34025
             },
             "initial_release": {
                 "major_version": 7,
@@ -232777,7 +232777,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24194
+                "set_id": 34026
             },
             "initial_release": {
                 "major_version": 7,
@@ -232812,7 +232812,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24195
+                "set_id": 34027
             },
             "initial_release": {
                 "major_version": 7,
@@ -232847,7 +232847,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24196
+                "set_id": 34028
             },
             "initial_release": {
                 "major_version": 7,
@@ -232882,7 +232882,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24197
+                "set_id": 34029
             },
             "initial_release": {
                 "major_version": 7,
@@ -232917,7 +232917,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24198
+                "set_id": 34030
             },
             "initial_release": {
                 "major_version": 7,
@@ -232952,7 +232952,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24199
+                "set_id": 34031
             },
             "initial_release": {
                 "major_version": 7,
@@ -232987,7 +232987,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24200
+                "set_id": 34032
             },
             "initial_release": {
                 "major_version": 7,
@@ -233022,7 +233022,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24201
+                "set_id": 34033
             },
             "initial_release": {
                 "major_version": 7,
@@ -233057,7 +233057,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24202
+                "set_id": 34034
             },
             "initial_release": {
                 "major_version": 7,
@@ -233162,7 +233162,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24205
+                "set_id": 34035
             },
             "initial_release": {
                 "major_version": 7,
@@ -233197,7 +233197,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24206
+                "set_id": 34036
             },
             "initial_release": {
                 "major_version": 7,
@@ -233232,7 +233232,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24207
+                "set_id": 34037
             },
             "initial_release": {
                 "major_version": 7,
@@ -233267,7 +233267,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24208
+                "set_id": 34038
             },
             "initial_release": {
                 "major_version": 7,
@@ -233302,7 +233302,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24209
+                "set_id": 34039
             },
             "initial_release": {
                 "major_version": 7,
@@ -233337,7 +233337,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24210
+                "set_id": 34040
             },
             "initial_release": {
                 "major_version": 7,
@@ -233372,7 +233372,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24211
+                "set_id": 34041
             },
             "initial_release": {
                 "major_version": 7,
@@ -233407,7 +233407,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24212
+                "set_id": 34042
             },
             "initial_release": {
                 "major_version": 7,
@@ -233442,7 +233442,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24213
+                "set_id": 34043
             },
             "initial_release": {
                 "major_version": 7,
@@ -233477,7 +233477,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24214
+                "set_id": 34044
             },
             "initial_release": {
                 "major_version": 7,
@@ -233512,7 +233512,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24215
+                "set_id": 34045
             },
             "initial_release": {
                 "major_version": 7,
@@ -233547,7 +233547,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24216
+                "set_id": 34046
             },
             "initial_release": {
                 "major_version": 7,
@@ -233582,7 +233582,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24217
+                "set_id": 34047
             },
             "initial_release": {
                 "major_version": 7,
@@ -233617,7 +233617,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24218
+                "set_id": 34048
             },
             "initial_release": {
                 "major_version": 7,
@@ -233652,7 +233652,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24219
+                "set_id": 34049
             },
             "initial_release": {
                 "major_version": 7,
@@ -233687,7 +233687,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24220
+                "set_id": 34050
             },
             "initial_release": {
                 "major_version": 7,
@@ -233722,7 +233722,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24221
+                "set_id": 34051
             },
             "initial_release": {
                 "major_version": 7,
@@ -233757,7 +233757,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24222
+                "set_id": 34052
             },
             "initial_release": {
                 "major_version": 7,
@@ -233792,7 +233792,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24223
+                "set_id": 34053
             },
             "initial_release": {
                 "major_version": 7,
@@ -233827,7 +233827,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24224
+                "set_id": 34054
             },
             "initial_release": {
                 "major_version": 7,
@@ -233862,7 +233862,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24225
+                "set_id": 34055
             },
             "initial_release": {
                 "major_version": 7,
@@ -233897,7 +233897,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24226
+                "set_id": 34056
             },
             "initial_release": {
                 "major_version": 7,
@@ -233932,7 +233932,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24227
+                "set_id": 34057
             },
             "initial_release": {
                 "major_version": 7,
@@ -233967,7 +233967,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24228
+                "set_id": 34058
             },
             "initial_release": {
                 "major_version": 7,
@@ -234002,7 +234002,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24229
+                "set_id": 34059
             },
             "initial_release": {
                 "major_version": 7,
@@ -234037,7 +234037,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24230
+                "set_id": 34060
             },
             "initial_release": {
                 "major_version": 7,
@@ -234072,7 +234072,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24231
+                "set_id": 34061
             },
             "initial_release": {
                 "major_version": 7,
@@ -234107,7 +234107,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24232
+                "set_id": 34062
             },
             "initial_release": {
                 "major_version": 7,
@@ -234142,7 +234142,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24233
+                "set_id": 34063
             },
             "initial_release": {
                 "major_version": 7,
@@ -234177,7 +234177,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24234
+                "set_id": 34064
             },
             "initial_release": {
                 "major_version": 7,
@@ -234212,7 +234212,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24235
+                "set_id": 34065
             },
             "initial_release": {
                 "major_version": 7,
@@ -234247,7 +234247,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24236
+                "set_id": 34066
             },
             "initial_release": {
                 "major_version": 7,
@@ -234282,7 +234282,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24237
+                "set_id": 34067
             },
             "initial_release": {
                 "major_version": 7,
@@ -234317,7 +234317,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24238
+                "set_id": 34068
             },
             "initial_release": {
                 "major_version": 7,
@@ -234352,7 +234352,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24239
+                "set_id": 34069
             },
             "initial_release": {
                 "major_version": 7,
@@ -234387,7 +234387,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24240
+                "set_id": 34070
             },
             "initial_release": {
                 "major_version": 7,
@@ -234457,7 +234457,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24241
+                "set_id": 34071
             },
             "initial_release": {
                 "major_version": 7,
@@ -234492,7 +234492,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24242
+                "set_id": 34072
             },
             "initial_release": {
                 "major_version": 7,
@@ -234527,7 +234527,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24243
+                "set_id": 34073
             },
             "initial_release": {
                 "major_version": 7,
@@ -234562,7 +234562,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24244
+                "set_id": 34074
             },
             "initial_release": {
                 "major_version": 7,
@@ -234597,7 +234597,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24245
+                "set_id": 34075
             },
             "initial_release": {
                 "major_version": 7,
@@ -234632,7 +234632,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24246
+                "set_id": 34076
             },
             "initial_release": {
                 "major_version": 7,
@@ -234667,7 +234667,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24247
+                "set_id": 34077
             },
             "initial_release": {
                 "major_version": 7,
@@ -234702,7 +234702,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24248
+                "set_id": 34078
             },
             "initial_release": {
                 "major_version": 7,
@@ -234737,7 +234737,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24249
+                "set_id": 34079
             },
             "initial_release": {
                 "major_version": 7,
@@ -234772,7 +234772,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24250
+                "set_id": 34080
             },
             "initial_release": {
                 "major_version": 7,
@@ -234807,7 +234807,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24251
+                "set_id": 34081
             },
             "initial_release": {
                 "major_version": 7,
@@ -234842,7 +234842,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24252
+                "set_id": 34082
             },
             "initial_release": {
                 "major_version": 7,
@@ -234877,7 +234877,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24253
+                "set_id": 34083
             },
             "initial_release": {
                 "major_version": 7,
@@ -234912,7 +234912,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24254
+                "set_id": 34084
             },
             "initial_release": {
                 "major_version": 7,
@@ -234947,7 +234947,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24255
+                "set_id": 34085
             },
             "initial_release": {
                 "major_version": 7,
@@ -234982,7 +234982,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24256
+                "set_id": 34086
             },
             "initial_release": {
                 "major_version": 7,
@@ -235017,7 +235017,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24257
+                "set_id": 34087
             },
             "initial_release": {
                 "major_version": 7,
@@ -235052,7 +235052,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24258
+                "set_id": 34088
             },
             "initial_release": {
                 "major_version": 7,
@@ -235087,7 +235087,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24259
+                "set_id": 34089
             },
             "initial_release": {
                 "major_version": 7,
@@ -235122,7 +235122,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24260
+                "set_id": 34090
             },
             "initial_release": {
                 "major_version": 7,
@@ -235157,7 +235157,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24261
+                "set_id": 34091
             },
             "initial_release": {
                 "major_version": 7,
@@ -235192,7 +235192,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24262
+                "set_id": 34092
             },
             "initial_release": {
                 "major_version": 7,
@@ -235227,7 +235227,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24263
+                "set_id": 34093
             },
             "initial_release": {
                 "major_version": 7,
@@ -235262,7 +235262,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24264
+                "set_id": 34094
             },
             "initial_release": {
                 "major_version": 7,
@@ -235297,7 +235297,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24265
+                "set_id": 34095
             },
             "initial_release": {
                 "major_version": 7,
@@ -235332,7 +235332,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24266
+                "set_id": 34096
             },
             "initial_release": {
                 "major_version": 7,
@@ -235367,7 +235367,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24267
+                "set_id": 34097
             },
             "initial_release": {
                 "major_version": 7,
@@ -235402,7 +235402,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24268
+                "set_id": 34098
             },
             "initial_release": {
                 "major_version": 7,
@@ -235437,7 +235437,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24269
+                "set_id": 34099
             },
             "initial_release": {
                 "major_version": 7,
@@ -235472,7 +235472,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24270
+                "set_id": 34100
             },
             "initial_release": {
                 "major_version": 7,
@@ -235507,7 +235507,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24271
+                "set_id": 34101
             },
             "initial_release": {
                 "major_version": 7,
@@ -235542,7 +235542,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24272
+                "set_id": 34102
             },
             "initial_release": {
                 "major_version": 7,
@@ -235577,7 +235577,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24273
+                "set_id": 34103
             },
             "initial_release": {
                 "major_version": 7,
@@ -235612,7 +235612,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24274
+                "set_id": 34104
             },
             "initial_release": {
                 "major_version": 7,
@@ -235647,7 +235647,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24275
+                "set_id": 34105
             },
             "initial_release": {
                 "major_version": 7,
@@ -235682,7 +235682,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24276
+                "set_id": 34106
             },
             "initial_release": {
                 "major_version": 7,
@@ -235717,7 +235717,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24277
+                "set_id": 34107
             },
             "initial_release": {
                 "major_version": 7,
@@ -235752,7 +235752,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24278
+                "set_id": 34108
             },
             "initial_release": {
                 "major_version": 7,
@@ -235787,7 +235787,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24279
+                "set_id": 34109
             },
             "initial_release": {
                 "major_version": 7,
@@ -235822,7 +235822,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24280
+                "set_id": 34110
             },
             "initial_release": {
                 "major_version": 7,
@@ -235857,7 +235857,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24281
+                "set_id": 34111
             },
             "initial_release": {
                 "major_version": 7,
@@ -235892,7 +235892,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24282
+                "set_id": 34112
             },
             "initial_release": {
                 "major_version": 7,
@@ -235927,7 +235927,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24283
+                "set_id": 34113
             },
             "initial_release": {
                 "major_version": 7,
@@ -235962,7 +235962,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24284
+                "set_id": 34114
             },
             "initial_release": {
                 "major_version": 7,
@@ -235997,7 +235997,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24285
+                "set_id": 34115
             },
             "initial_release": {
                 "major_version": 7,
@@ -236032,7 +236032,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24286
+                "set_id": 34116
             },
             "initial_release": {
                 "major_version": 7,
@@ -236067,7 +236067,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24287
+                "set_id": 34117
             },
             "initial_release": {
                 "major_version": 7,
@@ -236102,7 +236102,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24288
+                "set_id": 34118
             },
             "initial_release": {
                 "major_version": 7,
@@ -236137,7 +236137,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24289
+                "set_id": 34119
             },
             "initial_release": {
                 "major_version": 7,
@@ -236172,7 +236172,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24290
+                "set_id": 34120
             },
             "initial_release": {
                 "major_version": 7,
@@ -236207,7 +236207,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24291
+                "set_id": 34121
             },
             "initial_release": {
                 "major_version": 7,
@@ -236242,7 +236242,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24292
+                "set_id": 34122
             },
             "initial_release": {
                 "major_version": 7,
@@ -236277,7 +236277,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24293
+                "set_id": 34123
             },
             "initial_release": {
                 "major_version": 7,
@@ -236312,7 +236312,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24294
+                "set_id": 34124
             },
             "initial_release": {
                 "major_version": 7,
@@ -236347,7 +236347,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24295
+                "set_id": 34125
             },
             "initial_release": {
                 "major_version": 7,
@@ -236382,7 +236382,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24296
+                "set_id": 34126
             },
             "initial_release": {
                 "major_version": 7,
@@ -236452,7 +236452,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24297
+                "set_id": 34127
             },
             "initial_release": {
                 "major_version": 7,
@@ -236487,7 +236487,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24298
+                "set_id": 34128
             },
             "initial_release": {
                 "major_version": 7,
@@ -236522,7 +236522,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24299
+                "set_id": 34129
             },
             "initial_release": {
                 "major_version": 7,
@@ -236557,7 +236557,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24300
+                "set_id": 34130
             },
             "initial_release": {
                 "major_version": 7,
@@ -236592,7 +236592,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24301
+                "set_id": 34131
             },
             "initial_release": {
                 "major_version": 7,
@@ -236627,7 +236627,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24302
+                "set_id": 34132
             },
             "initial_release": {
                 "major_version": 7,
@@ -236662,7 +236662,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24303
+                "set_id": 34133
             },
             "initial_release": {
                 "major_version": 7,
@@ -236697,7 +236697,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24304
+                "set_id": 34134
             },
             "initial_release": {
                 "major_version": 7,
@@ -236732,7 +236732,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24305
+                "set_id": 34135
             },
             "initial_release": {
                 "major_version": 7,
@@ -236767,7 +236767,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24306
+                "set_id": 34136
             },
             "initial_release": {
                 "major_version": 7,
@@ -236802,7 +236802,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24307
+                "set_id": 34137
             },
             "initial_release": {
                 "major_version": 7,
@@ -236837,7 +236837,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24308
+                "set_id": 34138
             },
             "initial_release": {
                 "major_version": 7,
@@ -236872,7 +236872,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24309
+                "set_id": 34139
             },
             "initial_release": {
                 "major_version": 7,
@@ -236907,7 +236907,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24310
+                "set_id": 34140
             },
             "initial_release": {
                 "major_version": 7,
@@ -236942,7 +236942,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24311
+                "set_id": 34141
             },
             "initial_release": {
                 "major_version": 7,
@@ -236977,7 +236977,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24312
+                "set_id": 34142
             },
             "initial_release": {
                 "major_version": 7,
@@ -237012,7 +237012,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24313
+                "set_id": 34143
             },
             "initial_release": {
                 "major_version": 7,
@@ -237047,7 +237047,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24314
+                "set_id": 34144
             },
             "initial_release": {
                 "major_version": 7,
@@ -237082,7 +237082,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24315
+                "set_id": 34145
             },
             "initial_release": {
                 "major_version": 7,
@@ -237117,7 +237117,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24316
+                "set_id": 34146
             },
             "initial_release": {
                 "major_version": 7,
@@ -237152,7 +237152,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24317
+                "set_id": 34147
             },
             "initial_release": {
                 "major_version": 7,
@@ -237187,7 +237187,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24318
+                "set_id": 34148
             },
             "initial_release": {
                 "major_version": 7,
@@ -237222,7 +237222,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24319
+                "set_id": 34149
             },
             "initial_release": {
                 "major_version": 7,
@@ -237257,7 +237257,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24320
+                "set_id": 34150
             },
             "initial_release": {
                 "major_version": 7,
@@ -237292,7 +237292,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24321
+                "set_id": 34151
             },
             "initial_release": {
                 "major_version": 7,
@@ -237327,7 +237327,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24322
+                "set_id": 34152
             },
             "initial_release": {
                 "major_version": 7,
@@ -237362,7 +237362,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24323
+                "set_id": 34153
             },
             "initial_release": {
                 "major_version": 7,
@@ -237397,7 +237397,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24324
+                "set_id": 34154
             },
             "initial_release": {
                 "major_version": 7,
@@ -237432,7 +237432,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24325
+                "set_id": 34155
             },
             "initial_release": {
                 "major_version": 7,
@@ -237467,7 +237467,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24326
+                "set_id": 34156
             },
             "initial_release": {
                 "major_version": 7,
@@ -237502,7 +237502,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24327
+                "set_id": 34157
             },
             "initial_release": {
                 "major_version": 7,
@@ -237537,7 +237537,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24328
+                "set_id": 34158
             },
             "initial_release": {
                 "major_version": 7,
@@ -237572,7 +237572,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24329
+                "set_id": 34159
             },
             "initial_release": {
                 "major_version": 7,
@@ -237607,7 +237607,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24330
+                "set_id": 34160
             },
             "initial_release": {
                 "major_version": 7,
@@ -237642,7 +237642,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24331
+                "set_id": 34161
             },
             "initial_release": {
                 "major_version": 7,
@@ -237677,7 +237677,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24332
+                "set_id": 34162
             },
             "initial_release": {
                 "major_version": 7,
@@ -237712,7 +237712,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24333
+                "set_id": 34163
             },
             "initial_release": {
                 "major_version": 7,
@@ -237747,7 +237747,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24334
+                "set_id": 34164
             },
             "initial_release": {
                 "major_version": 7,
@@ -237782,7 +237782,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24335
+                "set_id": 34165
             },
             "initial_release": {
                 "major_version": 7,
@@ -237817,7 +237817,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24336
+                "set_id": 34166
             },
             "initial_release": {
                 "major_version": 7,
@@ -237852,7 +237852,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24337
+                "set_id": 34167
             },
             "initial_release": {
                 "major_version": 7,
@@ -237887,7 +237887,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24338
+                "set_id": 34168
             },
             "initial_release": {
                 "major_version": 7,
@@ -237922,7 +237922,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24339
+                "set_id": 34169
             },
             "initial_release": {
                 "major_version": 7,
@@ -237957,7 +237957,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24340
+                "set_id": 34170
             },
             "initial_release": {
                 "major_version": 7,
@@ -237992,7 +237992,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24341
+                "set_id": 34171
             },
             "initial_release": {
                 "major_version": 7,
@@ -238027,7 +238027,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24342
+                "set_id": 34172
             },
             "initial_release": {
                 "major_version": 7,
@@ -238062,7 +238062,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24343
+                "set_id": 34173
             },
             "initial_release": {
                 "major_version": 7,
@@ -238097,7 +238097,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24344
+                "set_id": 34174
             },
             "initial_release": {
                 "major_version": 7,


### PR DESCRIPTION
- Device driver deprecation data:
 leapp-repository sha 518722058ca53e94c8efa8958ca8fd7cac40dca7

- PES data:
 pes-events.json: upstream state 518722058ca53e94c8efa8958ca8fd7cac40dca7
 epel_pes.json_template: remove duplicated id and set_id
 config.json (except centos):
  - add libreport-rhel-anaconda-bugzilla to the removable packages list, with scenarios: 9to9, 9to10
  - add redhat-flatpak-repo, redhat-flatpak-preinstall-firefox, redhat-flatpak-preinstall-thunderbird to the removable packages list, with scenarios: 9to10