### PR TITLE
Add PostgreSQL Vendor for 9 to 10 upgrade. Update CI

### DIFF
--- a/.github/workflows/elevate.yml
+++ b/.github/workflows/elevate.yml
@@ -100,8 +100,8 @@ jobs:
               # ELevation to AlmaLinux 10 is available for testing and NG repositories
               [[ "${{ inputs.repository }}" == *"testing"*  || "${{ inputs.repository }}" == *"NG"* ]] && \
                 VARIANTS+=("almalinux 9 to almalinux 10")
-              # ELevation to AlmaLinux Kitten 10 is available for NG repository
-              [[ "${{ inputs.repository }}" == *"NG"*  ]] && \
+              # ELevation to AlmaLinux Kitten 10 is available for testing and NG repositories
+              [[ "${{ inputs.repository }}" == *"testing"*  || "${{ inputs.repository }}" == *"NG"* ]] && \
                 VARIANTS+=("almalinux 9 to almalinux-kitten 10")
             fi
           fi

--- a/.github/workflows/elevate.yml
+++ b/.github/workflows/elevate.yml
@@ -580,7 +580,7 @@ jobs:
         sudo vagrant ssh elevatevm -c "sudo /vagrant/Vendors.sh mariadb ${{ env.source_release }}" || exit 1
 
     - name: Vendor - PostgreSQL
-      if: inputs.vendors == 'all' && env.target_release != '10'
+      if: inputs.vendors == 'all'
       run: |
         sudo vagrant ssh elevatevm -c "sudo /vagrant/Vendors.sh postgresql ${{ env.source_release }}" || exit 1
 

--- a/leapp-data.spec
+++ b/leapp-data.spec
@@ -40,7 +40,7 @@
 %endif
 %endif
 %if 0%{?rhel} == 9
-%define supported_vendors epel docker-ce
+%define supported_vendors epel docker-ce postgresql
 %define target_version 10
 %define dist_gpg_path distro/%{dist_name}/rpm-gpg/%{target_version}
 %if "%{dist_name}" == "almalinux"
@@ -59,7 +59,7 @@
 
 Name:		leapp-data-%{dist_name}
 Version:	0.9
-Release:	2%{?dist}.%{pes_events_build_date}
+Release:	3%{?dist}.%{pes_events_build_date}
 Summary:	data for migrating tool
 Group:		Applications/Databases
 License:	ASL 2.0
@@ -171,6 +171,9 @@ python3 tests/check_debranding.py %{buildroot}%{_sysconfdir}/leapp/files/pes-eve
 
 
 %changelog
+* Wed May 28 2025 Yuriy Kohut <ykohut@almalinux.org> - 0.9-3.20250505
+- Add PostgreSQL Vendor for 9 to 10 upgrade
+
 * Wed May 28 2025 Yuriy Kohut <ykohut@almalinux.org> - 0.9-2.20250505
 - ELevate to AlmaLinux 10.0 stable
 

