### PR TITLE
Solve valgrind-docs, valgrind-scripts with valgrind package conflicts during 8to9 upgrade

### DIFF
--- a/files/almalinux/config.json
+++ b/files/almalinux/config.json
@@ -2060,6 +2060,63 @@
                 "minor_version": 0,
                 "os_name": "AlmaLinux"
             }
+        },
+        {
+            "action": 5,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 0,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "valgrind-docs",
+                        "repository": "appstream"
+                    },
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "valgrind-scripts",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 0
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [
+                {
+                    "in_modulestream": null,
+                    "out_modulestream": null
+                }
+            ],
+            "out_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "valgrind",
+                        "repository": "almalinux9-appstream"
+                    }
+                ],
+                "set_id": 0
+            },
+            "release": {
+                "major_version": 9,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
         }
     ]
 }

--- a/files/almalinux/pes-events.json
+++ b/files/almalinux/pes-events.json
@@ -630662,6 +630662,63 @@
                 "minor_version": 0,
                 "os_name": "AlmaLinux"
             }
+        },
+        {
+            "action": 5,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17753,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "valgrind-docs",
+                        "repository": "appstream"
+                    },
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "valgrind-scripts",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24346
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [
+                {
+                    "in_modulestream": null,
+                    "out_modulestream": null
+                }
+            ],
+            "out_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "valgrind",
+                        "repository": "almalinux9-appstream"
+                    }
+                ],
+                "set_id": 24345
+            },
+            "release": {
+                "major_version": 9,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
         }
     ]
 }

--- a/files/rocky/config.json
+++ b/files/rocky/config.json
@@ -1282,6 +1282,63 @@
                 "tag": null,
                 "z_stream": null
             }
+        },
+        {
+            "action": 5,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 0,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "valgrind-docs",
+                        "repository": "appstream"
+                    },
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "valgrind-scripts",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 0
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [
+                {
+                    "in_modulestream": null,
+                    "out_modulestream": null
+                }
+            ],
+            "out_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "valgrind",
+                        "repository": "rocky9-appstream"
+                    }
+                ],
+                "set_id": 0
+            },
+            "release": {
+                "major_version": 9,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
         }
     ]
 }

--- a/files/rocky/pes-events.json
+++ b/files/rocky/pes-events.json
@@ -628971,6 +628971,63 @@
                 "tag": null,
                 "z_stream": null
             }
+        },
+        {
+            "action": 5,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17731,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "valgrind-docs",
+                        "repository": "appstream"
+                    },
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "valgrind-scripts",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24320
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [
+                {
+                    "in_modulestream": null,
+                    "out_modulestream": null
+                }
+            ],
+            "out_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "valgrind",
+                        "repository": "rocky9-appstream"
+                    }
+                ],
+                "set_id": 24319
+            },
+            "release": {
+                "major_version": 9,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
         }
     ]
 }

--- a/leapp-data.spec
+++ b/leapp-data.spec
@@ -55,7 +55,7 @@
 
 Name:		leapp-data-%{dist_name}
 Version:	0.8
-Release:	1%{?dist}.%{pes_events_build_date}
+Release:	2%{?dist}.%{pes_events_build_date}
 Summary:	data for migrating tool
 Group:		Applications/Databases
 License:	ASL 2.0
@@ -180,6 +180,11 @@ python3 tests/check_debranding.py %{buildroot}%{_sysconfdir}/leapp/files/pes-eve
 
 
 %changelog
+* Thu Mar 27 2025 Yuriy Kohut <ykohut@almalinux.org> - 0.8-2.20250228
+- Update pes-events.json and config.json (except almalinux-kitten, centos):
+ - solve valgrind-docs, valgrind-scripts with valgrind package conflicts during 8to9 upgrade
+- Bump the package release
+
 * Thu Mar 06 2025 Yuriy Kohut <ykohut@almalinux.org> - 0.8-1.20250228
 - AlmaLinux Kitten 10 support
 

--- a/vendors.d/epel_pes.json_template
+++ b/vendors.d/epel_pes.json_template
@@ -174283,7 +174283,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17753,
+            "id": 33934,
             "in_packageset": {
                 "package": [
                     {
@@ -238132,7 +238132,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24345
+                "set_id": 34178
             },
             "initial_release": {
                 "major_version": 7,
@@ -238202,7 +238202,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24346
+                "set_id": 34179
             },
             "initial_release": {
                 "major_version": 7,


### PR DESCRIPTION
Update pes-events.json and config.json (except almalinux-kitten, centos):

 - solve valgrind-docs, valgrind-scripts with valgrind package conflicts during 8to9 upgrade

Update epel_pes.json_template:
 - remove duplicated id and set_id

Bump the package release