### PR TITLE
Solve valgrind-docs, valgrind-scripts with valgrind package conflicts during 8to9 upgrade

### DIFF
--- a/.github/workflows/elevate.yml
+++ b/.github/workflows/elevate.yml
@@ -103,10 +103,6 @@ jobs:
             repository: 'stable'
           - scenario: '10'
             repository: 'stable (ALBS product)'
-          - scenario: '10'
-            repository: 'testing'
-          - scenario: '10'
-            repository: 'testing (ALBS product)'
 
     env:
       vm_serial_log: '/var/log/elevatevm_consoles/serial.log'

--- a/files/almalinux/config.json
+++ b/files/almalinux/config.json
@@ -2035,6 +2035,63 @@
                 "minor_version": 0,
                 "os_name": "AlmaLinux"
             }
+        },
+        {
+            "action": 5,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 0,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "valgrind-docs",
+                        "repository": "appstream"
+                    },
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "valgrind-scripts",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 0
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [
+                {
+                    "in_modulestream": null,
+                    "out_modulestream": null
+                }
+            ],
+            "out_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "valgrind",
+                        "repository": "almalinux9-appstream"
+                    }
+                ],
+                "set_id": 0
+            },
+            "release": {
+                "major_version": 9,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
         }
     ]
 }

--- a/files/almalinux/pes-events.json
+++ b/files/almalinux/pes-events.json
@@ -623966,6 +623966,63 @@
                 "minor_version": 0,
                 "os_name": "AlmaLinux"
             }
+        },
+        {
+            "action": 5,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17473,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "valgrind-docs",
+                        "repository": "appstream"
+                    },
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "valgrind-scripts",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24031
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [
+                {
+                    "in_modulestream": null,
+                    "out_modulestream": null
+                }
+            ],
+            "out_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "valgrind",
+                        "repository": "almalinux9-appstream"
+                    }
+                ],
+                "set_id": 24030
+            },
+            "release": {
+                "major_version": 9,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
         }
     ]
 }

--- a/files/rocky/config.json
+++ b/files/rocky/config.json
@@ -1257,6 +1257,63 @@
                 "tag": null,
                 "z_stream": null
             }
+        },
+        {
+            "action": 5,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 0,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "valgrind-docs",
+                        "repository": "appstream"
+                    },
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "valgrind-scripts",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 0
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [
+                {
+                    "in_modulestream": null,
+                    "out_modulestream": null
+                }
+            ],
+            "out_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "valgrind",
+                        "repository": "rocky9-appstream"
+                    }
+                ],
+                "set_id": 0
+            },
+            "release": {
+                "major_version": 9,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
         }
     ]
 }

--- a/files/rocky/pes-events.json
+++ b/files/rocky/pes-events.json
@@ -622275,6 +622275,63 @@
                 "tag": null,
                 "z_stream": null
             }
+        },
+        {
+            "action": 5,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 17451,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "valgrind-docs",
+                        "repository": "appstream"
+                    },
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "valgrind-scripts",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 24005
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            },
+            "modulestream_maps": [
+                {
+                    "in_modulestream": null,
+                    "out_modulestream": null
+                }
+            ],
+            "out_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "valgrind",
+                        "repository": "rocky9-appstream"
+                    }
+                ],
+                "set_id": 24004
+            },
+            "release": {
+                "major_version": 9,
+                "minor_version": 0,
+                "os_name": "Rocky"
+            }
         }
     ]
 }

--- a/leapp-data.spec
+++ b/leapp-data.spec
@@ -52,7 +52,7 @@
 
 Name:		leapp-data-%{dist_name}
 Version:	0.6
-Release:	2%{?dist}.%{pes_events_build_date}
+Release:	3%{?dist}.%{pes_events_build_date}
 Summary:	data for migrating tool
 Group:		Applications/Databases
 License:	ASL 2.0
@@ -177,6 +177,11 @@ python3 tests/check_debranding.py %{buildroot}%{_sysconfdir}/leapp/files/pes-eve
 
 
 %changelog
+* Thu Mar 27 2025 Yuriy Kohut <ykohut@almalinux.org> - 0.6-3.20241127
+- Update pes-events.json and config.json (except centos):
+ - solve valgrind-docs, valgrind-scripts with valgrind package conflicts during 8to9 upgrade
+- Bump the package release
+
 * Wed Jan 15 2025 Yuriy Kohut <ykohut@almalinux.org> - 0.6-2.20241127
 - ELevate to CentOS Stream release 10
 

--- a/vendors.d/epel_pes.json_template
+++ b/vendors.d/epel_pes.json_template
@@ -162663,7 +162663,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 17473,
+            "id": 33655,
             "in_packageset": {
                 "package": [
                     {
@@ -227037,7 +227037,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24030
+                "set_id": 33869
             },
             "initial_release": {
                 "major_version": 7,
@@ -227072,7 +227072,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 24031
+                "set_id": 33870
             },
             "initial_release": {
                 "major_version": 7,


### PR DESCRIPTION
Update pes-events.json and config.json (except centos, oraclelinux):
 - solve valgrind-docs, valgrind-scripts with valgrind package conflicts during 8to9 upgrade
    
Update epel_pes.json_template:
 - remove duplicated id and set_id
    
Bump the package release
    
CI: Enable 9to10 upgrades if testing repository both ALBS and production