--- a/vendors.d/postgresql.repo.el10
+++ b/vendors.d/postgresql.repo.el10
@@ -1,0 +1,70 @@
+#########################################################################
+# PGDG Red Hat Enterprise Linux / Rocky / AlmaLinux repositories.	#
+#########################################################################
+
+# PGDG Red Hat Enterprise Linux / Rocky / AlmaLinux stable common repository for all PostgreSQL versions
+
+[el10-pgdg-common]
+name=PostgreSQL common RPMs for RHEL / Rocky / AlmaLinux 10 - $basearch
+baseurl=https://download.postgresql.org/pub/repos/yum/common/redhat/rhel-10-$basearch
+enabled=1
+gpgcheck=1
+gpgkey=file:///etc/leapp/files/vendors.d/rpm-gpg/postgresql.gpg
+
+# Red Hat recently breaks compatibility between 8.n and 8.n+1. PGDG repo is
+# affected with the LLVM packages. This is a band aid repo for the llvmjit users
+# whose installations cannot be updated.
+
+# [el10-pgdg-rocky10-sysupdates]
+# name=PostgreSQL Supplementary ucommon RPMs for RHEL / Rocky / AlmaLinux 10 - $basearch
+# baseurl=https://download.postgresql.org/pub/repos/yum/common/pgdg-rocky10-sysupdates/redhat/rhel-10-x86_64
+# enabled=0
+# gpgcheck=1
+# gpgkey=file:///etc/leapp/files/vendors.d/rpm-gpg/postgresql.gpg
+
+# We provide extra package to support some RPMs in the PostgreSQL RPM repo, like
+# consul, haproxy, etc.
+
+[el10-pgdg-rhel10-extras]
+name=Extra packages to support some RPMs in the PostgreSQL RPM repo RHEL / Rocky / AlmaLinux 10 - $basearch
+baseurl=https://download.postgresql.org/pub/repos/yum/common/pgdg-rhel10-extras/redhat/rhel-10-$basearch
+enabled=0
+gpgcheck=1
+gpgkey=file:///etc/leapp/files/vendors.d/rpm-gpg/postgresql.gpg
+
+# PGDG Red Hat Enterprise Linux / Rocky / AlmaLinux stable repositories:
+
+[el10-pgdg17]
+name=PostgreSQL 17 for RHEL / Rocky / AlmaLinux 10 - $basearch
+baseurl=https://download.postgresql.org/pub/repos/yum/17/redhat/rhel-10-$basearch
+enabled=1
+gpgcheck=1
+gpgkey=file:///etc/leapp/files/vendors.d/rpm-gpg/postgresql.gpg
+
+[el10-pgdg16]
+name=PostgreSQL 16 for RHEL / Rocky / AlmaLinux 10 - $basearch
+baseurl=https://download.postgresql.org/pub/repos/yum/16/redhat/rhel-10-$basearch
+enabled=1
+gpgcheck=1
+gpgkey=file:///etc/leapp/files/vendors.d/rpm-gpg/postgresql.gpg
+
+[el10-pgdg15]
+name=PostgreSQL 15 for RHEL / Rocky / AlmaLinux 10 - $basearch
+baseurl=https://download.postgresql.org/pub/repos/yum/15/redhat/rhel-10-$basearch
+enabled=1
+gpgcheck=1
+gpgkey=file:///etc/leapp/files/vendors.d/rpm-gpg/postgresql.gpg
+
+[el10-pgdg14]
+name=PostgreSQL 14 for RHEL / Rocky / AlmaLinux 10 - $basearch
+baseurl=https://download.postgresql.org/pub/repos/yum/14/redhat/rhel-10-$basearch
+enabled=1
+gpgcheck=1
+gpgkey=file:///etc/leapp/files/vendors.d/rpm-gpg/postgresql.gpg
+
+[el10-pgdg13]
+name=PostgreSQL 13 for RHEL / Rocky / AlmaLinux 10 - $basearch
+baseurl=https://download.postgresql.org/pub/repos/yum/13/redhat/rhel-10-$basearch
+enabled=1
+gpgcheck=1
+gpgkey=file:///etc/leapp/files/vendors.d/rpm-gpg/postgresql.gpg

--- a/vendors.d/postgresql_map.json.el10
+++ b/vendors.d/postgresql_map.json.el10
@@ -1,0 +1,308 @@
+{
+    "datetime": "202505281525Z",
+    "version_format": "1.2.1",
+    "mapping": [
+        {
+            "source_major_version": "9",
+            "target_major_version": "10",
+            "entries": [
+                {
+                    "source": "pgdg-common",
+                    "target": [
+                        "el10-pgdg-common"
+                    ]
+                },
+                {
+                    "source": "pgdg17",
+                    "target": [
+                        "el10-pgdg17",
+                        "el10-pgdg-rhel10-extras"
+                    ]
+                },
+                {
+                    "source": "pgdg16",
+                    "target": [
+                        "el10-pgdg16",
+                        "el10-pgdg-rhel10-extras"
+                    ]
+                },
+                {
+                    "source": "pgdg15",
+                    "target": [
+                        "el10-pgdg15",
+                        "el10-pgdg-rhel10-extras"
+                    ]
+                },
+                {
+                    "source": "pgdg14",
+                    "target": [
+                        "el10-pgdg14",
+                        "el10-pgdg-rhel10-extras"
+                    ]
+                },
+                {
+                    "source": "pgdg13",
+                    "target": [
+                        "el10-pgdg13",
+                        "el10-pgdg-rhel10-extras"
+                    ]
+                }
+            ]
+        }
+    ],
+    "repositories": [
+        {
+            "pesid": "pgdg-common",
+            "entries": [
+                {
+                    "major_version": "9",
+                    "repoid": "pgdg-common",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "pgdg-common",
+                    "arch": "aarch64",
+                    "channel": "ga",
+                    "repo_type": "rpm"
+                }
+            ]
+        },
+        {
+            "pesid": "pgdg17",
+            "entries": [
+                {
+                    "major_version": "9",
+                    "repoid": "pgdg17",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "pgdg17",
+                    "arch": "aarch64",
+                    "channel": "ga",
+                    "repo_type": "rpm"
+                }
+            ]
+        },
+        {
+            "pesid": "pgdg16",
+            "entries": [
+                {
+                    "major_version": "9",
+                    "repoid": "pgdg16",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "pgdg16",
+                    "arch": "aarch64",
+                    "channel": "ga",
+                    "repo_type": "rpm"
+                }
+            ]
+        },
+        {
+            "pesid": "pgdg15",
+            "entries": [
+                {
+                    "major_version": "9",
+                    "repoid": "pgdg15",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "pgdg15",
+                    "arch": "aarch64",
+                    "channel": "ga",
+                    "repo_type": "rpm"
+                }
+            ]
+        },
+        {
+            "pesid": "pgdg14",
+            "entries": [
+                {
+                    "major_version": "9",
+                    "repoid": "pgdg14",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "pgdg14",
+                    "arch": "aarch64",
+                    "channel": "ga",
+                    "repo_type": "rpm"
+                }
+            ]
+        },
+        {
+            "pesid": "pgdg13",
+            "entries": [
+                {
+                    "major_version": "9",
+                    "repoid": "pgdg13",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "pgdg13",
+                    "arch": "aarch64",
+                    "channel": "ga",
+                    "repo_type": "rpm"
+                }
+            ]
+        },
+        {
+            "pesid": "el10-pgdg-common",
+            "entries": [
+                {
+                    "major_version": "10",
+                    "repoid": "el10-pgdg-common",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "10",
+                    "repoid": "el10-pgdg-common",
+                    "arch": "aarch64",
+                    "channel": "ga",
+                    "repo_type": "rpm"
+                }
+            ]
+        },
+        {
+            "pesid": "el10-pgdg17",
+            "entries": [
+                {
+                    "major_version": "10",
+                    "repoid": "el10-pgdg17",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "10",
+                    "repoid": "el10-pgdg17",
+                    "arch": "aarch64",
+                    "channel": "ga",
+                    "repo_type": "rpm"
+                }
+            ]
+        },
+        {
+            "pesid": "el10-pgdg16",
+            "entries": [
+                {
+                    "major_version": "10",
+                    "repoid": "el10-pgdg16",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "10",
+                    "repoid": "el10-pgdg16",
+                    "arch": "aarch64",
+                    "channel": "ga",
+                    "repo_type": "rpm"
+                }
+            ]
+        },
+        {
+            "pesid": "el10-pgdg15",
+            "entries": [
+                {
+                    "major_version": "10",
+                    "repoid": "el10-pgdg15",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "10",
+                    "repoid": "el10-pgdg15",
+                    "arch": "aarch64",
+                    "channel": "ga",
+                    "repo_type": "rpm"
+                }
+            ]
+        },
+        {
+            "pesid": "el10-pgdg14",
+            "entries": [
+                {
+                    "major_version": "10",
+                    "repoid": "el10-pgdg14",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "10",
+                    "repoid": "el10-pgdg14",
+                    "arch": "aarch64",
+                    "channel": "ga",
+                    "repo_type": "rpm"
+                }
+            ]
+        },
+        {
+            "pesid": "el10-pgdg13",
+            "entries": [
+                {
+                    "major_version": "10",
+                    "repoid": "el10-pgdg13",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "10",
+                    "repoid": "el10-pgdg13",
+                    "arch": "aarch64",
+                    "channel": "ga",
+                    "repo_type": "rpm"
+                }
+            ]
+        },
+        {
+            "pesid": "el10-pgdg-rhel10-extras",
+            "entries": [
+                {
+                    "major_version": "10",
+                    "repoid": "el10-pgdg-rhel10-extras",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "10",
+                    "repoid": "el10-pgdg-rhel10-extras",
+                    "arch": "aarch64",
+                    "channel": "ga",
+                    "repo_type": "rpm"
+                }
+            ]
+        }
+    ],
+    "provided_data_streams": [
+        "1.1",
+        "2.0",
+        "3.0",
+        "3.1"
+    ]
+}


### PR DESCRIPTION
Add PostgreSQL Vendor for 9 to 10 upgrade, but with temporary disabled pgdg-rocky10-sysupdates as it isn't available yet

CI:
- enable postgresql vendor for 9 to 10
- allow AlmaLinux 9 to Kitten 10 elevation for stable and NG repositories
