### PR TITLE
Update data to the upstream most recent version 0.22.0-4 (stream 4.0)

### DIFF
--- a/.github/workflows/elevate.yml
+++ b/.github/workflows/elevate.yml
@@ -52,18 +52,6 @@ on:
         type: boolean
         default: true
 
-      oraclelinux:
-        description: 'OracleLinux (7 to 8 only)'
-        required: true
-        type: boolean
-        default: true
-
-      rocky:
-        description: 'Rocky Linux'
-        required: true
-        type: boolean
-        default: true
-
       vendors:
         description: 'Install vendors'
         required: true
@@ -115,23 +103,6 @@ jobs:
             fi
           fi
 
-          # Oracle Linux variants
-          if [ "${{ inputs.oraclelinux }}" = "true" ]; then
-            if [ "${{ inputs.to8 }}" = "true" ]; then
-              VARIANTS+=("centos 7 to oraclelinux 8")
-            fi
-          fi
-
-          # Rocky Linux variants
-          if [ "${{ inputs.rocky }}" = "true" ]; then
-            if [ "${{ inputs.to8 }}" = "true" ]; then
-              VARIANTS+=("centos 7 to rocky 8")
-            fi
-            if [ "${{ inputs.to9 }}" = "true" ]; then
-              VARIANTS+=("rocky 8 to rocky 9")
-            fi
-          fi
-
           [ ${#VARIANTS[@]} -ne 0 ] && matrix=$(printf '"%s",' "${VARIANTS[@]}")
           matrix=${matrix%,}  # Remove the trailing comma
           echo matrix=$(jq -c <<< [${matrix}]) >> $GITHUB_OUTPUT
@@ -174,15 +145,6 @@ jobs:
           centos )
             vm_box=eurolinux-vagrant/centos-stream-${source_release} # generic/centos8s
             target_release_string="CentOS Stream release ${target_release}"
-            ;;
-          oraclelinux )
-            vm_box=eurolinux-vagrant/oracle-linux-${source_release} # generic/oracle8
-            target_release_string="Oracle Linux Server release ${target_release}"
-            target_release_file=/etc/oracle-release
-            ;;
-          rocky )
-            vm_box=eurolinux-vagrant/rocky-${source_release} # generic/rocky8
-            target_release_string="Rocky Linux release ${target_release}"
             ;;
         esac
         if [ "${source_release}" = "7" ]; then

--- a/files/almalinux-kitten/device_driver_deprecation_data.json
+++ b/files/almalinux-kitten/device_driver_deprecation_data.json
@@ -1,6 +1,6 @@
 {
   "provided_data_streams": [
-    "3.3"
+    "4.0"
   ],
   "data": [
     {

--- a/files/almalinux-kitten/pes-events.json
+++ b/files/almalinux-kitten/pes-events.json
@@ -1,7 +1,7 @@
 {
-    "timestamp": "202505091506Z",
+    "timestamp": "202505191506Z",
     "provided_data_streams": [
-        "3.3"
+        "4.0"
     ],
     "packageinfo": [
         {
@@ -147603,7 +147603,10 @@
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "httpcomponents-client-cache",
                         "repository": "almalinux8-powertools"
@@ -147611,7 +147614,11 @@
                 ],
                 "set_id": 6640
             },
-            "initial_release": null,
+            "initial_release": {
+                "major_version": 7,
+                "minor_version": 9,
+                "os_name": "CentOS"
+            },
             "modulestream_maps": [],
             "out_packageset": null,
             "release": {
@@ -147673,7 +147680,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -147699,14 +147705,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "httpcomponents-core-javadoc",
                         "repository": "almalinux8-powertools"
@@ -147723,7 +147735,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -147749,14 +147760,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "httpcomponents-project",
                         "repository": "almalinux8-powertools"
@@ -148080,9 +148097,7 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 4131,
@@ -148106,14 +148121,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "pki-deps",
+                        "stream": "10.6"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "pki-deps",
+                                "stream": "10.6"
+                            }
                         ],
                         "name": "jakarta-commons-httpclient",
                         "repository": "almalinux8-appstream"
@@ -148130,7 +148151,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -148156,14 +148176,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "pki-deps",
+                        "stream": "10.6"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "pki-deps",
+                                "stream": "10.6"
+                            }
                         ],
                         "name": "jakarta-commons-httpclient-demo",
                         "repository": "almalinux8-appstream"
@@ -148180,7 +148206,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -148206,14 +148231,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "pki-deps",
+                        "stream": "10.6"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "pki-deps",
+                                "stream": "10.6"
+                            }
                         ],
                         "name": "jakarta-commons-httpclient-javadoc",
                         "repository": "almalinux8-appstream"
@@ -148230,7 +148261,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -148256,14 +148286,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "pki-deps",
+                        "stream": "10.6"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "pki-deps",
+                                "stream": "10.6"
+                            }
                         ],
                         "name": "jakarta-commons-httpclient-manual",
                         "repository": "almalinux8-appstream"
@@ -148829,7 +148865,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -148855,14 +148890,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "javacc",
                         "repository": "almalinux8-powertools"
@@ -148879,7 +148920,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -148905,14 +148945,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "javacc-demo",
                         "repository": "almalinux8-powertools"
@@ -148929,7 +148975,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -148955,14 +149000,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "javacc-javadoc",
                         "repository": "almalinux8-powertools"
@@ -148979,7 +149030,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -149005,14 +149055,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "javacc-manual",
                         "repository": "almalinux8-powertools"
@@ -149029,7 +149085,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -149055,14 +149110,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "javacc-maven-plugin",
                         "repository": "almalinux8-powertools"
@@ -149244,7 +149305,6 @@
         {
             "action": 4,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -149270,28 +149330,40 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "ivy-local",
                         "repository": "almalinux8-powertools"
                     },
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "javapackages-filesystem",
                         "repository": "almalinux8-powertools"
                     },
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "javapackages-tools",
                         "repository": "almalinux8-powertools"
@@ -149308,7 +149380,6 @@
         {
             "action": 4,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -149334,21 +149405,30 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "javapackages-local",
                         "repository": "almalinux8-powertools"
                     },
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-local",
                         "repository": "almalinux8-powertools"
@@ -149530,9 +149610,7 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 4159,
@@ -149556,14 +149634,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "jaxen",
                         "repository": "almalinux8-powertools"
@@ -149580,7 +149664,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -149606,14 +149689,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "jaxen-demo",
                         "repository": "almalinux8-powertools"
@@ -150189,7 +150278,10 @@
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "jdom2",
                         "repository": "almalinux8-powertools"
@@ -150197,7 +150289,11 @@
                 ],
                 "set_id": 6737
             },
-            "initial_release": null,
+            "initial_release": {
+                "major_version": 7,
+                "minor_version": 9,
+                "os_name": "CentOS"
+            },
             "modulestream_maps": [],
             "out_packageset": null,
             "release": {
@@ -151861,7 +151957,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -151887,14 +151982,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "jflex",
                         "repository": "almalinux8-powertools"
@@ -151911,7 +152012,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -151937,14 +152037,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "jflex-javadoc",
                         "repository": "almalinux8-powertools"
@@ -152903,7 +153009,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -152929,14 +153034,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "junit-javadoc",
                         "repository": "almalinux8-powertools"
@@ -152953,7 +153064,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -152979,14 +153089,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "junit-manual",
                         "repository": "almalinux8-powertools"
@@ -153036,9 +153152,7 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 4250,
@@ -153062,14 +153176,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "jvnet-parent",
                         "repository": "almalinux8-powertools"
@@ -153086,7 +153206,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -153112,14 +153231,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "jzlib",
                         "repository": "almalinux8-powertools"
@@ -153136,7 +153261,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -153162,14 +153286,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "jzlib-demo",
                         "repository": "almalinux8-powertools"
@@ -153186,7 +153316,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -153212,14 +153341,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "jzlib-javadoc",
                         "repository": "almalinux8-powertools"
@@ -153501,7 +153636,6 @@
         {
             "action": 4,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -153527,21 +153661,30 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "maven",
+                        "stream": "3.5"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "maven",
+                                "stream": "3.5"
+                            }
                         ],
                         "name": "maven",
                         "repository": "almalinux8-appstream"
                     },
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "maven",
+                                "stream": "3.5"
+                            }
                         ],
                         "name": "maven-lib",
                         "repository": "almalinux8-appstream"
@@ -153558,7 +153701,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -153584,14 +153726,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-javadoc",
                         "repository": "almalinux8-powertools"
@@ -153608,7 +153756,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -153634,14 +153781,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-antrun-plugin",
                         "repository": "almalinux8-powertools"
@@ -153658,7 +153811,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -153684,14 +153836,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-antrun-plugin-javadoc",
                         "repository": "almalinux8-powertools"
@@ -153708,7 +153866,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -153734,14 +153891,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-archiver",
                         "repository": "almalinux8-powertools"
@@ -153758,7 +153921,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -153784,14 +153946,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-archiver-javadoc",
                         "repository": "almalinux8-powertools"
@@ -153808,7 +153976,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -153834,14 +154001,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-artifact-resolver",
                         "repository": "almalinux8-powertools"
@@ -153858,7 +154031,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -153884,14 +154056,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-artifact-resolver-javadoc",
                         "repository": "almalinux8-powertools"
@@ -153908,7 +154086,6 @@
         {
             "action": 3,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -153934,14 +154111,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-artifact-transfer",
                         "repository": "almalinux8-powertools"
@@ -153958,7 +154141,6 @@
         {
             "action": 3,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -153984,14 +154166,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-artifact-transfer-javadoc",
                         "repository": "almalinux8-powertools"
@@ -154008,7 +154196,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -154034,14 +154221,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-assembly-plugin",
                         "repository": "almalinux8-powertools"
@@ -154058,7 +154251,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -154084,14 +154276,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-assembly-plugin-javadoc",
                         "repository": "almalinux8-powertools"
@@ -154174,7 +154372,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -154200,14 +154397,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-clean-plugin",
                         "repository": "almalinux8-powertools"
@@ -154224,7 +154427,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -154250,14 +154452,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-clean-plugin-javadoc",
                         "repository": "almalinux8-powertools"
@@ -154274,7 +154482,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -154300,14 +154507,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-common-artifact-filters",
                         "repository": "almalinux8-powertools"
@@ -154324,7 +154537,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -154350,14 +154562,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-common-artifact-filters-javadoc",
                         "repository": "almalinux8-powertools"
@@ -154374,7 +154592,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -154400,14 +154617,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-compiler-plugin",
                         "repository": "almalinux8-powertools"
@@ -154424,7 +154647,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -154450,14 +154672,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-compiler-plugin-javadoc",
                         "repository": "almalinux8-powertools"
@@ -154474,7 +154702,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -154500,14 +154727,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-dependency-analyzer",
                         "repository": "almalinux8-powertools"
@@ -154524,7 +154757,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -154550,14 +154782,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-dependency-analyzer-javadoc",
                         "repository": "almalinux8-powertools"
@@ -154574,7 +154812,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -154600,14 +154837,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-dependency-plugin",
                         "repository": "almalinux8-powertools"
@@ -154624,7 +154867,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -154650,14 +154892,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-dependency-plugin-javadoc",
                         "repository": "almalinux8-powertools"
@@ -154674,7 +154922,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -154700,14 +154947,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-dependency-tree",
                         "repository": "almalinux8-powertools"
@@ -154724,7 +154977,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -154750,14 +155002,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-dependency-tree-javadoc",
                         "repository": "almalinux8-powertools"
@@ -154840,7 +155098,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -154866,14 +155123,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-doxia",
                         "repository": "almalinux8-powertools"
@@ -154890,7 +155153,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -154916,14 +155178,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-doxia-core",
                         "repository": "almalinux8-powertools"
@@ -154940,7 +155208,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -154966,14 +155233,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-doxia-javadoc",
                         "repository": "almalinux8-powertools"
@@ -154990,7 +155263,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -155016,14 +155288,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-doxia-logging-api",
                         "repository": "almalinux8-powertools"
@@ -155040,7 +155318,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -155066,14 +155343,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-doxia-module-apt",
                         "repository": "almalinux8-powertools"
@@ -155090,7 +155373,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -155116,14 +155398,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-doxia-module-confluence",
                         "repository": "almalinux8-powertools"
@@ -155140,7 +155428,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -155166,14 +155453,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-doxia-module-docbook-simple",
                         "repository": "almalinux8-powertools"
@@ -155190,7 +155483,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -155216,14 +155508,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-doxia-module-fml",
                         "repository": "almalinux8-powertools"
@@ -155240,7 +155538,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -155266,14 +155563,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-doxia-module-latex",
                         "repository": "almalinux8-powertools"
@@ -155290,7 +155593,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -155316,14 +155618,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-doxia-module-rtf",
                         "repository": "almalinux8-powertools"
@@ -155340,7 +155648,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -155366,14 +155673,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-doxia-module-twiki",
                         "repository": "almalinux8-powertools"
@@ -155390,7 +155703,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -155416,14 +155728,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-doxia-module-xdoc",
                         "repository": "almalinux8-powertools"
@@ -155440,7 +155758,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -155466,14 +155783,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-doxia-module-xhtml",
                         "repository": "almalinux8-powertools"
@@ -155490,7 +155813,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -155516,14 +155838,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-doxia-modules",
                         "repository": "almalinux8-powertools"
@@ -155540,7 +155868,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -155566,14 +155893,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-doxia-sink-api",
                         "repository": "almalinux8-powertools"
@@ -155590,7 +155923,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -155616,14 +155948,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-doxia-test-docs",
                         "repository": "almalinux8-powertools"
@@ -155640,7 +155978,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -155666,14 +156003,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-doxia-tests",
                         "repository": "almalinux8-powertools"
@@ -155723,7 +156066,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -155749,14 +156091,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-doxia-sitetools",
                         "repository": "almalinux8-powertools"
@@ -155773,7 +156121,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -155799,14 +156146,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-doxia-sitetools-javadoc",
                         "repository": "almalinux8-powertools"
@@ -155823,7 +156176,6 @@
         {
             "action": 3,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -155849,14 +156201,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-doxia-sitetools",
                         "repository": "almalinux8-powertools"
@@ -155873,7 +156231,6 @@
         {
             "action": 3,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -155899,14 +156256,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-doxia-sitetools-javadoc",
                         "repository": "almalinux8-powertools"
@@ -155923,7 +156286,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -155949,14 +156311,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-enforcer",
                         "repository": "almalinux8-powertools"
@@ -155973,7 +156341,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -155999,14 +156366,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-enforcer-api",
                         "repository": "almalinux8-powertools"
@@ -156023,7 +156396,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -156049,14 +156421,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-enforcer-javadoc",
                         "repository": "almalinux8-powertools"
@@ -156073,7 +156451,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -156099,14 +156476,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-enforcer-plugin",
                         "repository": "almalinux8-powertools"
@@ -156123,7 +156506,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -156149,14 +156531,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-enforcer-rules",
                         "repository": "almalinux8-powertools"
@@ -156173,7 +156561,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -156199,14 +156586,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-file-management",
                         "repository": "almalinux8-powertools"
@@ -156223,7 +156616,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -156249,14 +156641,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-file-management-javadoc",
                         "repository": "almalinux8-powertools"
@@ -156273,7 +156671,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -156299,14 +156696,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-filtering",
                         "repository": "almalinux8-powertools"
@@ -156323,7 +156726,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -156349,14 +156751,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-filtering-javadoc",
                         "repository": "almalinux8-powertools"
@@ -156439,7 +156847,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -156465,14 +156872,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-install-plugin",
                         "repository": "almalinux8-powertools"
@@ -156489,7 +156902,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -156515,14 +156927,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-install-plugin-javadoc",
                         "repository": "almalinux8-powertools"
@@ -156539,7 +156957,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -156565,14 +156982,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-invoker",
                         "repository": "almalinux8-powertools"
@@ -156589,7 +157012,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -156615,14 +157037,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-invoker-javadoc",
                         "repository": "almalinux8-powertools"
@@ -156639,7 +157067,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -156665,14 +157092,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-invoker-plugin",
                         "repository": "almalinux8-powertools"
@@ -156689,7 +157122,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -156715,14 +157147,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-invoker-plugin-javadoc",
                         "repository": "almalinux8-powertools"
@@ -156739,7 +157177,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -156765,14 +157202,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-jar-plugin",
                         "repository": "almalinux8-powertools"
@@ -156789,7 +157232,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -156815,14 +157257,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-jar-plugin-javadoc",
                         "repository": "almalinux8-powertools"
@@ -157136,7 +157584,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -157162,14 +157609,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-parent",
                         "repository": "almalinux8-powertools"
@@ -157186,7 +157639,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -157212,14 +157664,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-plugin-build-helper",
                         "repository": "almalinux8-powertools"
@@ -157236,7 +157694,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -157262,14 +157719,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-plugin-build-helper-javadoc",
                         "repository": "almalinux8-powertools"
@@ -157286,7 +157749,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -157312,14 +157774,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-plugin-bundle",
                         "repository": "almalinux8-powertools"
@@ -157336,7 +157804,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -157362,14 +157829,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-plugin-bundle-javadoc",
                         "repository": "almalinux8-powertools"
@@ -157386,7 +157859,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -157412,14 +157884,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-plugin-testing",
                         "repository": "almalinux8-powertools"
@@ -157436,7 +157914,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -157462,14 +157939,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-plugin-testing-harness",
                         "repository": "almalinux8-powertools"
@@ -157486,7 +157969,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -157512,14 +157994,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-plugin-testing-javadoc",
                         "repository": "almalinux8-powertools"
@@ -157536,7 +158024,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -157562,14 +158049,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-plugin-testing-tools",
                         "repository": "almalinux8-powertools"
@@ -157586,7 +158079,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -157612,14 +158104,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-test-tools",
                         "repository": "almalinux8-powertools"
@@ -158784,7 +159282,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -158810,14 +159307,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-reporting-api-javadoc",
                         "repository": "almalinux8-powertools"
@@ -159547,7 +160050,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -159573,14 +160075,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-shared-incremental-javadoc",
                         "repository": "almalinux8-powertools"
@@ -159597,7 +160105,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -159623,14 +160130,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-shared-io",
                         "repository": "almalinux8-powertools"
@@ -159647,7 +160160,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -159673,14 +160185,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-shared-io-javadoc",
                         "repository": "almalinux8-powertools"
@@ -159813,7 +160331,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -159839,14 +160356,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-shared-utils-javadoc",
                         "repository": "almalinux8-powertools"
@@ -690839,6 +691362,139 @@
             }
         },
         {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 19561,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "dyninst-testsuite",
+                        "repository": "almalinux10-crb"
+                    }
+                ],
+                "set_id": 26167
+            },
+            "initial_release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 1,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 19562,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "dyninst-testsuite",
+                        "repository": "almalinux9-crb"
+                    }
+                ],
+                "set_id": 26168
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 7,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 19563,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "dyninst-testsuite",
+                        "repository": "almalinux10-crb"
+                    }
+                ],
+                "set_id": 26169
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 7,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 19564,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "rpm-plugin-dbus-announce",
+                        "repository": "almalinux10-appstream"
+                    }
+                ],
+                "set_id": 26170
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 7,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
             "action": 3,
             "architectures": [
                 "x86_64",
@@ -690846,7 +691502,7 @@
                 "ppc64le",
                 "s390x"
             ],
-            "id": 19561,
+            "id": 19565,
             "in_packageset": {
                 "package": [
                     {
@@ -690857,7 +691513,7 @@
                         "repository": "base"
                     }
                 ],
-                "set_id": 26168
+                "set_id": 26172
             },
             "initial_release": {
                 "major_version": 7,
@@ -690882,203 +691538,7 @@
                         "repository": "almalinux8-baseos"
                     }
                 ],
-                "set_id": 26167
-            },
-            "release": {
-                "major_version": 8,
-                "minor_version": 0,
-                "os_name": "AlmaLinux",
-                "tag": null,
-                "z_stream": null
-            }
-        },
-        {
-            "action": 1,
-            "architectures": [
-                "x86_64",
-                "aarch64",
-                "ppc64le",
-                "s390x"
-            ],
-            "id": 19562,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "libreport-rhel-bugzilla",
-                        "repository": "base"
-                    }
-                ],
-                "set_id": 26169
-            },
-            "initial_release": {
-                "major_version": 7,
-                "minor_version": 6,
-                "os_name": "CentOS"
-            },
-            "modulestream_maps": [],
-            "out_packageset": null,
-            "release": {
-                "major_version": 8,
-                "minor_version": 3,
-                "os_name": "AlmaLinux"
-            }
-        },
-        {
-            "action": 3,
-            "architectures": [
-                "x86_64",
-                "aarch64",
-                "ppc64le",
-                "s390x"
-            ],
-            "id": 19563,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "libssh2",
-                        "repository": "base"
-                    }
-                ],
                 "set_id": 26171
-            },
-            "initial_release": {
-                "major_version": 7,
-                "minor_version": 7,
-                "os_name": "CentOS",
-                "tag": null,
-                "z_stream": null
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "libssh",
-                        "repository": "almalinux8-baseos"
-                    }
-                ],
-                "set_id": 26170
-            },
-            "release": {
-                "major_version": 8,
-                "minor_version": 0,
-                "os_name": "AlmaLinux",
-                "tag": null,
-                "z_stream": null
-            }
-        },
-        {
-            "action": 3,
-            "architectures": [
-                "x86_64",
-                "aarch64",
-                "ppc64le",
-                "s390x"
-            ],
-            "id": 19564,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "libssh2-devel",
-                        "repository": "base"
-                    }
-                ],
-                "set_id": 26173
-            },
-            "initial_release": {
-                "major_version": 7,
-                "minor_version": 7,
-                "os_name": "CentOS",
-                "tag": null,
-                "z_stream": null
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "libssh-devel",
-                        "repository": "almalinux8-baseos"
-                    }
-                ],
-                "set_id": 26172
-            },
-            "release": {
-                "major_version": 8,
-                "minor_version": 0,
-                "os_name": "AlmaLinux",
-                "tag": null,
-                "z_stream": null
-            }
-        },
-        {
-            "action": 3,
-            "architectures": [
-                "x86_64",
-                "aarch64",
-                "ppc64le",
-                "s390x"
-            ],
-            "id": 19565,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "libssh2-docs",
-                        "repository": "base"
-                    }
-                ],
-                "set_id": 26175
-            },
-            "initial_release": {
-                "major_version": 7,
-                "minor_version": 7,
-                "os_name": "CentOS",
-                "tag": null,
-                "z_stream": null
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "libssh-docs",
-                        "repository": "almalinux8-baseos"
-                    }
-                ],
-                "set_id": 26174
             },
             "release": {
                 "major_version": 8,
@@ -691103,36 +691563,27 @@
                         "modulestreams": [
                             null
                         ],
-                        "name": "ustr",
-                        "repository": "powertools"
+                        "name": "libreport-rhel-bugzilla",
+                        "repository": "base"
                     }
                 ],
-                "set_id": 26176
+                "set_id": 26173
             },
             "initial_release": {
-                "major_version": 8,
-                "minor_version": 5,
-                "os_name": "AlmaLinux",
-                "tag": null,
-                "z_stream": null
+                "major_version": 7,
+                "minor_version": 6,
+                "os_name": "CentOS"
             },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
+            "modulestream_maps": [],
             "out_packageset": null,
             "release": {
-                "major_version": 9,
-                "minor_version": 0,
-                "os_name": "AlmaLinux",
-                "tag": null,
-                "z_stream": null
+                "major_version": 8,
+                "minor_version": 3,
+                "os_name": "AlmaLinux"
             }
         },
         {
-            "action": 1,
+            "action": 3,
             "architectures": [
                 "x86_64",
                 "aarch64",
@@ -691146,16 +691597,16 @@
                         "modulestreams": [
                             null
                         ],
-                        "name": "nautilus-sendto",
-                        "repository": "appstream"
+                        "name": "libssh2",
+                        "repository": "base"
                     }
                 ],
-                "set_id": 26177
+                "set_id": 26175
             },
             "initial_release": {
-                "major_version": 8,
-                "minor_version": 5,
-                "os_name": "AlmaLinux",
+                "major_version": 7,
+                "minor_version": 7,
+                "os_name": "CentOS",
                 "tag": null,
                 "z_stream": null
             },
@@ -691165,9 +691616,20 @@
                     "out_modulestream": null
                 }
             ],
-            "out_packageset": null,
+            "out_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "libssh",
+                        "repository": "almalinux8-baseos"
+                    }
+                ],
+                "set_id": 26174
+            },
             "release": {
-                "major_version": 9,
+                "major_version": 8,
                 "minor_version": 0,
                 "os_name": "AlmaLinux",
                 "tag": null,
@@ -691175,7 +691637,7 @@
             }
         },
         {
-            "action": 1,
+            "action": 3,
             "architectures": [
                 "x86_64",
                 "aarch64",
@@ -691189,16 +691651,16 @@
                         "modulestreams": [
                             null
                         ],
-                        "name": "libdmapsharing",
-                        "repository": "appstream"
+                        "name": "libssh2-devel",
+                        "repository": "base"
                     }
                 ],
-                "set_id": 26178
+                "set_id": 26177
             },
             "initial_release": {
-                "major_version": 8,
-                "minor_version": 5,
-                "os_name": "AlmaLinux",
+                "major_version": 7,
+                "minor_version": 7,
+                "os_name": "CentOS",
                 "tag": null,
                 "z_stream": null
             },
@@ -691208,9 +691670,20 @@
                     "out_modulestream": null
                 }
             ],
-            "out_packageset": null,
+            "out_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "libssh-devel",
+                        "repository": "almalinux8-baseos"
+                    }
+                ],
+                "set_id": 26176
+            },
             "release": {
-                "major_version": 9,
+                "major_version": 8,
                 "minor_version": 0,
                 "os_name": "AlmaLinux",
                 "tag": null,
@@ -691218,7 +691691,7 @@
             }
         },
         {
-            "action": 1,
+            "action": 3,
             "architectures": [
                 "x86_64",
                 "aarch64",
@@ -691232,16 +691705,16 @@
                         "modulestreams": [
                             null
                         ],
-                        "name": "iptstate",
-                        "repository": "baseos"
+                        "name": "libssh2-docs",
+                        "repository": "base"
                     }
                 ],
                 "set_id": 26179
             },
             "initial_release": {
-                "major_version": 8,
-                "minor_version": 5,
-                "os_name": "AlmaLinux",
+                "major_version": 7,
+                "minor_version": 7,
+                "os_name": "CentOS",
                 "tag": null,
                 "z_stream": null
             },
@@ -691251,9 +691724,20 @@
                     "out_modulestream": null
                 }
             ],
-            "out_packageset": null,
+            "out_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "libssh-docs",
+                        "repository": "almalinux8-baseos"
+                    }
+                ],
+                "set_id": 26178
+            },
             "release": {
-                "major_version": 9,
+                "major_version": 8,
                 "minor_version": 0,
                 "os_name": "AlmaLinux",
                 "tag": null,
@@ -691275,8 +691759,8 @@
                         "modulestreams": [
                             null
                         ],
-                        "name": "gupnp",
-                        "repository": "appstream"
+                        "name": "ustr",
+                        "repository": "powertools"
                     }
                 ],
                 "set_id": 26180
@@ -691318,7 +691802,7 @@
                         "modulestreams": [
                             null
                         ],
-                        "name": "libplist",
+                        "name": "nautilus-sendto",
                         "repository": "appstream"
                     }
                 ],
@@ -691361,8 +691845,8 @@
                         "modulestreams": [
                             null
                         ],
-                        "name": "jimtcl",
-                        "repository": "baseos"
+                        "name": "libdmapsharing",
+                        "repository": "appstream"
                     }
                 ],
                 "set_id": 26182
@@ -691404,7 +691888,7 @@
                         "modulestreams": [
                             null
                         ],
-                        "name": "libmodman",
+                        "name": "iptstate",
                         "repository": "baseos"
                     }
                 ],
@@ -691447,7 +691931,7 @@
                         "modulestreams": [
                             null
                         ],
-                        "name": "libimobiledevice",
+                        "name": "gupnp",
                         "repository": "appstream"
                     }
                 ],
@@ -691490,7 +691974,7 @@
                         "modulestreams": [
                             null
                         ],
-                        "name": "khmeros-fonts-common",
+                        "name": "libplist",
                         "repository": "appstream"
                     }
                 ],
@@ -691533,8 +692017,8 @@
                         "modulestreams": [
                             null
                         ],
-                        "name": "gupnp-dlna",
-                        "repository": "appstream"
+                        "name": "jimtcl",
+                        "repository": "baseos"
                     }
                 ],
                 "set_id": 26186
@@ -691576,8 +692060,8 @@
                         "modulestreams": [
                             null
                         ],
-                        "name": "gupnp-av",
-                        "repository": "appstream"
+                        "name": "libmodman",
+                        "repository": "baseos"
                     }
                 ],
                 "set_id": 26187
@@ -691619,7 +692103,7 @@
                         "modulestreams": [
                             null
                         ],
-                        "name": "lua-socket",
+                        "name": "libimobiledevice",
                         "repository": "appstream"
                     }
                 ],
@@ -691662,7 +692146,7 @@
                         "modulestreams": [
                             null
                         ],
-                        "name": "usbmuxd",
+                        "name": "khmeros-fonts-common",
                         "repository": "appstream"
                     }
                 ],
@@ -691705,7 +692189,7 @@
                         "modulestreams": [
                             null
                         ],
-                        "name": "gssdp",
+                        "name": "gupnp-dlna",
                         "repository": "appstream"
                     }
                 ],
@@ -691748,7 +692232,7 @@
                         "modulestreams": [
                             null
                         ],
-                        "name": "libusbmuxd",
+                        "name": "gupnp-av",
                         "repository": "appstream"
                     }
                 ],
@@ -691779,7 +692263,10 @@
         {
             "action": 1,
             "architectures": [
-                "x86_64"
+                "x86_64",
+                "aarch64",
+                "ppc64le",
+                "s390x"
             ],
             "id": 19582,
             "in_packageset": {
@@ -691788,29 +692275,41 @@
                         "modulestreams": [
                             null
                         ],
-                        "name": "sl-release-notes",
-                        "repository": "sl"
+                        "name": "lua-socket",
+                        "repository": "appstream"
                     }
                 ],
                 "set_id": 26192
             },
             "initial_release": {
-                "major_version": 7,
-                "minor_version": 7,
-                "os_name": "scientific"
+                "major_version": 8,
+                "minor_version": 5,
+                "os_name": "AlmaLinux",
+                "tag": null,
+                "z_stream": null
             },
-            "modulestream_maps": [],
+            "modulestream_maps": [
+                {
+                    "in_modulestream": null,
+                    "out_modulestream": null
+                }
+            ],
             "out_packageset": null,
             "release": {
-                "major_version": 8,
+                "major_version": 9,
                 "minor_version": 0,
-                "os_name": "AlmaLinux"
+                "os_name": "AlmaLinux",
+                "tag": null,
+                "z_stream": null
             }
         },
         {
             "action": 1,
             "architectures": [
-                "x86_64"
+                "x86_64",
+                "aarch64",
+                "ppc64le",
+                "s390x"
             ],
             "id": 19583,
             "in_packageset": {
@@ -691819,29 +692318,41 @@
                         "modulestreams": [
                             null
                         ],
-                        "name": "sl7-upgrade",
-                        "repository": "sl"
+                        "name": "usbmuxd",
+                        "repository": "appstream"
                     }
                 ],
                 "set_id": 26193
             },
             "initial_release": {
-                "major_version": 7,
-                "minor_version": 7,
-                "os_name": "scientific"
+                "major_version": 8,
+                "minor_version": 5,
+                "os_name": "AlmaLinux",
+                "tag": null,
+                "z_stream": null
             },
-            "modulestream_maps": [],
+            "modulestream_maps": [
+                {
+                    "in_modulestream": null,
+                    "out_modulestream": null
+                }
+            ],
             "out_packageset": null,
             "release": {
-                "major_version": 8,
+                "major_version": 9,
                 "minor_version": 0,
-                "os_name": "AlmaLinux"
+                "os_name": "AlmaLinux",
+                "tag": null,
+                "z_stream": null
             }
         },
         {
             "action": 1,
             "architectures": [
-                "x86_64"
+                "x86_64",
+                "aarch64",
+                "ppc64le",
+                "s390x"
             ],
             "id": 19584,
             "in_packageset": {
@@ -691850,29 +692361,41 @@
                         "modulestreams": [
                             null
                         ],
-                        "name": "yum-conf-extras",
-                        "repository": "repos"
+                        "name": "gssdp",
+                        "repository": "appstream"
                     }
                 ],
                 "set_id": 26194
             },
             "initial_release": {
-                "major_version": 7,
-                "minor_version": 7,
-                "os_name": "scientific"
+                "major_version": 8,
+                "minor_version": 5,
+                "os_name": "AlmaLinux",
+                "tag": null,
+                "z_stream": null
             },
-            "modulestream_maps": [],
+            "modulestream_maps": [
+                {
+                    "in_modulestream": null,
+                    "out_modulestream": null
+                }
+            ],
             "out_packageset": null,
             "release": {
-                "major_version": 8,
+                "major_version": 9,
                 "minor_version": 0,
-                "os_name": "AlmaLinux"
+                "os_name": "AlmaLinux",
+                "tag": null,
+                "z_stream": null
             }
         },
         {
             "action": 1,
             "architectures": [
-                "x86_64"
+                "x86_64",
+                "aarch64",
+                "ppc64le",
+                "s390x"
             ],
             "id": 19585,
             "in_packageset": {
@@ -691881,23 +692404,32 @@
                         "modulestreams": [
                             null
                         ],
-                        "name": "yum-conf-repos",
-                        "repository": "repos"
+                        "name": "libusbmuxd",
+                        "repository": "appstream"
                     }
                 ],
                 "set_id": 26195
             },
             "initial_release": {
-                "major_version": 7,
-                "minor_version": 7,
-                "os_name": "scientific"
+                "major_version": 8,
+                "minor_version": 5,
+                "os_name": "AlmaLinux",
+                "tag": null,
+                "z_stream": null
             },
-            "modulestream_maps": [],
+            "modulestream_maps": [
+                {
+                    "in_modulestream": null,
+                    "out_modulestream": null
+                }
+            ],
             "out_packageset": null,
             "release": {
-                "major_version": 8,
+                "major_version": 9,
                 "minor_version": 0,
-                "os_name": "AlmaLinux"
+                "os_name": "AlmaLinux",
+                "tag": null,
+                "z_stream": null
             }
         },
         {
@@ -691912,7 +692444,7 @@
                         "modulestreams": [
                             null
                         ],
-                        "name": "yum-conf-sl7x",
+                        "name": "sl-release-notes",
                         "repository": "sl"
                     }
                 ],
@@ -691943,11 +692475,135 @@
                         "modulestreams": [
                             null
                         ],
-                        "name": "sl-bookmarks",
+                        "name": "sl7-upgrade",
                         "repository": "sl"
                     }
                 ],
                 "set_id": 26197
+            },
+            "initial_release": {
+                "major_version": 7,
+                "minor_version": 7,
+                "os_name": "scientific"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 8,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "x86_64"
+            ],
+            "id": 19588,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "yum-conf-extras",
+                        "repository": "repos"
+                    }
+                ],
+                "set_id": 26198
+            },
+            "initial_release": {
+                "major_version": 7,
+                "minor_version": 7,
+                "os_name": "scientific"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 8,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "x86_64"
+            ],
+            "id": 19589,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "yum-conf-repos",
+                        "repository": "repos"
+                    }
+                ],
+                "set_id": 26199
+            },
+            "initial_release": {
+                "major_version": 7,
+                "minor_version": 7,
+                "os_name": "scientific"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 8,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "x86_64"
+            ],
+            "id": 19590,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "yum-conf-sl7x",
+                        "repository": "sl"
+                    }
+                ],
+                "set_id": 26200
+            },
+            "initial_release": {
+                "major_version": 7,
+                "minor_version": 7,
+                "os_name": "scientific"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 8,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "x86_64"
+            ],
+            "id": 19591,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "sl-bookmarks",
+                        "repository": "sl"
+                    }
+                ],
+                "set_id": 26201
             },
             "initial_release": {
                 "major_version": 7,
@@ -691968,7 +692624,7 @@
                 "x86_64",
                 "aarch64"
             ],
-            "id": 19588,
+            "id": 19592,
             "in_packageset": {
                 "package": [
                     {
@@ -691976,110 +692632,6 @@
                             null
                         ],
                         "name": "sl-indexhtml",
-                        "repository": "sl"
-                    }
-                ],
-                "set_id": 26199
-            },
-            "initial_release": {
-                "major_version": 7,
-                "minor_version": 7,
-                "os_name": "scientific",
-                "tag": null,
-                "z_stream": null
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "almalinux-indexhtml",
-                        "repository": "almalinux8-baseos"
-                    }
-                ],
-                "set_id": 26198
-            },
-            "release": {
-                "major_version": 8,
-                "minor_version": 0,
-                "os_name": "AlmaLinux",
-                "tag": null,
-                "z_stream": null
-            }
-        },
-        {
-            "action": 3,
-            "architectures": [
-                "x86_64",
-                "aarch64"
-            ],
-            "id": 19589,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "sl-logos",
-                        "repository": "sl"
-                    }
-                ],
-                "set_id": 26201
-            },
-            "initial_release": {
-                "major_version": 7,
-                "minor_version": 7,
-                "os_name": "scientific",
-                "tag": null,
-                "z_stream": null
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "almalinux-logos",
-                        "repository": "almalinux8-appstream"
-                    }
-                ],
-                "set_id": 26200
-            },
-            "release": {
-                "major_version": 8,
-                "minor_version": 0,
-                "os_name": "AlmaLinux",
-                "tag": null,
-                "z_stream": null
-            }
-        },
-        {
-            "action": 3,
-            "architectures": [
-                "x86_64",
-                "aarch64"
-            ],
-            "id": 19590,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "sl-release",
                         "repository": "sl"
                     }
                 ],
@@ -692104,7 +692656,7 @@
                         "modulestreams": [
                             null
                         ],
-                        "name": "almalinux-release",
+                        "name": "almalinux-indexhtml",
                         "repository": "almalinux8-baseos"
                     }
                 ],
@@ -692124,14 +692676,14 @@
                 "x86_64",
                 "aarch64"
             ],
-            "id": 19591,
+            "id": 19593,
             "in_packageset": {
                 "package": [
                     {
                         "modulestreams": [
                             null
                         ],
-                        "name": "libssh2",
+                        "name": "sl-logos",
                         "repository": "sl"
                     }
                 ],
@@ -692156,11 +692708,115 @@
                         "modulestreams": [
                             null
                         ],
+                        "name": "almalinux-logos",
+                        "repository": "almalinux8-appstream"
+                    }
+                ],
+                "set_id": 26204
+            },
+            "release": {
+                "major_version": 8,
+                "minor_version": 0,
+                "os_name": "AlmaLinux",
+                "tag": null,
+                "z_stream": null
+            }
+        },
+        {
+            "action": 3,
+            "architectures": [
+                "x86_64",
+                "aarch64"
+            ],
+            "id": 19594,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "sl-release",
+                        "repository": "sl"
+                    }
+                ],
+                "set_id": 26207
+            },
+            "initial_release": {
+                "major_version": 7,
+                "minor_version": 7,
+                "os_name": "scientific",
+                "tag": null,
+                "z_stream": null
+            },
+            "modulestream_maps": [
+                {
+                    "in_modulestream": null,
+                    "out_modulestream": null
+                }
+            ],
+            "out_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "almalinux-release",
+                        "repository": "almalinux8-baseos"
+                    }
+                ],
+                "set_id": 26206
+            },
+            "release": {
+                "major_version": 8,
+                "minor_version": 0,
+                "os_name": "AlmaLinux",
+                "tag": null,
+                "z_stream": null
+            }
+        },
+        {
+            "action": 3,
+            "architectures": [
+                "x86_64",
+                "aarch64"
+            ],
+            "id": 19595,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "libssh2",
+                        "repository": "sl"
+                    }
+                ],
+                "set_id": 26209
+            },
+            "initial_release": {
+                "major_version": 7,
+                "minor_version": 7,
+                "os_name": "scientific",
+                "tag": null,
+                "z_stream": null
+            },
+            "modulestream_maps": [
+                {
+                    "in_modulestream": null,
+                    "out_modulestream": null
+                }
+            ],
+            "out_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
                         "name": "libssh",
                         "repository": "almalinux8-baseos"
                     }
                 ],
-                "set_id": 26204
+                "set_id": 26208
             },
             "release": {
                 "major_version": 8,
@@ -692175,7 +692831,7 @@
             "architectures": [
                 "x86_64"
             ],
-            "id": 19592,
+            "id": 19596,
             "in_packageset": {
                 "package": [
                     {
@@ -692186,7 +692842,7 @@
                         "repository": "sl"
                     }
                 ],
-                "set_id": 26206
+                "set_id": 26210
             },
             "initial_release": {
                 "major_version": 7,
@@ -692207,7 +692863,7 @@
                 "x86_64",
                 "aarch64"
             ],
-            "id": 19593,
+            "id": 19597,
             "in_packageset": {
                 "package": [
                     {
@@ -692218,7 +692874,7 @@
                         "repository": "sl"
                     }
                 ],
-                "set_id": 26208
+                "set_id": 26212
             },
             "initial_release": {
                 "major_version": 7,
@@ -692243,7 +692899,7 @@
                         "repository": "almalinux8-baseos"
                     }
                 ],
-                "set_id": 26207
+                "set_id": 26211
             },
             "release": {
                 "major_version": 8,
@@ -692258,130 +692914,6 @@
             "architectures": [
                 "x86_64"
             ],
-            "id": 19594,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "openafs-1.6-sl-devel",
-                        "repository": "sl"
-                    }
-                ],
-                "set_id": 26209
-            },
-            "initial_release": {
-                "major_version": 7,
-                "minor_version": 7,
-                "os_name": "scientific"
-            },
-            "modulestream_maps": [],
-            "out_packageset": null,
-            "release": {
-                "major_version": 8,
-                "minor_version": 0,
-                "os_name": "AlmaLinux"
-            }
-        },
-        {
-            "action": 1,
-            "architectures": [
-                "x86_64"
-            ],
-            "id": 19595,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "openafs-1.6-sl-authlibs",
-                        "repository": "sl"
-                    }
-                ],
-                "set_id": 26210
-            },
-            "initial_release": {
-                "major_version": 7,
-                "minor_version": 7,
-                "os_name": "scientific"
-            },
-            "modulestream_maps": [],
-            "out_packageset": null,
-            "release": {
-                "major_version": 8,
-                "minor_version": 0,
-                "os_name": "AlmaLinux"
-            }
-        },
-        {
-            "action": 1,
-            "architectures": [
-                "x86_64"
-            ],
-            "id": 19596,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "openafs-1.6-sl-krb5",
-                        "repository": "sl"
-                    }
-                ],
-                "set_id": 26211
-            },
-            "initial_release": {
-                "major_version": 7,
-                "minor_version": 7,
-                "os_name": "scientific"
-            },
-            "modulestream_maps": [],
-            "out_packageset": null,
-            "release": {
-                "major_version": 8,
-                "minor_version": 0,
-                "os_name": "AlmaLinux"
-            }
-        },
-        {
-            "action": 1,
-            "architectures": [
-                "x86_64"
-            ],
-            "id": 19597,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "openafs-1.6-sl-server",
-                        "repository": "sl"
-                    }
-                ],
-                "set_id": 26212
-            },
-            "initial_release": {
-                "major_version": 7,
-                "minor_version": 7,
-                "os_name": "scientific"
-            },
-            "modulestream_maps": [],
-            "out_packageset": null,
-            "release": {
-                "major_version": 8,
-                "minor_version": 0,
-                "os_name": "AlmaLinux"
-            }
-        },
-        {
-            "action": 1,
-            "architectures": [
-                "x86_64"
-            ],
             "id": 19598,
             "in_packageset": {
                 "package": [
@@ -692389,7 +692921,7 @@
                         "modulestreams": [
                             null
                         ],
-                        "name": "openafs-1.6-sl-kpasswd",
+                        "name": "openafs-1.6-sl-devel",
                         "repository": "sl"
                     }
                 ],
@@ -692420,7 +692952,7 @@
                         "modulestreams": [
                             null
                         ],
-                        "name": "openafs-1.6-sl-compat",
+                        "name": "openafs-1.6-sl-authlibs",
                         "repository": "sl"
                     }
                 ],
@@ -692451,7 +692983,7 @@
                         "modulestreams": [
                             null
                         ],
-                        "name": "openafs-1.6-sl-kernel-source",
+                        "name": "openafs-1.6-sl-krb5",
                         "repository": "sl"
                     }
                 ],
@@ -692482,7 +693014,7 @@
                         "modulestreams": [
                             null
                         ],
-                        "name": "openafs-1.6-sl-module-tools",
+                        "name": "openafs-1.6-sl-server",
                         "repository": "sl"
                     }
                 ],
@@ -692513,7 +693045,7 @@
                         "modulestreams": [
                             null
                         ],
-                        "name": "openafs-1.6-sl",
+                        "name": "openafs-1.6-sl-kpasswd",
                         "repository": "sl"
                     }
                 ],
@@ -692544,11 +693076,135 @@
                         "modulestreams": [
                             null
                         ],
-                        "name": "openafs-1.6-sl-plumbing-tools",
+                        "name": "openafs-1.6-sl-compat",
                         "repository": "sl"
                     }
                 ],
                 "set_id": 26218
+            },
+            "initial_release": {
+                "major_version": 7,
+                "minor_version": 7,
+                "os_name": "scientific"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 8,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "x86_64"
+            ],
+            "id": 19604,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "openafs-1.6-sl-kernel-source",
+                        "repository": "sl"
+                    }
+                ],
+                "set_id": 26219
+            },
+            "initial_release": {
+                "major_version": 7,
+                "minor_version": 7,
+                "os_name": "scientific"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 8,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "x86_64"
+            ],
+            "id": 19605,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "openafs-1.6-sl-module-tools",
+                        "repository": "sl"
+                    }
+                ],
+                "set_id": 26220
+            },
+            "initial_release": {
+                "major_version": 7,
+                "minor_version": 7,
+                "os_name": "scientific"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 8,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "x86_64"
+            ],
+            "id": 19606,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "openafs-1.6-sl",
+                        "repository": "sl"
+                    }
+                ],
+                "set_id": 26221
+            },
+            "initial_release": {
+                "major_version": 7,
+                "minor_version": 7,
+                "os_name": "scientific"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 8,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "x86_64"
+            ],
+            "id": 19607,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "openafs-1.6-sl-plumbing-tools",
+                        "repository": "sl"
+                    }
+                ],
+                "set_id": 26222
             },
             "initial_release": {
                 "major_version": 7,

--- a/files/almalinux-kitten/repomap.json.el10
+++ b/files/almalinux-kitten/repomap.json.el10
@@ -1,8 +1,8 @@
 {
-    "datetime": "202410111040Z",
-    "version_format": "1.2.1",
+    "datetime": "202506241030Z",
+    "version_format": "1.3.0",
     "provided_data_streams": [
-        "3.0"
+        "4.0"
     ],
     "mapping": [
         {
@@ -74,6 +74,7 @@
                     "repoid": "baseos",
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "arch": "x86_64",
                     "channel": "ga"
                 },
@@ -81,6 +82,7 @@
                     "repoid": "baseos",
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "arch": "aarch64",
                     "channel": "ga"
                 },
@@ -88,6 +90,7 @@
                     "repoid": "baseos",
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "arch": "ppc64le",
                     "channel": "ga"
                 },
@@ -95,6 +98,7 @@
                     "repoid": "baseos",
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "arch": "s390x",
                     "channel": "ga"
                 }
@@ -106,6 +110,7 @@
                 {
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "appstream",
                     "arch": "x86_64",
                     "channel": "ga"
@@ -113,6 +118,7 @@
                 {
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "appstream",
                     "arch": "aarch64",
                     "channel": "ga"
@@ -120,6 +126,7 @@
                 {
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "appstream",
                     "arch": "ppc64le",
                     "channel": "ga"
@@ -127,6 +134,7 @@
                 {
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "appstream",
                     "arch": "s390x",
                     "channel": "ga"
@@ -140,6 +148,7 @@
                     "major_version": "9",
                     "repoid": "crb",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "arch": "x86_64",
                     "channel": "ga"
                 },
@@ -147,6 +156,7 @@
                     "major_version": "9",
                     "repoid": "crb",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "arch": "aarch64",
                     "channel": "ga"
                 },
@@ -154,6 +164,7 @@
                     "major_version": "9",
                     "repoid": "crb",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "arch": "ppc64le",
                     "channel": "ga"
                 },
@@ -161,6 +172,7 @@
                     "major_version": "9",
                     "repoid": "crb",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "arch": "s390x",
                     "channel": "ga"
                 }
@@ -172,6 +184,7 @@
                 {
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "ha",
                     "arch": "x86_64",
                     "channel": "ga"
@@ -179,6 +192,7 @@
                 {
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "ha",
                     "arch": "aarch64",
                     "channel": "ga"
@@ -186,6 +200,7 @@
                 {
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "ha",
                     "arch": "ppc64le",
                     "channel": "ga"
@@ -193,6 +208,7 @@
                 {
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "ha",
                     "arch": "s390x",
                     "channel": "ga"
@@ -205,6 +221,7 @@
                 {
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "resilientstorage",
                     "arch": "x86_64",
                     "channel": "ga"
@@ -212,6 +229,7 @@
                 {
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "resilientstorage",
                     "arch": "aarch64",
                     "channel": "ga"
@@ -219,6 +237,7 @@
                 {
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "resilientstorage",
                     "arch": "ppc64le",
                     "channel": "ga"
@@ -226,6 +245,7 @@
                 {
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "resilientstorage",
                     "arch": "s390x",
                     "channel": "ga"
@@ -238,6 +258,7 @@
                 {
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "extras",
                     "arch": "x86_64",
                     "channel": "ga"
@@ -245,6 +266,7 @@
                 {
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "extras",
                     "arch": "aarch64",
                     "channel": "ga"
@@ -252,6 +274,7 @@
                 {
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "extras",
                     "arch": "ppc64le",
                     "channel": "ga"
@@ -259,6 +282,7 @@
                 {
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "extras",
                     "arch": "s390x",
                     "channel": "ga"
@@ -271,6 +295,7 @@
                 {
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "rt",
                     "arch": "x86_64",
                     "channel": "ga"
@@ -278,6 +303,7 @@
                 {
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "rt",
                     "arch": "aarch64",
                     "channel": "ga"
@@ -285,6 +311,7 @@
                 {
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "rt",
                     "arch": "ppc64le",
                     "channel": "ga"
@@ -292,6 +319,7 @@
                 {
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "rt",
                     "arch": "s390x",
                     "channel": "ga"
@@ -304,6 +332,7 @@
                 {
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "nfv",
                     "arch": "x86_64",
                     "channel": "ga"
@@ -311,6 +340,7 @@
                 {
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "nfv",
                     "arch": "aarch64",
                     "channel": "ga"
@@ -318,6 +348,7 @@
                 {
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "nfv",
                     "arch": "ppc64le",
                     "channel": "ga"
@@ -325,6 +356,7 @@
                 {
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "nfv",
                     "arch": "s390x",
                     "channel": "ga"
@@ -337,6 +369,7 @@
                 {
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "sap",
                     "arch": "x86_64",
                     "channel": "ga"
@@ -344,6 +377,7 @@
                 {
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "sap",
                     "arch": "aarch64",
                     "channel": "ga"
@@ -351,6 +385,7 @@
                 {
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "sap",
                     "arch": "ppc64le",
                     "channel": "ga"
@@ -358,6 +393,7 @@
                 {
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "sap",
                     "arch": "s390x",
                     "channel": "ga"
@@ -370,6 +406,7 @@
                 {
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "saphana",
                     "arch": "x86_64",
                     "channel": "ga"
@@ -377,6 +414,7 @@
                 {
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "saphana",
                     "arch": "aarch64",
                     "channel": "ga"
@@ -384,6 +422,7 @@
                 {
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "saphana",
                     "arch": "ppc64le",
                     "channel": "ga"
@@ -391,6 +430,7 @@
                 {
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "saphana",
                     "arch": "s390x",
                     "channel": "ga"
@@ -404,6 +444,7 @@
                     "repoid": "almalinux10-baseos",
                     "major_version": "10",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "arch": "x86_64",
                     "channel": "ga"
                 },
@@ -411,6 +452,7 @@
                     "repoid": "almalinux10-baseos",
                     "major_version": "10",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "arch": "aarch64",
                     "channel": "ga"
                 },
@@ -418,6 +460,7 @@
                     "repoid": "almalinux10-baseos",
                     "major_version": "10",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "arch": "ppc64le",
                     "channel": "ga"
                 },
@@ -425,6 +468,7 @@
                     "repoid": "almalinux10-baseos",
                     "major_version": "10",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "arch": "s390x",
                     "channel": "ga"
                 }
@@ -436,6 +480,7 @@
                 {
                     "major_version": "10",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "almalinux10-appstream",
                     "arch": "x86_64",
                     "channel": "ga"
@@ -443,6 +488,7 @@
                 {
                     "major_version": "10",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "almalinux10-appstream",
                     "arch": "aarch64",
                     "channel": "ga"
@@ -450,6 +496,7 @@
                 {
                     "major_version": "10",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "almalinux10-appstream",
                     "arch": "ppc64le",
                     "channel": "ga"
@@ -457,6 +504,7 @@
                 {
                     "major_version": "10",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "almalinux10-appstream",
                     "arch": "s390x",
                     "channel": "ga"
@@ -470,6 +518,7 @@
                     "major_version": "10",
                     "repoid": "almalinux10-crb",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "arch": "x86_64",
                     "channel": "ga"
                 },
@@ -477,6 +526,7 @@
                     "major_version": "10",
                     "repoid": "almalinux10-crb",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "arch": "aarch64",
                     "channel": "ga"
                 },
@@ -484,6 +534,7 @@
                     "major_version": "10",
                     "repoid": "almalinux10-crb",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "arch": "ppc64le",
                     "channel": "ga"
                 },
@@ -491,6 +542,7 @@
                     "major_version": "10",
                     "repoid": "almalinux10-crb",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "arch": "s390x",
                     "channel": "ga"
                 }
@@ -502,6 +554,7 @@
                 {
                     "major_version": "10",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "almalinux10-highavailability",
                     "arch": "x86_64",
                     "channel": "ga"
@@ -509,6 +562,7 @@
                 {
                     "major_version": "10",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "almalinux10-highavailability",
                     "arch": "aarch64",
                     "channel": "ga"
@@ -516,6 +570,7 @@
                 {
                     "major_version": "10",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "almalinux10-highavailability",
                     "arch": "ppc64le",
                     "channel": "ga"
@@ -523,6 +578,7 @@
                 {
                     "major_version": "10",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "almalinux10-highavailability",
                     "arch": "s390x",
                     "channel": "ga"
@@ -535,6 +591,7 @@
                 {
                     "major_version": "10",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "almalinux10-extras",
                     "arch": "x86_64",
                     "channel": "ga"
@@ -542,6 +599,7 @@
                 {
                     "major_version": "10",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "almalinux10-extras",
                     "arch": "aarch64",
                     "channel": "ga"
@@ -549,6 +607,7 @@
                 {
                     "major_version": "10",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "almalinux10-extras",
                     "arch": "ppc64le",
                     "channel": "ga"
@@ -556,6 +615,7 @@
                 {
                     "major_version": "10",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "almalinux10-extras",
                     "arch": "s390x",
                     "channel": "ga"
@@ -568,6 +628,7 @@
                 {
                     "major_version": "10",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "almalinux10-rt",
                     "arch": "x86_64",
                     "channel": "ga"
@@ -580,6 +641,7 @@
                 {
                     "major_version": "10",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "almalinux10-nfv",
                     "arch": "x86_64",
                     "channel": "ga"
@@ -592,6 +654,7 @@
                 {
                     "major_version": "10",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "almalinux10-sap",
                     "arch": "x86_64",
                     "channel": "ga"
@@ -599,6 +662,7 @@
                 {
                     "major_version": "10",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "almalinux10-sap",
                     "arch": "aarch64",
                     "channel": "ga"
@@ -606,6 +670,7 @@
                 {
                     "major_version": "10",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "almalinux10-sap",
                     "arch": "ppc64le",
                     "channel": "ga"
@@ -613,6 +678,7 @@
                 {
                     "major_version": "10",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "almalinux10-sap",
                     "arch": "s390x",
                     "channel": "ga"
@@ -625,6 +691,7 @@
                 {
                     "major_version": "10",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "almalinux10-saphana",
                     "arch": "x86_64",
                     "channel": "ga"
@@ -632,6 +699,7 @@
                 {
                     "major_version": "10",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "almalinux10-saphana",
                     "arch": "aarch64",
                     "channel": "ga"
@@ -639,6 +707,7 @@
                 {
                     "major_version": "10",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "almalinux10-saphana",
                     "arch": "ppc64le",
                     "channel": "ga"
@@ -646,6 +715,7 @@
                 {
                     "major_version": "10",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "almalinux10-saphana",
                     "arch": "s390x",
                     "channel": "ga"

--- a/files/almalinux/device_driver_deprecation_data.json
+++ b/files/almalinux/device_driver_deprecation_data.json
@@ -1,6 +1,6 @@
 {
   "provided_data_streams": [
-    "3.3"
+    "4.0"
   ],
   "data": [
     {

--- a/files/almalinux/pes-events.json
+++ b/files/almalinux/pes-events.json
@@ -1,7 +1,7 @@
 {
-    "timestamp": "202505091506Z",
+    "timestamp": "202505191506Z",
     "provided_data_streams": [
-        "3.3"
+        "4.0"
     ],
     "packageinfo": [
         {
@@ -147603,7 +147603,10 @@
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "httpcomponents-client-cache",
                         "repository": "almalinux8-powertools"
@@ -147611,7 +147614,11 @@
                 ],
                 "set_id": 6640
             },
-            "initial_release": null,
+            "initial_release": {
+                "major_version": 7,
+                "minor_version": 9,
+                "os_name": "CentOS"
+            },
             "modulestream_maps": [],
             "out_packageset": null,
             "release": {
@@ -147673,7 +147680,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -147699,14 +147705,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "httpcomponents-core-javadoc",
                         "repository": "almalinux8-powertools"
@@ -147723,7 +147735,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -147749,14 +147760,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "httpcomponents-project",
                         "repository": "almalinux8-powertools"
@@ -148080,9 +148097,7 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 4131,
@@ -148106,14 +148121,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "pki-deps",
+                        "stream": "10.6"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "pki-deps",
+                                "stream": "10.6"
+                            }
                         ],
                         "name": "jakarta-commons-httpclient",
                         "repository": "almalinux8-appstream"
@@ -148130,7 +148151,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -148156,14 +148176,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "pki-deps",
+                        "stream": "10.6"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "pki-deps",
+                                "stream": "10.6"
+                            }
                         ],
                         "name": "jakarta-commons-httpclient-demo",
                         "repository": "almalinux8-appstream"
@@ -148180,7 +148206,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -148206,14 +148231,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "pki-deps",
+                        "stream": "10.6"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "pki-deps",
+                                "stream": "10.6"
+                            }
                         ],
                         "name": "jakarta-commons-httpclient-javadoc",
                         "repository": "almalinux8-appstream"
@@ -148230,7 +148261,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -148256,14 +148286,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "pki-deps",
+                        "stream": "10.6"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "pki-deps",
+                                "stream": "10.6"
+                            }
                         ],
                         "name": "jakarta-commons-httpclient-manual",
                         "repository": "almalinux8-appstream"
@@ -148829,7 +148865,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -148855,14 +148890,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "javacc",
                         "repository": "almalinux8-powertools"
@@ -148879,7 +148920,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -148905,14 +148945,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "javacc-demo",
                         "repository": "almalinux8-powertools"
@@ -148929,7 +148975,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -148955,14 +149000,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "javacc-javadoc",
                         "repository": "almalinux8-powertools"
@@ -148979,7 +149030,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -149005,14 +149055,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "javacc-manual",
                         "repository": "almalinux8-powertools"
@@ -149029,7 +149085,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -149055,14 +149110,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "javacc-maven-plugin",
                         "repository": "almalinux8-powertools"
@@ -149244,7 +149305,6 @@
         {
             "action": 4,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -149270,28 +149330,40 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "ivy-local",
                         "repository": "almalinux8-powertools"
                     },
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "javapackages-filesystem",
                         "repository": "almalinux8-powertools"
                     },
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "javapackages-tools",
                         "repository": "almalinux8-powertools"
@@ -149308,7 +149380,6 @@
         {
             "action": 4,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -149334,21 +149405,30 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "javapackages-local",
                         "repository": "almalinux8-powertools"
                     },
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-local",
                         "repository": "almalinux8-powertools"
@@ -149530,9 +149610,7 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 4159,
@@ -149556,14 +149634,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "jaxen",
                         "repository": "almalinux8-powertools"
@@ -149580,7 +149664,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -149606,14 +149689,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "jaxen-demo",
                         "repository": "almalinux8-powertools"
@@ -150189,7 +150278,10 @@
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "jdom2",
                         "repository": "almalinux8-powertools"
@@ -150197,7 +150289,11 @@
                 ],
                 "set_id": 6737
             },
-            "initial_release": null,
+            "initial_release": {
+                "major_version": 7,
+                "minor_version": 9,
+                "os_name": "CentOS"
+            },
             "modulestream_maps": [],
             "out_packageset": null,
             "release": {
@@ -151861,7 +151957,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -151887,14 +151982,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "jflex",
                         "repository": "almalinux8-powertools"
@@ -151911,7 +152012,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -151937,14 +152037,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "jflex-javadoc",
                         "repository": "almalinux8-powertools"
@@ -152903,7 +153009,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -152929,14 +153034,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "junit-javadoc",
                         "repository": "almalinux8-powertools"
@@ -152953,7 +153064,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -152979,14 +153089,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "junit-manual",
                         "repository": "almalinux8-powertools"
@@ -153036,9 +153152,7 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 4250,
@@ -153062,14 +153176,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "jvnet-parent",
                         "repository": "almalinux8-powertools"
@@ -153086,7 +153206,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -153112,14 +153231,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "jzlib",
                         "repository": "almalinux8-powertools"
@@ -153136,7 +153261,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -153162,14 +153286,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "jzlib-demo",
                         "repository": "almalinux8-powertools"
@@ -153186,7 +153316,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -153212,14 +153341,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "jzlib-javadoc",
                         "repository": "almalinux8-powertools"
@@ -153501,7 +153636,6 @@
         {
             "action": 4,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -153527,21 +153661,30 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "maven",
+                        "stream": "3.5"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "maven",
+                                "stream": "3.5"
+                            }
                         ],
                         "name": "maven",
                         "repository": "almalinux8-appstream"
                     },
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "maven",
+                                "stream": "3.5"
+                            }
                         ],
                         "name": "maven-lib",
                         "repository": "almalinux8-appstream"
@@ -153558,7 +153701,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -153584,14 +153726,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-javadoc",
                         "repository": "almalinux8-powertools"
@@ -153608,7 +153756,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -153634,14 +153781,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-antrun-plugin",
                         "repository": "almalinux8-powertools"
@@ -153658,7 +153811,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -153684,14 +153836,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-antrun-plugin-javadoc",
                         "repository": "almalinux8-powertools"
@@ -153708,7 +153866,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -153734,14 +153891,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-archiver",
                         "repository": "almalinux8-powertools"
@@ -153758,7 +153921,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -153784,14 +153946,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-archiver-javadoc",
                         "repository": "almalinux8-powertools"
@@ -153808,7 +153976,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -153834,14 +154001,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-artifact-resolver",
                         "repository": "almalinux8-powertools"
@@ -153858,7 +154031,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -153884,14 +154056,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-artifact-resolver-javadoc",
                         "repository": "almalinux8-powertools"
@@ -153908,7 +154086,6 @@
         {
             "action": 3,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -153934,14 +154111,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-artifact-transfer",
                         "repository": "almalinux8-powertools"
@@ -153958,7 +154141,6 @@
         {
             "action": 3,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -153984,14 +154166,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-artifact-transfer-javadoc",
                         "repository": "almalinux8-powertools"
@@ -154008,7 +154196,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -154034,14 +154221,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-assembly-plugin",
                         "repository": "almalinux8-powertools"
@@ -154058,7 +154251,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -154084,14 +154276,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-assembly-plugin-javadoc",
                         "repository": "almalinux8-powertools"
@@ -154174,7 +154372,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -154200,14 +154397,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-clean-plugin",
                         "repository": "almalinux8-powertools"
@@ -154224,7 +154427,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -154250,14 +154452,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-clean-plugin-javadoc",
                         "repository": "almalinux8-powertools"
@@ -154274,7 +154482,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -154300,14 +154507,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-common-artifact-filters",
                         "repository": "almalinux8-powertools"
@@ -154324,7 +154537,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -154350,14 +154562,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-common-artifact-filters-javadoc",
                         "repository": "almalinux8-powertools"
@@ -154374,7 +154592,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -154400,14 +154617,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-compiler-plugin",
                         "repository": "almalinux8-powertools"
@@ -154424,7 +154647,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -154450,14 +154672,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-compiler-plugin-javadoc",
                         "repository": "almalinux8-powertools"
@@ -154474,7 +154702,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -154500,14 +154727,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-dependency-analyzer",
                         "repository": "almalinux8-powertools"
@@ -154524,7 +154757,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -154550,14 +154782,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-dependency-analyzer-javadoc",
                         "repository": "almalinux8-powertools"
@@ -154574,7 +154812,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -154600,14 +154837,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-dependency-plugin",
                         "repository": "almalinux8-powertools"
@@ -154624,7 +154867,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -154650,14 +154892,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-dependency-plugin-javadoc",
                         "repository": "almalinux8-powertools"
@@ -154674,7 +154922,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -154700,14 +154947,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-dependency-tree",
                         "repository": "almalinux8-powertools"
@@ -154724,7 +154977,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -154750,14 +155002,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-dependency-tree-javadoc",
                         "repository": "almalinux8-powertools"
@@ -154840,7 +155098,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -154866,14 +155123,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-doxia",
                         "repository": "almalinux8-powertools"
@@ -154890,7 +155153,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -154916,14 +155178,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-doxia-core",
                         "repository": "almalinux8-powertools"
@@ -154940,7 +155208,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -154966,14 +155233,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-doxia-javadoc",
                         "repository": "almalinux8-powertools"
@@ -154990,7 +155263,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -155016,14 +155288,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-doxia-logging-api",
                         "repository": "almalinux8-powertools"
@@ -155040,7 +155318,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -155066,14 +155343,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-doxia-module-apt",
                         "repository": "almalinux8-powertools"
@@ -155090,7 +155373,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -155116,14 +155398,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-doxia-module-confluence",
                         "repository": "almalinux8-powertools"
@@ -155140,7 +155428,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -155166,14 +155453,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-doxia-module-docbook-simple",
                         "repository": "almalinux8-powertools"
@@ -155190,7 +155483,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -155216,14 +155508,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-doxia-module-fml",
                         "repository": "almalinux8-powertools"
@@ -155240,7 +155538,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -155266,14 +155563,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-doxia-module-latex",
                         "repository": "almalinux8-powertools"
@@ -155290,7 +155593,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -155316,14 +155618,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-doxia-module-rtf",
                         "repository": "almalinux8-powertools"
@@ -155340,7 +155648,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -155366,14 +155673,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-doxia-module-twiki",
                         "repository": "almalinux8-powertools"
@@ -155390,7 +155703,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -155416,14 +155728,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-doxia-module-xdoc",
                         "repository": "almalinux8-powertools"
@@ -155440,7 +155758,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -155466,14 +155783,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-doxia-module-xhtml",
                         "repository": "almalinux8-powertools"
@@ -155490,7 +155813,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -155516,14 +155838,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-doxia-modules",
                         "repository": "almalinux8-powertools"
@@ -155540,7 +155868,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -155566,14 +155893,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-doxia-sink-api",
                         "repository": "almalinux8-powertools"
@@ -155590,7 +155923,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -155616,14 +155948,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-doxia-test-docs",
                         "repository": "almalinux8-powertools"
@@ -155640,7 +155978,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -155666,14 +156003,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-doxia-tests",
                         "repository": "almalinux8-powertools"
@@ -155723,7 +156066,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -155749,14 +156091,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-doxia-sitetools",
                         "repository": "almalinux8-powertools"
@@ -155773,7 +156121,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -155799,14 +156146,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-doxia-sitetools-javadoc",
                         "repository": "almalinux8-powertools"
@@ -155823,7 +156176,6 @@
         {
             "action": 3,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -155849,14 +156201,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-doxia-sitetools",
                         "repository": "almalinux8-powertools"
@@ -155873,7 +156231,6 @@
         {
             "action": 3,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -155899,14 +156256,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-doxia-sitetools-javadoc",
                         "repository": "almalinux8-powertools"
@@ -155923,7 +156286,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -155949,14 +156311,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-enforcer",
                         "repository": "almalinux8-powertools"
@@ -155973,7 +156341,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -155999,14 +156366,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-enforcer-api",
                         "repository": "almalinux8-powertools"
@@ -156023,7 +156396,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -156049,14 +156421,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-enforcer-javadoc",
                         "repository": "almalinux8-powertools"
@@ -156073,7 +156451,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -156099,14 +156476,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-enforcer-plugin",
                         "repository": "almalinux8-powertools"
@@ -156123,7 +156506,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -156149,14 +156531,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-enforcer-rules",
                         "repository": "almalinux8-powertools"
@@ -156173,7 +156561,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -156199,14 +156586,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-file-management",
                         "repository": "almalinux8-powertools"
@@ -156223,7 +156616,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -156249,14 +156641,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-file-management-javadoc",
                         "repository": "almalinux8-powertools"
@@ -156273,7 +156671,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -156299,14 +156696,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-filtering",
                         "repository": "almalinux8-powertools"
@@ -156323,7 +156726,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -156349,14 +156751,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-filtering-javadoc",
                         "repository": "almalinux8-powertools"
@@ -156439,7 +156847,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -156465,14 +156872,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-install-plugin",
                         "repository": "almalinux8-powertools"
@@ -156489,7 +156902,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -156515,14 +156927,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-install-plugin-javadoc",
                         "repository": "almalinux8-powertools"
@@ -156539,7 +156957,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -156565,14 +156982,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-invoker",
                         "repository": "almalinux8-powertools"
@@ -156589,7 +157012,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -156615,14 +157037,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-invoker-javadoc",
                         "repository": "almalinux8-powertools"
@@ -156639,7 +157067,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -156665,14 +157092,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-invoker-plugin",
                         "repository": "almalinux8-powertools"
@@ -156689,7 +157122,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -156715,14 +157147,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-invoker-plugin-javadoc",
                         "repository": "almalinux8-powertools"
@@ -156739,7 +157177,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -156765,14 +157202,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-jar-plugin",
                         "repository": "almalinux8-powertools"
@@ -156789,7 +157232,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -156815,14 +157257,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-jar-plugin-javadoc",
                         "repository": "almalinux8-powertools"
@@ -157136,7 +157584,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -157162,14 +157609,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-parent",
                         "repository": "almalinux8-powertools"
@@ -157186,7 +157639,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -157212,14 +157664,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-plugin-build-helper",
                         "repository": "almalinux8-powertools"
@@ -157236,7 +157694,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -157262,14 +157719,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-plugin-build-helper-javadoc",
                         "repository": "almalinux8-powertools"
@@ -157286,7 +157749,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -157312,14 +157774,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-plugin-bundle",
                         "repository": "almalinux8-powertools"
@@ -157336,7 +157804,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -157362,14 +157829,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-plugin-bundle-javadoc",
                         "repository": "almalinux8-powertools"
@@ -157386,7 +157859,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -157412,14 +157884,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-plugin-testing",
                         "repository": "almalinux8-powertools"
@@ -157436,7 +157914,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -157462,14 +157939,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-plugin-testing-harness",
                         "repository": "almalinux8-powertools"
@@ -157486,7 +157969,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -157512,14 +157994,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-plugin-testing-javadoc",
                         "repository": "almalinux8-powertools"
@@ -157536,7 +158024,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -157562,14 +158049,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-plugin-testing-tools",
                         "repository": "almalinux8-powertools"
@@ -157586,7 +158079,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -157612,14 +158104,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-test-tools",
                         "repository": "almalinux8-powertools"
@@ -158784,7 +159282,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -158810,14 +159307,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-reporting-api-javadoc",
                         "repository": "almalinux8-powertools"
@@ -159547,7 +160050,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -159573,14 +160075,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-shared-incremental-javadoc",
                         "repository": "almalinux8-powertools"
@@ -159597,7 +160105,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -159623,14 +160130,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-shared-io",
                         "repository": "almalinux8-powertools"
@@ -159647,7 +160160,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -159673,14 +160185,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-shared-io-javadoc",
                         "repository": "almalinux8-powertools"
@@ -159813,7 +160331,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -159839,14 +160356,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-shared-utils-javadoc",
                         "repository": "almalinux8-powertools"
@@ -690839,6 +691362,139 @@
             }
         },
         {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 19561,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "dyninst-testsuite",
+                        "repository": "almalinux10-crb"
+                    }
+                ],
+                "set_id": 26167
+            },
+            "initial_release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 1,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 19562,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "dyninst-testsuite",
+                        "repository": "almalinux9-crb"
+                    }
+                ],
+                "set_id": 26168
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 7,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 19563,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "dyninst-testsuite",
+                        "repository": "almalinux10-crb"
+                    }
+                ],
+                "set_id": 26169
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 7,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 19564,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "rpm-plugin-dbus-announce",
+                        "repository": "almalinux10-appstream"
+                    }
+                ],
+                "set_id": 26170
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 7,
+                "os_name": "AlmaLinux"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
             "action": 3,
             "architectures": [
                 "x86_64",
@@ -690846,7 +691502,7 @@
                 "ppc64le",
                 "s390x"
             ],
-            "id": 19561,
+            "id": 19565,
             "in_packageset": {
                 "package": [
                     {
@@ -690857,7 +691513,7 @@
                         "repository": "base"
                     }
                 ],
-                "set_id": 26168
+                "set_id": 26172
             },
             "initial_release": {
                 "major_version": 7,
@@ -690882,203 +691538,7 @@
                         "repository": "almalinux8-baseos"
                     }
                 ],
-                "set_id": 26167
-            },
-            "release": {
-                "major_version": 8,
-                "minor_version": 0,
-                "os_name": "AlmaLinux",
-                "tag": null,
-                "z_stream": null
-            }
-        },
-        {
-            "action": 1,
-            "architectures": [
-                "x86_64",
-                "aarch64",
-                "ppc64le",
-                "s390x"
-            ],
-            "id": 19562,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "libreport-rhel-bugzilla",
-                        "repository": "base"
-                    }
-                ],
-                "set_id": 26169
-            },
-            "initial_release": {
-                "major_version": 7,
-                "minor_version": 6,
-                "os_name": "CentOS"
-            },
-            "modulestream_maps": [],
-            "out_packageset": null,
-            "release": {
-                "major_version": 8,
-                "minor_version": 3,
-                "os_name": "AlmaLinux"
-            }
-        },
-        {
-            "action": 3,
-            "architectures": [
-                "x86_64",
-                "aarch64",
-                "ppc64le",
-                "s390x"
-            ],
-            "id": 19563,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "libssh2",
-                        "repository": "base"
-                    }
-                ],
                 "set_id": 26171
-            },
-            "initial_release": {
-                "major_version": 7,
-                "minor_version": 7,
-                "os_name": "CentOS",
-                "tag": null,
-                "z_stream": null
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "libssh",
-                        "repository": "almalinux8-baseos"
-                    }
-                ],
-                "set_id": 26170
-            },
-            "release": {
-                "major_version": 8,
-                "minor_version": 0,
-                "os_name": "AlmaLinux",
-                "tag": null,
-                "z_stream": null
-            }
-        },
-        {
-            "action": 3,
-            "architectures": [
-                "x86_64",
-                "aarch64",
-                "ppc64le",
-                "s390x"
-            ],
-            "id": 19564,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "libssh2-devel",
-                        "repository": "base"
-                    }
-                ],
-                "set_id": 26173
-            },
-            "initial_release": {
-                "major_version": 7,
-                "minor_version": 7,
-                "os_name": "CentOS",
-                "tag": null,
-                "z_stream": null
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "libssh-devel",
-                        "repository": "almalinux8-baseos"
-                    }
-                ],
-                "set_id": 26172
-            },
-            "release": {
-                "major_version": 8,
-                "minor_version": 0,
-                "os_name": "AlmaLinux",
-                "tag": null,
-                "z_stream": null
-            }
-        },
-        {
-            "action": 3,
-            "architectures": [
-                "x86_64",
-                "aarch64",
-                "ppc64le",
-                "s390x"
-            ],
-            "id": 19565,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "libssh2-docs",
-                        "repository": "base"
-                    }
-                ],
-                "set_id": 26175
-            },
-            "initial_release": {
-                "major_version": 7,
-                "minor_version": 7,
-                "os_name": "CentOS",
-                "tag": null,
-                "z_stream": null
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "libssh-docs",
-                        "repository": "almalinux8-baseos"
-                    }
-                ],
-                "set_id": 26174
             },
             "release": {
                 "major_version": 8,
@@ -691103,36 +691563,27 @@
                         "modulestreams": [
                             null
                         ],
-                        "name": "ustr",
-                        "repository": "powertools"
+                        "name": "libreport-rhel-bugzilla",
+                        "repository": "base"
                     }
                 ],
-                "set_id": 26176
+                "set_id": 26173
             },
             "initial_release": {
-                "major_version": 8,
-                "minor_version": 5,
-                "os_name": "AlmaLinux",
-                "tag": null,
-                "z_stream": null
+                "major_version": 7,
+                "minor_version": 6,
+                "os_name": "CentOS"
             },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
+            "modulestream_maps": [],
             "out_packageset": null,
             "release": {
-                "major_version": 9,
-                "minor_version": 0,
-                "os_name": "AlmaLinux",
-                "tag": null,
-                "z_stream": null
+                "major_version": 8,
+                "minor_version": 3,
+                "os_name": "AlmaLinux"
             }
         },
         {
-            "action": 1,
+            "action": 3,
             "architectures": [
                 "x86_64",
                 "aarch64",
@@ -691146,16 +691597,16 @@
                         "modulestreams": [
                             null
                         ],
-                        "name": "nautilus-sendto",
-                        "repository": "appstream"
+                        "name": "libssh2",
+                        "repository": "base"
                     }
                 ],
-                "set_id": 26177
+                "set_id": 26175
             },
             "initial_release": {
-                "major_version": 8,
-                "minor_version": 5,
-                "os_name": "AlmaLinux",
+                "major_version": 7,
+                "minor_version": 7,
+                "os_name": "CentOS",
                 "tag": null,
                 "z_stream": null
             },
@@ -691165,9 +691616,20 @@
                     "out_modulestream": null
                 }
             ],
-            "out_packageset": null,
+            "out_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "libssh",
+                        "repository": "almalinux8-baseos"
+                    }
+                ],
+                "set_id": 26174
+            },
             "release": {
-                "major_version": 9,
+                "major_version": 8,
                 "minor_version": 0,
                 "os_name": "AlmaLinux",
                 "tag": null,
@@ -691175,7 +691637,7 @@
             }
         },
         {
-            "action": 1,
+            "action": 3,
             "architectures": [
                 "x86_64",
                 "aarch64",
@@ -691189,16 +691651,16 @@
                         "modulestreams": [
                             null
                         ],
-                        "name": "libdmapsharing",
-                        "repository": "appstream"
+                        "name": "libssh2-devel",
+                        "repository": "base"
                     }
                 ],
-                "set_id": 26178
+                "set_id": 26177
             },
             "initial_release": {
-                "major_version": 8,
-                "minor_version": 5,
-                "os_name": "AlmaLinux",
+                "major_version": 7,
+                "minor_version": 7,
+                "os_name": "CentOS",
                 "tag": null,
                 "z_stream": null
             },
@@ -691208,9 +691670,20 @@
                     "out_modulestream": null
                 }
             ],
-            "out_packageset": null,
+            "out_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "libssh-devel",
+                        "repository": "almalinux8-baseos"
+                    }
+                ],
+                "set_id": 26176
+            },
             "release": {
-                "major_version": 9,
+                "major_version": 8,
                 "minor_version": 0,
                 "os_name": "AlmaLinux",
                 "tag": null,
@@ -691218,7 +691691,7 @@
             }
         },
         {
-            "action": 1,
+            "action": 3,
             "architectures": [
                 "x86_64",
                 "aarch64",
@@ -691232,16 +691705,16 @@
                         "modulestreams": [
                             null
                         ],
-                        "name": "iptstate",
-                        "repository": "baseos"
+                        "name": "libssh2-docs",
+                        "repository": "base"
                     }
                 ],
                 "set_id": 26179
             },
             "initial_release": {
-                "major_version": 8,
-                "minor_version": 5,
-                "os_name": "AlmaLinux",
+                "major_version": 7,
+                "minor_version": 7,
+                "os_name": "CentOS",
                 "tag": null,
                 "z_stream": null
             },
@@ -691251,9 +691724,20 @@
                     "out_modulestream": null
                 }
             ],
-            "out_packageset": null,
+            "out_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "libssh-docs",
+                        "repository": "almalinux8-baseos"
+                    }
+                ],
+                "set_id": 26178
+            },
             "release": {
-                "major_version": 9,
+                "major_version": 8,
                 "minor_version": 0,
                 "os_name": "AlmaLinux",
                 "tag": null,
@@ -691275,8 +691759,8 @@
                         "modulestreams": [
                             null
                         ],
-                        "name": "gupnp",
-                        "repository": "appstream"
+                        "name": "ustr",
+                        "repository": "powertools"
                     }
                 ],
                 "set_id": 26180
@@ -691318,7 +691802,7 @@
                         "modulestreams": [
                             null
                         ],
-                        "name": "libplist",
+                        "name": "nautilus-sendto",
                         "repository": "appstream"
                     }
                 ],
@@ -691361,8 +691845,8 @@
                         "modulestreams": [
                             null
                         ],
-                        "name": "jimtcl",
-                        "repository": "baseos"
+                        "name": "libdmapsharing",
+                        "repository": "appstream"
                     }
                 ],
                 "set_id": 26182
@@ -691404,7 +691888,7 @@
                         "modulestreams": [
                             null
                         ],
-                        "name": "libmodman",
+                        "name": "iptstate",
                         "repository": "baseos"
                     }
                 ],
@@ -691447,7 +691931,7 @@
                         "modulestreams": [
                             null
                         ],
-                        "name": "libimobiledevice",
+                        "name": "gupnp",
                         "repository": "appstream"
                     }
                 ],
@@ -691490,7 +691974,7 @@
                         "modulestreams": [
                             null
                         ],
-                        "name": "khmeros-fonts-common",
+                        "name": "libplist",
                         "repository": "appstream"
                     }
                 ],
@@ -691533,8 +692017,8 @@
                         "modulestreams": [
                             null
                         ],
-                        "name": "gupnp-dlna",
-                        "repository": "appstream"
+                        "name": "jimtcl",
+                        "repository": "baseos"
                     }
                 ],
                 "set_id": 26186
@@ -691576,8 +692060,8 @@
                         "modulestreams": [
                             null
                         ],
-                        "name": "gupnp-av",
-                        "repository": "appstream"
+                        "name": "libmodman",
+                        "repository": "baseos"
                     }
                 ],
                 "set_id": 26187
@@ -691619,7 +692103,7 @@
                         "modulestreams": [
                             null
                         ],
-                        "name": "lua-socket",
+                        "name": "libimobiledevice",
                         "repository": "appstream"
                     }
                 ],
@@ -691662,7 +692146,7 @@
                         "modulestreams": [
                             null
                         ],
-                        "name": "usbmuxd",
+                        "name": "khmeros-fonts-common",
                         "repository": "appstream"
                     }
                 ],
@@ -691705,7 +692189,7 @@
                         "modulestreams": [
                             null
                         ],
-                        "name": "gssdp",
+                        "name": "gupnp-dlna",
                         "repository": "appstream"
                     }
                 ],
@@ -691748,7 +692232,7 @@
                         "modulestreams": [
                             null
                         ],
-                        "name": "libusbmuxd",
+                        "name": "gupnp-av",
                         "repository": "appstream"
                     }
                 ],
@@ -691779,7 +692263,10 @@
         {
             "action": 1,
             "architectures": [
-                "x86_64"
+                "x86_64",
+                "aarch64",
+                "ppc64le",
+                "s390x"
             ],
             "id": 19582,
             "in_packageset": {
@@ -691788,29 +692275,41 @@
                         "modulestreams": [
                             null
                         ],
-                        "name": "sl-release-notes",
-                        "repository": "sl"
+                        "name": "lua-socket",
+                        "repository": "appstream"
                     }
                 ],
                 "set_id": 26192
             },
             "initial_release": {
-                "major_version": 7,
-                "minor_version": 7,
-                "os_name": "scientific"
+                "major_version": 8,
+                "minor_version": 5,
+                "os_name": "AlmaLinux",
+                "tag": null,
+                "z_stream": null
             },
-            "modulestream_maps": [],
+            "modulestream_maps": [
+                {
+                    "in_modulestream": null,
+                    "out_modulestream": null
+                }
+            ],
             "out_packageset": null,
             "release": {
-                "major_version": 8,
+                "major_version": 9,
                 "minor_version": 0,
-                "os_name": "AlmaLinux"
+                "os_name": "AlmaLinux",
+                "tag": null,
+                "z_stream": null
             }
         },
         {
             "action": 1,
             "architectures": [
-                "x86_64"
+                "x86_64",
+                "aarch64",
+                "ppc64le",
+                "s390x"
             ],
             "id": 19583,
             "in_packageset": {
@@ -691819,29 +692318,41 @@
                         "modulestreams": [
                             null
                         ],
-                        "name": "sl7-upgrade",
-                        "repository": "sl"
+                        "name": "usbmuxd",
+                        "repository": "appstream"
                     }
                 ],
                 "set_id": 26193
             },
             "initial_release": {
-                "major_version": 7,
-                "minor_version": 7,
-                "os_name": "scientific"
+                "major_version": 8,
+                "minor_version": 5,
+                "os_name": "AlmaLinux",
+                "tag": null,
+                "z_stream": null
             },
-            "modulestream_maps": [],
+            "modulestream_maps": [
+                {
+                    "in_modulestream": null,
+                    "out_modulestream": null
+                }
+            ],
             "out_packageset": null,
             "release": {
-                "major_version": 8,
+                "major_version": 9,
                 "minor_version": 0,
-                "os_name": "AlmaLinux"
+                "os_name": "AlmaLinux",
+                "tag": null,
+                "z_stream": null
             }
         },
         {
             "action": 1,
             "architectures": [
-                "x86_64"
+                "x86_64",
+                "aarch64",
+                "ppc64le",
+                "s390x"
             ],
             "id": 19584,
             "in_packageset": {
@@ -691850,29 +692361,41 @@
                         "modulestreams": [
                             null
                         ],
-                        "name": "yum-conf-extras",
-                        "repository": "repos"
+                        "name": "gssdp",
+                        "repository": "appstream"
                     }
                 ],
                 "set_id": 26194
             },
             "initial_release": {
-                "major_version": 7,
-                "minor_version": 7,
-                "os_name": "scientific"
+                "major_version": 8,
+                "minor_version": 5,
+                "os_name": "AlmaLinux",
+                "tag": null,
+                "z_stream": null
             },
-            "modulestream_maps": [],
+            "modulestream_maps": [
+                {
+                    "in_modulestream": null,
+                    "out_modulestream": null
+                }
+            ],
             "out_packageset": null,
             "release": {
-                "major_version": 8,
+                "major_version": 9,
                 "minor_version": 0,
-                "os_name": "AlmaLinux"
+                "os_name": "AlmaLinux",
+                "tag": null,
+                "z_stream": null
             }
         },
         {
             "action": 1,
             "architectures": [
-                "x86_64"
+                "x86_64",
+                "aarch64",
+                "ppc64le",
+                "s390x"
             ],
             "id": 19585,
             "in_packageset": {
@@ -691881,23 +692404,32 @@
                         "modulestreams": [
                             null
                         ],
-                        "name": "yum-conf-repos",
-                        "repository": "repos"
+                        "name": "libusbmuxd",
+                        "repository": "appstream"
                     }
                 ],
                 "set_id": 26195
             },
             "initial_release": {
-                "major_version": 7,
-                "minor_version": 7,
-                "os_name": "scientific"
+                "major_version": 8,
+                "minor_version": 5,
+                "os_name": "AlmaLinux",
+                "tag": null,
+                "z_stream": null
             },
-            "modulestream_maps": [],
+            "modulestream_maps": [
+                {
+                    "in_modulestream": null,
+                    "out_modulestream": null
+                }
+            ],
             "out_packageset": null,
             "release": {
-                "major_version": 8,
+                "major_version": 9,
                 "minor_version": 0,
-                "os_name": "AlmaLinux"
+                "os_name": "AlmaLinux",
+                "tag": null,
+                "z_stream": null
             }
         },
         {
@@ -691912,7 +692444,7 @@
                         "modulestreams": [
                             null
                         ],
-                        "name": "yum-conf-sl7x",
+                        "name": "sl-release-notes",
                         "repository": "sl"
                     }
                 ],
@@ -691943,11 +692475,135 @@
                         "modulestreams": [
                             null
                         ],
-                        "name": "sl-bookmarks",
+                        "name": "sl7-upgrade",
                         "repository": "sl"
                     }
                 ],
                 "set_id": 26197
+            },
+            "initial_release": {
+                "major_version": 7,
+                "minor_version": 7,
+                "os_name": "scientific"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 8,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "x86_64"
+            ],
+            "id": 19588,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "yum-conf-extras",
+                        "repository": "repos"
+                    }
+                ],
+                "set_id": 26198
+            },
+            "initial_release": {
+                "major_version": 7,
+                "minor_version": 7,
+                "os_name": "scientific"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 8,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "x86_64"
+            ],
+            "id": 19589,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "yum-conf-repos",
+                        "repository": "repos"
+                    }
+                ],
+                "set_id": 26199
+            },
+            "initial_release": {
+                "major_version": 7,
+                "minor_version": 7,
+                "os_name": "scientific"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 8,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "x86_64"
+            ],
+            "id": 19590,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "yum-conf-sl7x",
+                        "repository": "sl"
+                    }
+                ],
+                "set_id": 26200
+            },
+            "initial_release": {
+                "major_version": 7,
+                "minor_version": 7,
+                "os_name": "scientific"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 8,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "x86_64"
+            ],
+            "id": 19591,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "sl-bookmarks",
+                        "repository": "sl"
+                    }
+                ],
+                "set_id": 26201
             },
             "initial_release": {
                 "major_version": 7,
@@ -691968,7 +692624,7 @@
                 "x86_64",
                 "aarch64"
             ],
-            "id": 19588,
+            "id": 19592,
             "in_packageset": {
                 "package": [
                     {
@@ -691976,110 +692632,6 @@
                             null
                         ],
                         "name": "sl-indexhtml",
-                        "repository": "sl"
-                    }
-                ],
-                "set_id": 26199
-            },
-            "initial_release": {
-                "major_version": 7,
-                "minor_version": 7,
-                "os_name": "scientific",
-                "tag": null,
-                "z_stream": null
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "almalinux-indexhtml",
-                        "repository": "almalinux8-baseos"
-                    }
-                ],
-                "set_id": 26198
-            },
-            "release": {
-                "major_version": 8,
-                "minor_version": 0,
-                "os_name": "AlmaLinux",
-                "tag": null,
-                "z_stream": null
-            }
-        },
-        {
-            "action": 3,
-            "architectures": [
-                "x86_64",
-                "aarch64"
-            ],
-            "id": 19589,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "sl-logos",
-                        "repository": "sl"
-                    }
-                ],
-                "set_id": 26201
-            },
-            "initial_release": {
-                "major_version": 7,
-                "minor_version": 7,
-                "os_name": "scientific",
-                "tag": null,
-                "z_stream": null
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "almalinux-logos",
-                        "repository": "almalinux8-appstream"
-                    }
-                ],
-                "set_id": 26200
-            },
-            "release": {
-                "major_version": 8,
-                "minor_version": 0,
-                "os_name": "AlmaLinux",
-                "tag": null,
-                "z_stream": null
-            }
-        },
-        {
-            "action": 3,
-            "architectures": [
-                "x86_64",
-                "aarch64"
-            ],
-            "id": 19590,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "sl-release",
                         "repository": "sl"
                     }
                 ],
@@ -692104,7 +692656,7 @@
                         "modulestreams": [
                             null
                         ],
-                        "name": "almalinux-release",
+                        "name": "almalinux-indexhtml",
                         "repository": "almalinux8-baseos"
                     }
                 ],
@@ -692124,14 +692676,14 @@
                 "x86_64",
                 "aarch64"
             ],
-            "id": 19591,
+            "id": 19593,
             "in_packageset": {
                 "package": [
                     {
                         "modulestreams": [
                             null
                         ],
-                        "name": "libssh2",
+                        "name": "sl-logos",
                         "repository": "sl"
                     }
                 ],
@@ -692156,11 +692708,115 @@
                         "modulestreams": [
                             null
                         ],
+                        "name": "almalinux-logos",
+                        "repository": "almalinux8-appstream"
+                    }
+                ],
+                "set_id": 26204
+            },
+            "release": {
+                "major_version": 8,
+                "minor_version": 0,
+                "os_name": "AlmaLinux",
+                "tag": null,
+                "z_stream": null
+            }
+        },
+        {
+            "action": 3,
+            "architectures": [
+                "x86_64",
+                "aarch64"
+            ],
+            "id": 19594,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "sl-release",
+                        "repository": "sl"
+                    }
+                ],
+                "set_id": 26207
+            },
+            "initial_release": {
+                "major_version": 7,
+                "minor_version": 7,
+                "os_name": "scientific",
+                "tag": null,
+                "z_stream": null
+            },
+            "modulestream_maps": [
+                {
+                    "in_modulestream": null,
+                    "out_modulestream": null
+                }
+            ],
+            "out_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "almalinux-release",
+                        "repository": "almalinux8-baseos"
+                    }
+                ],
+                "set_id": 26206
+            },
+            "release": {
+                "major_version": 8,
+                "minor_version": 0,
+                "os_name": "AlmaLinux",
+                "tag": null,
+                "z_stream": null
+            }
+        },
+        {
+            "action": 3,
+            "architectures": [
+                "x86_64",
+                "aarch64"
+            ],
+            "id": 19595,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "libssh2",
+                        "repository": "sl"
+                    }
+                ],
+                "set_id": 26209
+            },
+            "initial_release": {
+                "major_version": 7,
+                "minor_version": 7,
+                "os_name": "scientific",
+                "tag": null,
+                "z_stream": null
+            },
+            "modulestream_maps": [
+                {
+                    "in_modulestream": null,
+                    "out_modulestream": null
+                }
+            ],
+            "out_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
                         "name": "libssh",
                         "repository": "almalinux8-baseos"
                     }
                 ],
-                "set_id": 26204
+                "set_id": 26208
             },
             "release": {
                 "major_version": 8,
@@ -692175,7 +692831,7 @@
             "architectures": [
                 "x86_64"
             ],
-            "id": 19592,
+            "id": 19596,
             "in_packageset": {
                 "package": [
                     {
@@ -692186,7 +692842,7 @@
                         "repository": "sl"
                     }
                 ],
-                "set_id": 26206
+                "set_id": 26210
             },
             "initial_release": {
                 "major_version": 7,
@@ -692207,7 +692863,7 @@
                 "x86_64",
                 "aarch64"
             ],
-            "id": 19593,
+            "id": 19597,
             "in_packageset": {
                 "package": [
                     {
@@ -692218,7 +692874,7 @@
                         "repository": "sl"
                     }
                 ],
-                "set_id": 26208
+                "set_id": 26212
             },
             "initial_release": {
                 "major_version": 7,
@@ -692243,7 +692899,7 @@
                         "repository": "almalinux8-baseos"
                     }
                 ],
-                "set_id": 26207
+                "set_id": 26211
             },
             "release": {
                 "major_version": 8,
@@ -692258,130 +692914,6 @@
             "architectures": [
                 "x86_64"
             ],
-            "id": 19594,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "openafs-1.6-sl-devel",
-                        "repository": "sl"
-                    }
-                ],
-                "set_id": 26209
-            },
-            "initial_release": {
-                "major_version": 7,
-                "minor_version": 7,
-                "os_name": "scientific"
-            },
-            "modulestream_maps": [],
-            "out_packageset": null,
-            "release": {
-                "major_version": 8,
-                "minor_version": 0,
-                "os_name": "AlmaLinux"
-            }
-        },
-        {
-            "action": 1,
-            "architectures": [
-                "x86_64"
-            ],
-            "id": 19595,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "openafs-1.6-sl-authlibs",
-                        "repository": "sl"
-                    }
-                ],
-                "set_id": 26210
-            },
-            "initial_release": {
-                "major_version": 7,
-                "minor_version": 7,
-                "os_name": "scientific"
-            },
-            "modulestream_maps": [],
-            "out_packageset": null,
-            "release": {
-                "major_version": 8,
-                "minor_version": 0,
-                "os_name": "AlmaLinux"
-            }
-        },
-        {
-            "action": 1,
-            "architectures": [
-                "x86_64"
-            ],
-            "id": 19596,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "openafs-1.6-sl-krb5",
-                        "repository": "sl"
-                    }
-                ],
-                "set_id": 26211
-            },
-            "initial_release": {
-                "major_version": 7,
-                "minor_version": 7,
-                "os_name": "scientific"
-            },
-            "modulestream_maps": [],
-            "out_packageset": null,
-            "release": {
-                "major_version": 8,
-                "minor_version": 0,
-                "os_name": "AlmaLinux"
-            }
-        },
-        {
-            "action": 1,
-            "architectures": [
-                "x86_64"
-            ],
-            "id": 19597,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "openafs-1.6-sl-server",
-                        "repository": "sl"
-                    }
-                ],
-                "set_id": 26212
-            },
-            "initial_release": {
-                "major_version": 7,
-                "minor_version": 7,
-                "os_name": "scientific"
-            },
-            "modulestream_maps": [],
-            "out_packageset": null,
-            "release": {
-                "major_version": 8,
-                "minor_version": 0,
-                "os_name": "AlmaLinux"
-            }
-        },
-        {
-            "action": 1,
-            "architectures": [
-                "x86_64"
-            ],
             "id": 19598,
             "in_packageset": {
                 "package": [
@@ -692389,7 +692921,7 @@
                         "modulestreams": [
                             null
                         ],
-                        "name": "openafs-1.6-sl-kpasswd",
+                        "name": "openafs-1.6-sl-devel",
                         "repository": "sl"
                     }
                 ],
@@ -692420,7 +692952,7 @@
                         "modulestreams": [
                             null
                         ],
-                        "name": "openafs-1.6-sl-compat",
+                        "name": "openafs-1.6-sl-authlibs",
                         "repository": "sl"
                     }
                 ],
@@ -692451,7 +692983,7 @@
                         "modulestreams": [
                             null
                         ],
-                        "name": "openafs-1.6-sl-kernel-source",
+                        "name": "openafs-1.6-sl-krb5",
                         "repository": "sl"
                     }
                 ],
@@ -692482,7 +693014,7 @@
                         "modulestreams": [
                             null
                         ],
-                        "name": "openafs-1.6-sl-module-tools",
+                        "name": "openafs-1.6-sl-server",
                         "repository": "sl"
                     }
                 ],
@@ -692513,7 +693045,7 @@
                         "modulestreams": [
                             null
                         ],
-                        "name": "openafs-1.6-sl",
+                        "name": "openafs-1.6-sl-kpasswd",
                         "repository": "sl"
                     }
                 ],
@@ -692544,11 +693076,135 @@
                         "modulestreams": [
                             null
                         ],
-                        "name": "openafs-1.6-sl-plumbing-tools",
+                        "name": "openafs-1.6-sl-compat",
                         "repository": "sl"
                     }
                 ],
                 "set_id": 26218
+            },
+            "initial_release": {
+                "major_version": 7,
+                "minor_version": 7,
+                "os_name": "scientific"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 8,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "x86_64"
+            ],
+            "id": 19604,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "openafs-1.6-sl-kernel-source",
+                        "repository": "sl"
+                    }
+                ],
+                "set_id": 26219
+            },
+            "initial_release": {
+                "major_version": 7,
+                "minor_version": 7,
+                "os_name": "scientific"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 8,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "x86_64"
+            ],
+            "id": 19605,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "openafs-1.6-sl-module-tools",
+                        "repository": "sl"
+                    }
+                ],
+                "set_id": 26220
+            },
+            "initial_release": {
+                "major_version": 7,
+                "minor_version": 7,
+                "os_name": "scientific"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 8,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "x86_64"
+            ],
+            "id": 19606,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "openafs-1.6-sl",
+                        "repository": "sl"
+                    }
+                ],
+                "set_id": 26221
+            },
+            "initial_release": {
+                "major_version": 7,
+                "minor_version": 7,
+                "os_name": "scientific"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 8,
+                "minor_version": 0,
+                "os_name": "AlmaLinux"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "x86_64"
+            ],
+            "id": 19607,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "openafs-1.6-sl-plumbing-tools",
+                        "repository": "sl"
+                    }
+                ],
+                "set_id": 26222
             },
             "initial_release": {
                 "major_version": 7,
@@ -692571,7 +693227,7 @@
                 "s390x",
                 "x86_64"
             ],
-            "id": 19604,
+            "id": 19608,
             "in_packageset": {
                 "package": [
                     {
@@ -692589,7 +693245,7 @@
                         "repository": "appstream"
                     }
                 ],
-                "set_id": 26220
+                "set_id": 26224
             },
             "initial_release": {
                 "major_version": 8,
@@ -692612,7 +693268,7 @@
                         "repository": "almalinux9-appstream"
                     }
                 ],
-                "set_id": 26219
+                "set_id": 26223
             },
             "release": {
                 "major_version": 9,

--- a/files/almalinux/repomap.json.el10
+++ b/files/almalinux/repomap.json.el10
@@ -1,8 +1,8 @@
 {
-    "datetime": "202410111040Z",
-    "version_format": "1.2.1",
+    "datetime": "202506241030Z",
+    "version_format": "1.3.0",
     "provided_data_streams": [
-        "3.0"
+        "4.0"
     ],
     "mapping": [
         {
@@ -74,6 +74,7 @@
                     "repoid": "baseos",
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "arch": "x86_64",
                     "channel": "ga"
                 },
@@ -81,6 +82,7 @@
                     "repoid": "baseos",
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "arch": "aarch64",
                     "channel": "ga"
                 },
@@ -88,6 +90,7 @@
                     "repoid": "baseos",
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "arch": "ppc64le",
                     "channel": "ga"
                 },
@@ -95,6 +98,7 @@
                     "repoid": "baseos",
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "arch": "s390x",
                     "channel": "ga"
                 }
@@ -106,6 +110,7 @@
                 {
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "appstream",
                     "arch": "x86_64",
                     "channel": "ga"
@@ -113,6 +118,7 @@
                 {
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "appstream",
                     "arch": "aarch64",
                     "channel": "ga"
@@ -120,6 +126,7 @@
                 {
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "appstream",
                     "arch": "ppc64le",
                     "channel": "ga"
@@ -127,6 +134,7 @@
                 {
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "appstream",
                     "arch": "s390x",
                     "channel": "ga"
@@ -140,6 +148,7 @@
                     "major_version": "9",
                     "repoid": "crb",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "arch": "x86_64",
                     "channel": "ga"
                 },
@@ -147,6 +156,7 @@
                     "major_version": "9",
                     "repoid": "crb",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "arch": "aarch64",
                     "channel": "ga"
                 },
@@ -154,6 +164,7 @@
                     "major_version": "9",
                     "repoid": "crb",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "arch": "ppc64le",
                     "channel": "ga"
                 },
@@ -161,6 +172,7 @@
                     "major_version": "9",
                     "repoid": "crb",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "arch": "s390x",
                     "channel": "ga"
                 }
@@ -172,6 +184,7 @@
                 {
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "ha",
                     "arch": "x86_64",
                     "channel": "ga"
@@ -179,6 +192,7 @@
                 {
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "ha",
                     "arch": "aarch64",
                     "channel": "ga"
@@ -186,6 +200,7 @@
                 {
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "ha",
                     "arch": "ppc64le",
                     "channel": "ga"
@@ -193,6 +208,7 @@
                 {
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "ha",
                     "arch": "s390x",
                     "channel": "ga"
@@ -205,6 +221,7 @@
                 {
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "resilientstorage",
                     "arch": "x86_64",
                     "channel": "ga"
@@ -212,6 +229,7 @@
                 {
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "resilientstorage",
                     "arch": "aarch64",
                     "channel": "ga"
@@ -219,6 +237,7 @@
                 {
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "resilientstorage",
                     "arch": "ppc64le",
                     "channel": "ga"
@@ -226,6 +245,7 @@
                 {
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "resilientstorage",
                     "arch": "s390x",
                     "channel": "ga"
@@ -238,6 +258,7 @@
                 {
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "extras",
                     "arch": "x86_64",
                     "channel": "ga"
@@ -245,6 +266,7 @@
                 {
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "extras",
                     "arch": "aarch64",
                     "channel": "ga"
@@ -252,6 +274,7 @@
                 {
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "extras",
                     "arch": "ppc64le",
                     "channel": "ga"
@@ -259,6 +282,7 @@
                 {
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "extras",
                     "arch": "s390x",
                     "channel": "ga"
@@ -271,6 +295,7 @@
                 {
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "rt",
                     "arch": "x86_64",
                     "channel": "ga"
@@ -278,6 +303,7 @@
                 {
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "rt",
                     "arch": "aarch64",
                     "channel": "ga"
@@ -285,6 +311,7 @@
                 {
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "rt",
                     "arch": "ppc64le",
                     "channel": "ga"
@@ -292,6 +319,7 @@
                 {
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "rt",
                     "arch": "s390x",
                     "channel": "ga"
@@ -304,6 +332,7 @@
                 {
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "nfv",
                     "arch": "x86_64",
                     "channel": "ga"
@@ -311,6 +340,7 @@
                 {
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "nfv",
                     "arch": "aarch64",
                     "channel": "ga"
@@ -318,6 +348,7 @@
                 {
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "nfv",
                     "arch": "ppc64le",
                     "channel": "ga"
@@ -325,6 +356,7 @@
                 {
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "nfv",
                     "arch": "s390x",
                     "channel": "ga"
@@ -337,6 +369,7 @@
                 {
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "sap",
                     "arch": "x86_64",
                     "channel": "ga"
@@ -344,6 +377,7 @@
                 {
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "sap",
                     "arch": "aarch64",
                     "channel": "ga"
@@ -351,6 +385,7 @@
                 {
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "sap",
                     "arch": "ppc64le",
                     "channel": "ga"
@@ -358,6 +393,7 @@
                 {
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "sap",
                     "arch": "s390x",
                     "channel": "ga"
@@ -370,6 +406,7 @@
                 {
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "saphana",
                     "arch": "x86_64",
                     "channel": "ga"
@@ -377,6 +414,7 @@
                 {
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "saphana",
                     "arch": "aarch64",
                     "channel": "ga"
@@ -384,6 +422,7 @@
                 {
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "saphana",
                     "arch": "ppc64le",
                     "channel": "ga"
@@ -391,6 +430,7 @@
                 {
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "saphana",
                     "arch": "s390x",
                     "channel": "ga"
@@ -404,6 +444,7 @@
                     "repoid": "almalinux10-baseos",
                     "major_version": "10",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "arch": "x86_64",
                     "channel": "ga"
                 },
@@ -411,6 +452,7 @@
                     "repoid": "almalinux10-baseos",
                     "major_version": "10",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "arch": "aarch64",
                     "channel": "ga"
                 },
@@ -418,6 +460,7 @@
                     "repoid": "almalinux10-baseos",
                     "major_version": "10",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "arch": "ppc64le",
                     "channel": "ga"
                 },
@@ -425,6 +468,7 @@
                     "repoid": "almalinux10-baseos",
                     "major_version": "10",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "arch": "s390x",
                     "channel": "ga"
                 }
@@ -436,6 +480,7 @@
                 {
                     "major_version": "10",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "almalinux10-appstream",
                     "arch": "x86_64",
                     "channel": "ga"
@@ -443,6 +488,7 @@
                 {
                     "major_version": "10",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "almalinux10-appstream",
                     "arch": "aarch64",
                     "channel": "ga"
@@ -450,6 +496,7 @@
                 {
                     "major_version": "10",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "almalinux10-appstream",
                     "arch": "ppc64le",
                     "channel": "ga"
@@ -457,6 +504,7 @@
                 {
                     "major_version": "10",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "almalinux10-appstream",
                     "arch": "s390x",
                     "channel": "ga"
@@ -470,6 +518,7 @@
                     "major_version": "10",
                     "repoid": "almalinux10-crb",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "arch": "x86_64",
                     "channel": "ga"
                 },
@@ -477,6 +526,7 @@
                     "major_version": "10",
                     "repoid": "almalinux10-crb",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "arch": "aarch64",
                     "channel": "ga"
                 },
@@ -484,6 +534,7 @@
                     "major_version": "10",
                     "repoid": "almalinux10-crb",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "arch": "ppc64le",
                     "channel": "ga"
                 },
@@ -491,6 +542,7 @@
                     "major_version": "10",
                     "repoid": "almalinux10-crb",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "arch": "s390x",
                     "channel": "ga"
                 }
@@ -502,6 +554,7 @@
                 {
                     "major_version": "10",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "almalinux10-highavailability",
                     "arch": "x86_64",
                     "channel": "ga"
@@ -509,6 +562,7 @@
                 {
                     "major_version": "10",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "almalinux10-highavailability",
                     "arch": "aarch64",
                     "channel": "ga"
@@ -516,6 +570,7 @@
                 {
                     "major_version": "10",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "almalinux10-highavailability",
                     "arch": "ppc64le",
                     "channel": "ga"
@@ -523,6 +578,7 @@
                 {
                     "major_version": "10",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "almalinux10-highavailability",
                     "arch": "s390x",
                     "channel": "ga"
@@ -535,6 +591,7 @@
                 {
                     "major_version": "10",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "almalinux10-extras",
                     "arch": "x86_64",
                     "channel": "ga"
@@ -542,6 +599,7 @@
                 {
                     "major_version": "10",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "almalinux10-extras",
                     "arch": "aarch64",
                     "channel": "ga"
@@ -549,6 +607,7 @@
                 {
                     "major_version": "10",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "almalinux10-extras",
                     "arch": "ppc64le",
                     "channel": "ga"
@@ -556,6 +615,7 @@
                 {
                     "major_version": "10",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "almalinux10-extras",
                     "arch": "s390x",
                     "channel": "ga"
@@ -568,6 +628,7 @@
                 {
                     "major_version": "10",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "almalinux10-rt",
                     "arch": "x86_64",
                     "channel": "ga"
@@ -580,6 +641,7 @@
                 {
                     "major_version": "10",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "almalinux10-nfv",
                     "arch": "x86_64",
                     "channel": "ga"
@@ -592,6 +654,7 @@
                 {
                     "major_version": "10",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "almalinux10-sap",
                     "arch": "x86_64",
                     "channel": "ga"
@@ -599,6 +662,7 @@
                 {
                     "major_version": "10",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "almalinux10-sap",
                     "arch": "aarch64",
                     "channel": "ga"
@@ -606,6 +670,7 @@
                 {
                     "major_version": "10",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "almalinux10-sap",
                     "arch": "ppc64le",
                     "channel": "ga"
@@ -613,6 +678,7 @@
                 {
                     "major_version": "10",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "almalinux10-sap",
                     "arch": "s390x",
                     "channel": "ga"
@@ -625,6 +691,7 @@
                 {
                     "major_version": "10",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "almalinux10-saphana",
                     "arch": "x86_64",
                     "channel": "ga"
@@ -632,6 +699,7 @@
                 {
                     "major_version": "10",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "almalinux10-saphana",
                     "arch": "aarch64",
                     "channel": "ga"
@@ -639,6 +707,7 @@
                 {
                     "major_version": "10",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "almalinux10-saphana",
                     "arch": "ppc64le",
                     "channel": "ga"
@@ -646,6 +715,7 @@
                 {
                     "major_version": "10",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "almalinux10-saphana",
                     "arch": "s390x",
                     "channel": "ga"

--- a/files/almalinux/repomap.json.el8
+++ b/files/almalinux/repomap.json.el8
@@ -1,8 +1,8 @@
 {
-    "datetime": "202410111040Z",
-    "version_format": "1.2.1",
+    "datetime": "202506241030Z",
+    "version_format": "1.3.0",
     "provided_data_streams": [
-        "3.0"
+        "4.0"
     ],
     "mapping": [
         {
@@ -191,6 +191,7 @@
                 {
                     "major_version": "7",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "base",
                     "arch": "x86_64",
                     "channel": "ga"
@@ -198,6 +199,7 @@
                 {
                     "major_version": "7",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "base",
                     "arch": "aarch64",
                     "channel": "ga"
@@ -205,6 +207,7 @@
                 {
                     "major_version": "7",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "base",
                     "arch": "ppc64le",
                     "channel": "ga"
@@ -218,6 +221,7 @@
                     "repoid": "almalinux8-baseos",
                     "major_version": "8",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "arch": "x86_64",
                     "channel": "ga"
                 },
@@ -225,6 +229,7 @@
                     "repoid": "almalinux8-baseos",
                     "major_version": "8",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "arch": "aarch64",
                     "channel": "ga"
                 },
@@ -232,6 +237,7 @@
                     "repoid": "almalinux8-baseos",
                     "major_version": "8",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "arch": "ppc64le",
                     "channel": "ga"
                 }
@@ -243,6 +249,7 @@
                 {
                     "major_version": "8",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "almalinux8-appstream",
                     "arch": "x86_64",
                     "channel": "ga"
@@ -250,6 +257,7 @@
                 {
                     "major_version": "8",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "almalinux8-appstream",
                     "arch": "aarch64",
                     "channel": "ga"
@@ -257,6 +265,7 @@
                 {
                     "major_version": "8",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "almalinux8-appstream",
                     "arch": "ppc64le",
                     "channel": "ga"
@@ -270,6 +279,7 @@
                     "major_version": "8",
                     "repoid": "almalinux8-powertools",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "arch": "x86_64",
                     "channel": "ga"
                 },
@@ -277,6 +287,7 @@
                     "major_version": "8",
                     "repoid": "almalinux8-powertools",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "arch": "aarch64",
                     "channel": "ga"
                 },
@@ -284,6 +295,7 @@
                     "major_version": "8",
                     "repoid": "almalinux8-powertools",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "arch": "ppc64le",
                     "channel": "ga"
                 }
@@ -295,6 +307,7 @@
                 {
                     "major_version": "8",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "almalinux8-ha",
                     "arch": "x86_64",
                     "channel": "ga"
@@ -302,6 +315,7 @@
                 {
                     "major_version": "8",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "almalinux8-ha",
                     "arch": "aarch64",
                     "channel": "ga"
@@ -309,6 +323,7 @@
                 {
                     "major_version": "8",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "almalinux8-ha",
                     "arch": "ppc64le",
                     "channel": "ga"
@@ -321,6 +336,7 @@
                 {
                     "major_version": "8",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "almalinux8-resilientstorage",
                     "arch": "x86_64",
                     "channel": "ga"
@@ -328,6 +344,7 @@
                 {
                     "major_version": "8",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "almalinux8-resilientstorage",
                     "arch": "aarch64",
                     "channel": "ga"
@@ -335,6 +352,7 @@
                 {
                     "major_version": "8",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "almalinux8-resilientstorage",
                     "arch": "ppc64le",
                     "channel": "ga"
@@ -347,6 +365,7 @@
                 {
                     "major_version": "7",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "updates",
                     "arch": "x86_64",
                     "channel": "ga"
@@ -354,6 +373,7 @@
                 {
                     "major_version": "7",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "updates",
                     "arch": "aarch64",
                     "channel": "ga"
@@ -361,6 +381,7 @@
                 {
                     "major_version": "7",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "updates",
                     "arch": "ppc64le",
                     "channel": "ga"
@@ -373,6 +394,7 @@
                 {
                     "major_version": "7",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "extras",
                     "arch": "x86_64",
                     "channel": "ga"
@@ -380,6 +402,7 @@
                 {
                     "major_version": "7",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "extras",
                     "arch": "aarch64",
                     "channel": "ga"
@@ -387,6 +410,7 @@
                 {
                     "major_version": "7",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "extras",
                     "arch": "ppc64le",
                     "channel": "ga"
@@ -399,6 +423,7 @@
                 {
                     "major_version": "8",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "almalinux8-extras",
                     "arch": "x86_64",
                     "channel": "ga"
@@ -406,6 +431,7 @@
                 {
                     "major_version": "8",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "almalinux8-extras",
                     "arch": "aarch64",
                     "channel": "ga"
@@ -413,6 +439,7 @@
                 {
                     "major_version": "8",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "almalinux8-extras",
                     "arch": "ppc64le",
                     "channel": "ga"
@@ -425,6 +452,7 @@
                 {
                     "major_version": "8",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "almalinux8-nfv",
                     "arch": "x86_64",
                     "channel": "ga"
@@ -437,6 +465,7 @@
                 {
                     "major_version": "8",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "almalinux8-sap",
                     "arch": "x86_64",
                     "channel": "ga"
@@ -444,6 +473,7 @@
                 {
                     "major_version": "8",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "almalinux8-sap",
                     "arch": "aarch64",
                     "channel": "ga"
@@ -451,6 +481,7 @@
                 {
                     "major_version": "8",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "almalinux8-sap",
                     "arch": "ppc64le",
                     "channel": "ga"
@@ -463,6 +494,7 @@
                 {
                     "major_version": "8",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "almalinux8-saphana",
                     "arch": "x86_64",
                     "channel": "ga"
@@ -470,6 +502,7 @@
                 {
                     "major_version": "8",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "almalinux8-saphana",
                     "arch": "aarch64",
                     "channel": "ga"
@@ -477,6 +510,7 @@
                 {
                     "major_version": "8",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "almalinux8-saphana",
                     "arch": "ppc64le",
                     "channel": "ga"
@@ -489,6 +523,7 @@
                 {
                     "major_version": "7",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "centos7-els",
                     "arch": "x86_64",
                     "channel": "ga"
@@ -501,6 +536,7 @@
                 {
                     "major_version": "7",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "centos7-els-testing",
                     "arch": "x86_64",
                     "channel": "ga"
@@ -513,6 +549,7 @@
                 {
                     "major_version": "7",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "centos7els-rollout-1",
                     "arch": "x86_64",
                     "channel": "ga"
@@ -525,6 +562,7 @@
                 {
                     "major_version": "7",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "centos7els-rollout-1-bypass",
                     "arch": "x86_64",
                     "channel": "ga"
@@ -537,6 +575,7 @@
                 {
                     "major_version": "7",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "centos7els-rollout-2",
                     "arch": "x86_64",
                     "channel": "ga"
@@ -549,6 +588,7 @@
                 {
                     "major_version": "7",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "centos7els-rollout-2-bypass",
                     "arch": "x86_64",
                     "channel": "ga"
@@ -561,6 +601,7 @@
                 {
                     "major_version": "7",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "centos7els-rollout-3",
                     "arch": "x86_64",
                     "channel": "ga"
@@ -573,6 +614,7 @@
                 {
                     "major_version": "7",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "centos7els-rollout-3-bypass",
                     "arch": "x86_64",
                     "channel": "ga"
@@ -585,6 +627,7 @@
                 {
                     "major_version": "7",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "centos7els-rollout-4",
                     "arch": "x86_64",
                     "channel": "ga"
@@ -597,6 +640,7 @@
                 {
                     "major_version": "7",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "centos7els-rollout-4-bypass",
                     "arch": "x86_64",
                     "channel": "ga"
@@ -609,6 +653,7 @@
                 {
                     "major_version": "7",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "centos7els-rollout-5",
                     "arch": "x86_64",
                     "channel": "ga"
@@ -621,6 +666,7 @@
                 {
                     "major_version": "7",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "centos7els-rollout-5-bypass",
                     "arch": "x86_64",
                     "channel": "ga"
@@ -633,6 +679,7 @@
                 {
                     "major_version": "7",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "centos7els-rollout-6",
                     "arch": "x86_64",
                     "channel": "ga"
@@ -645,11 +692,12 @@
                 {
                     "major_version": "7",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "centos7els-rollout-6-bypass",
                     "arch": "x86_64",
                     "channel": "ga"
                 }
             ]
-        }        
+        }
     ]
 }

--- a/files/almalinux/repomap.json.el9
+++ b/files/almalinux/repomap.json.el9
@@ -1,8 +1,8 @@
 {
-    "datetime": "202410111040Z",
-    "version_format": "1.2.1",
+    "datetime": "202506241030Z",
+    "version_format": "1.3.0",
     "provided_data_streams": [
-        "3.0"
+        "4.0"
     ],
     "mapping": [
         {
@@ -80,6 +80,7 @@
                     "repoid": "baseos",
                     "major_version": "8",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "arch": "x86_64",
                     "channel": "ga"
                 },
@@ -87,6 +88,7 @@
                     "repoid": "baseos",
                     "major_version": "8",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "arch": "aarch64",
                     "channel": "ga"
                 },
@@ -94,6 +96,7 @@
                     "repoid": "baseos",
                     "major_version": "8",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "arch": "ppc64le",
                     "channel": "ga"
                 },
@@ -101,6 +104,7 @@
                     "repoid": "baseos",
                     "major_version": "8",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "arch": "s390x",
                     "channel": "ga"
                 }
@@ -112,6 +116,7 @@
                 {
                     "major_version": "8",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "appstream",
                     "arch": "x86_64",
                     "channel": "ga"
@@ -119,6 +124,7 @@
                 {
                     "major_version": "8",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "appstream",
                     "arch": "aarch64",
                     "channel": "ga"
@@ -126,6 +132,7 @@
                 {
                     "major_version": "8",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "appstream",
                     "arch": "ppc64le",
                     "channel": "ga"
@@ -133,6 +140,7 @@
                 {
                     "major_version": "8",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "appstream",
                     "arch": "s390x",
                     "channel": "ga"
@@ -146,6 +154,7 @@
                     "major_version": "8",
                     "repoid": "powertools",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "arch": "x86_64",
                     "channel": "ga"
                 },
@@ -153,6 +162,7 @@
                     "major_version": "8",
                     "repoid": "powertools",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "arch": "aarch64",
                     "channel": "ga"
                 },
@@ -160,6 +170,7 @@
                     "major_version": "8",
                     "repoid": "powertools",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "arch": "ppc64le",
                     "channel": "ga"
                 },
@@ -167,6 +178,7 @@
                     "major_version": "8",
                     "repoid": "powertools",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "arch": "s390x",
                     "channel": "ga"
                 }
@@ -178,6 +190,7 @@
                 {
                     "major_version": "8",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "ha",
                     "arch": "x86_64",
                     "channel": "ga"
@@ -185,6 +198,7 @@
                 {
                     "major_version": "8",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "ha",
                     "arch": "aarch64",
                     "channel": "ga"
@@ -192,6 +206,7 @@
                 {
                     "major_version": "8",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "ha",
                     "arch": "ppc64le",
                     "channel": "ga"
@@ -199,6 +214,7 @@
                 {
                     "major_version": "8",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "ha",
                     "arch": "s390x",
                     "channel": "ga"
@@ -211,6 +227,7 @@
                 {
                     "major_version": "8",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "resilientstorage",
                     "arch": "x86_64",
                     "channel": "ga"
@@ -218,6 +235,7 @@
                 {
                     "major_version": "8",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "resilientstorage",
                     "arch": "aarch64",
                     "channel": "ga"
@@ -225,6 +243,7 @@
                 {
                     "major_version": "8",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "resilientstorage",
                     "arch": "ppc64le",
                     "channel": "ga"
@@ -232,6 +251,7 @@
                 {
                     "major_version": "8",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "resilientstorage",
                     "arch": "s390x",
                     "channel": "ga"
@@ -244,6 +264,7 @@
                 {
                     "major_version": "8",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "extras",
                     "arch": "x86_64",
                     "channel": "ga"
@@ -251,6 +272,7 @@
                 {
                     "major_version": "8",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "extras",
                     "arch": "aarch64",
                     "channel": "ga"
@@ -258,6 +280,7 @@
                 {
                     "major_version": "8",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "extras",
                     "arch": "ppc64le",
                     "channel": "ga"
@@ -265,6 +288,7 @@
                 {
                     "major_version": "8",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "extras",
                     "arch": "s390x",
                     "channel": "ga"
@@ -277,6 +301,7 @@
                 {
                     "major_version": "8",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "rt",
                     "arch": "x86_64",
                     "channel": "ga"
@@ -284,6 +309,7 @@
                 {
                     "major_version": "8",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "rt",
                     "arch": "aarch64",
                     "channel": "ga"
@@ -291,6 +317,7 @@
                 {
                     "major_version": "8",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "rt",
                     "arch": "ppc64le",
                     "channel": "ga"
@@ -298,6 +325,7 @@
                 {
                     "major_version": "8",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "rt",
                     "arch": "s390x",
                     "channel": "ga"
@@ -310,6 +338,7 @@
                 {
                     "major_version": "8",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "nfv",
                     "arch": "x86_64",
                     "channel": "ga"
@@ -317,6 +346,7 @@
                 {
                     "major_version": "8",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "nfv",
                     "arch": "aarch64",
                     "channel": "ga"
@@ -324,6 +354,7 @@
                 {
                     "major_version": "8",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "nfv",
                     "arch": "ppc64le",
                     "channel": "ga"
@@ -331,6 +362,7 @@
                 {
                     "major_version": "8",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "nfv",
                     "arch": "s390x",
                     "channel": "ga"
@@ -343,6 +375,7 @@
                 {
                     "major_version": "8",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "sap",
                     "arch": "x86_64",
                     "channel": "ga"
@@ -350,6 +383,7 @@
                 {
                     "major_version": "8",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "sap",
                     "arch": "aarch64",
                     "channel": "ga"
@@ -357,6 +391,7 @@
                 {
                     "major_version": "8",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "sap",
                     "arch": "ppc64le",
                     "channel": "ga"
@@ -364,6 +399,7 @@
                 {
                     "major_version": "8",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "sap",
                     "arch": "s390x",
                     "channel": "ga"
@@ -376,6 +412,7 @@
                 {
                     "major_version": "8",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "saphana",
                     "arch": "x86_64",
                     "channel": "ga"
@@ -383,6 +420,7 @@
                 {
                     "major_version": "8",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "saphana",
                     "arch": "aarch64",
                     "channel": "ga"
@@ -390,6 +428,7 @@
                 {
                     "major_version": "8",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "saphana",
                     "arch": "ppc64le",
                     "channel": "ga"
@@ -397,6 +436,7 @@
                 {
                     "major_version": "8",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "saphana",
                     "arch": "s390x",
                     "channel": "ga"
@@ -410,6 +450,7 @@
                     "repoid": "almalinux9-baseos",
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "arch": "x86_64",
                     "channel": "ga"
                 },
@@ -417,6 +458,7 @@
                     "repoid": "almalinux9-baseos",
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "arch": "aarch64",
                     "channel": "ga"
                 },
@@ -424,6 +466,7 @@
                     "repoid": "almalinux9-baseos",
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "arch": "ppc64le",
                     "channel": "ga"
                 },
@@ -431,6 +474,7 @@
                     "repoid": "almalinux9-baseos",
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "arch": "s390x",
                     "channel": "ga"
                 }
@@ -442,6 +486,7 @@
                 {
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "almalinux9-appstream",
                     "arch": "x86_64",
                     "channel": "ga"
@@ -449,6 +494,7 @@
                 {
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "almalinux9-appstream",
                     "arch": "aarch64",
                     "channel": "ga"
@@ -456,6 +502,7 @@
                 {
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "almalinux9-appstream",
                     "arch": "ppc64le",
                     "channel": "ga"
@@ -463,6 +510,7 @@
                 {
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "almalinux9-appstream",
                     "arch": "s390x",
                     "channel": "ga"
@@ -476,6 +524,7 @@
                     "major_version": "9",
                     "repoid": "almalinux9-crb",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "arch": "x86_64",
                     "channel": "ga"
                 },
@@ -483,6 +532,7 @@
                     "major_version": "9",
                     "repoid": "almalinux9-crb",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "arch": "aarch64",
                     "channel": "ga"
                 },
@@ -490,6 +540,7 @@
                     "major_version": "9",
                     "repoid": "almalinux9-crb",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "arch": "ppc64le",
                     "channel": "ga"
                 },
@@ -497,6 +548,7 @@
                     "major_version": "9",
                     "repoid": "almalinux9-crb",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "arch": "s390x",
                     "channel": "ga"
                 }
@@ -508,6 +560,7 @@
                 {
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "almalinux9-highavailability",
                     "arch": "x86_64",
                     "channel": "ga"
@@ -515,6 +568,7 @@
                 {
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "almalinux9-highavailability",
                     "arch": "aarch64",
                     "channel": "ga"
@@ -522,6 +576,7 @@
                 {
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "almalinux9-highavailability",
                     "arch": "ppc64le",
                     "channel": "ga"
@@ -529,6 +584,7 @@
                 {
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "almalinux9-highavailability",
                     "arch": "s390x",
                     "channel": "ga"
@@ -541,6 +597,7 @@
                 {
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "almalinux9-resilientstorage",
                     "arch": "x86_64",
                     "channel": "ga"
@@ -548,6 +605,7 @@
                 {
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "almalinux9-resilientstorage",
                     "arch": "aarch64",
                     "channel": "ga"
@@ -555,6 +613,7 @@
                 {
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "almalinux9-resilientstorage",
                     "arch": "ppc64le",
                     "channel": "ga"
@@ -562,6 +621,7 @@
                 {
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "almalinux9-resilientstorage",
                     "arch": "s390x",
                     "channel": "ga"
@@ -574,6 +634,7 @@
                 {
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "almalinux9-extras",
                     "arch": "x86_64",
                     "channel": "ga"
@@ -581,6 +642,7 @@
                 {
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "almalinux9-extras",
                     "arch": "aarch64",
                     "channel": "ga"
@@ -588,6 +650,7 @@
                 {
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "almalinux9-extras",
                     "arch": "ppc64le",
                     "channel": "ga"
@@ -595,6 +658,7 @@
                 {
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "almalinux9-extras",
                     "arch": "s390x",
                     "channel": "ga"
@@ -607,6 +671,7 @@
                 {
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "almalinux9-rt",
                     "arch": "x86_64",
                     "channel": "ga"
@@ -619,6 +684,7 @@
                 {
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "almalinux9-nfv",
                     "arch": "x86_64",
                     "channel": "ga"
@@ -631,6 +697,7 @@
                 {
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "almalinux9-sap",
                     "arch": "x86_64",
                     "channel": "ga"
@@ -638,6 +705,7 @@
                 {
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "almalinux9-sap",
                     "arch": "aarch64",
                     "channel": "ga"
@@ -645,6 +713,7 @@
                 {
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "almalinux9-sap",
                     "arch": "ppc64le",
                     "channel": "ga"
@@ -652,6 +721,7 @@
                 {
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "almalinux9-sap",
                     "arch": "s390x",
                     "channel": "ga"
@@ -664,6 +734,7 @@
                 {
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "almalinux9-saphana",
                     "arch": "x86_64",
                     "channel": "ga"
@@ -671,6 +742,7 @@
                 {
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "almalinux9-saphana",
                     "arch": "aarch64",
                     "channel": "ga"
@@ -678,6 +750,7 @@
                 {
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "almalinux9-saphana",
                     "arch": "ppc64le",
                     "channel": "ga"
@@ -685,6 +758,7 @@
                 {
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "almalinux",
                     "repoid": "almalinux9-saphana",
                     "arch": "s390x",
                     "channel": "ga"

--- a/files/centos/device_driver_deprecation_data.json
+++ b/files/centos/device_driver_deprecation_data.json
@@ -1,6 +1,6 @@
 {
   "provided_data_streams": [
-    "3.3"
+    "4.0"
   ],
   "data": [
     {

--- a/files/centos/pes-events.json
+++ b/files/centos/pes-events.json
@@ -1,7 +1,7 @@
 {
-    "timestamp": "202505091506Z",
+    "timestamp": "202505191506Z",
     "provided_data_streams": [
-        "3.3"
+        "4.0"
     ],
     "packageinfo": [
         {
@@ -147603,7 +147603,10 @@
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "httpcomponents-client-cache",
                         "repository": "centos8-powertools"
@@ -147611,7 +147614,11 @@
                 ],
                 "set_id": 6640
             },
-            "initial_release": null,
+            "initial_release": {
+                "major_version": 7,
+                "minor_version": 9,
+                "os_name": "CentOS"
+            },
             "modulestream_maps": [],
             "out_packageset": null,
             "release": {
@@ -147673,7 +147680,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -147699,14 +147705,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "httpcomponents-core-javadoc",
                         "repository": "centos8-powertools"
@@ -147723,7 +147735,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -147749,14 +147760,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "httpcomponents-project",
                         "repository": "centos8-powertools"
@@ -148080,9 +148097,7 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 4131,
@@ -148106,14 +148121,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "pki-deps",
+                        "stream": "10.6"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "pki-deps",
+                                "stream": "10.6"
+                            }
                         ],
                         "name": "jakarta-commons-httpclient",
                         "repository": "centos8-appstream"
@@ -148130,7 +148151,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -148156,14 +148176,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "pki-deps",
+                        "stream": "10.6"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "pki-deps",
+                                "stream": "10.6"
+                            }
                         ],
                         "name": "jakarta-commons-httpclient-demo",
                         "repository": "centos8-appstream"
@@ -148180,7 +148206,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -148206,14 +148231,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "pki-deps",
+                        "stream": "10.6"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "pki-deps",
+                                "stream": "10.6"
+                            }
                         ],
                         "name": "jakarta-commons-httpclient-javadoc",
                         "repository": "centos8-appstream"
@@ -148230,7 +148261,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -148256,14 +148286,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "pki-deps",
+                        "stream": "10.6"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "pki-deps",
+                                "stream": "10.6"
+                            }
                         ],
                         "name": "jakarta-commons-httpclient-manual",
                         "repository": "centos8-appstream"
@@ -148829,7 +148865,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -148855,14 +148890,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "javacc",
                         "repository": "centos8-powertools"
@@ -148879,7 +148920,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -148905,14 +148945,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "javacc-demo",
                         "repository": "centos8-powertools"
@@ -148929,7 +148975,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -148955,14 +149000,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "javacc-javadoc",
                         "repository": "centos8-powertools"
@@ -148979,7 +149030,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -149005,14 +149055,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "javacc-manual",
                         "repository": "centos8-powertools"
@@ -149029,7 +149085,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -149055,14 +149110,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "javacc-maven-plugin",
                         "repository": "centos8-powertools"
@@ -149244,7 +149305,6 @@
         {
             "action": 4,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -149270,28 +149330,40 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "ivy-local",
                         "repository": "centos8-powertools"
                     },
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "javapackages-filesystem",
                         "repository": "centos8-powertools"
                     },
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "javapackages-tools",
                         "repository": "centos8-powertools"
@@ -149308,7 +149380,6 @@
         {
             "action": 4,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -149334,21 +149405,30 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "javapackages-local",
                         "repository": "centos8-powertools"
                     },
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-local",
                         "repository": "centos8-powertools"
@@ -149530,9 +149610,7 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 4159,
@@ -149556,14 +149634,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "jaxen",
                         "repository": "centos8-powertools"
@@ -149580,7 +149664,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -149606,14 +149689,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "jaxen-demo",
                         "repository": "centos8-powertools"
@@ -150189,7 +150278,10 @@
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "jdom2",
                         "repository": "centos8-powertools"
@@ -150197,7 +150289,11 @@
                 ],
                 "set_id": 6737
             },
-            "initial_release": null,
+            "initial_release": {
+                "major_version": 7,
+                "minor_version": 9,
+                "os_name": "CentOS"
+            },
             "modulestream_maps": [],
             "out_packageset": null,
             "release": {
@@ -151861,7 +151957,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -151887,14 +151982,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "jflex",
                         "repository": "centos8-powertools"
@@ -151911,7 +152012,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -151937,14 +152037,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "jflex-javadoc",
                         "repository": "centos8-powertools"
@@ -152903,7 +153009,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -152929,14 +153034,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "junit-javadoc",
                         "repository": "centos8-powertools"
@@ -152953,7 +153064,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -152979,14 +153089,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "junit-manual",
                         "repository": "centos8-powertools"
@@ -153036,9 +153152,7 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
-                "s390x",
                 "x86_64"
             ],
             "id": 4250,
@@ -153062,14 +153176,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "jvnet-parent",
                         "repository": "centos8-powertools"
@@ -153086,7 +153206,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -153112,14 +153231,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "jzlib",
                         "repository": "centos8-powertools"
@@ -153136,7 +153261,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -153162,14 +153286,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "jzlib-demo",
                         "repository": "centos8-powertools"
@@ -153186,7 +153316,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -153212,14 +153341,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "jzlib-javadoc",
                         "repository": "centos8-powertools"
@@ -153501,7 +153636,6 @@
         {
             "action": 4,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -153527,21 +153661,30 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "maven",
+                        "stream": "3.5"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "maven",
+                                "stream": "3.5"
+                            }
                         ],
                         "name": "maven",
                         "repository": "centos8-appstream"
                     },
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "maven",
+                                "stream": "3.5"
+                            }
                         ],
                         "name": "maven-lib",
                         "repository": "centos8-appstream"
@@ -153558,7 +153701,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -153584,14 +153726,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-javadoc",
                         "repository": "centos8-powertools"
@@ -153608,7 +153756,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -153634,14 +153781,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-antrun-plugin",
                         "repository": "centos8-powertools"
@@ -153658,7 +153811,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -153684,14 +153836,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-antrun-plugin-javadoc",
                         "repository": "centos8-powertools"
@@ -153708,7 +153866,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -153734,14 +153891,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-archiver",
                         "repository": "centos8-powertools"
@@ -153758,7 +153921,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -153784,14 +153946,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-archiver-javadoc",
                         "repository": "centos8-powertools"
@@ -153808,7 +153976,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -153834,14 +154001,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-artifact-resolver",
                         "repository": "centos8-powertools"
@@ -153858,7 +154031,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -153884,14 +154056,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-artifact-resolver-javadoc",
                         "repository": "centos8-powertools"
@@ -153908,7 +154086,6 @@
         {
             "action": 3,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -153934,14 +154111,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-artifact-transfer",
                         "repository": "centos8-powertools"
@@ -153958,7 +154141,6 @@
         {
             "action": 3,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -153984,14 +154166,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-artifact-transfer-javadoc",
                         "repository": "centos8-powertools"
@@ -154008,7 +154196,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -154034,14 +154221,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-assembly-plugin",
                         "repository": "centos8-powertools"
@@ -154058,7 +154251,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -154084,14 +154276,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-assembly-plugin-javadoc",
                         "repository": "centos8-powertools"
@@ -154174,7 +154372,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -154200,14 +154397,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-clean-plugin",
                         "repository": "centos8-powertools"
@@ -154224,7 +154427,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -154250,14 +154452,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-clean-plugin-javadoc",
                         "repository": "centos8-powertools"
@@ -154274,7 +154482,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -154300,14 +154507,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-common-artifact-filters",
                         "repository": "centos8-powertools"
@@ -154324,7 +154537,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -154350,14 +154562,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-common-artifact-filters-javadoc",
                         "repository": "centos8-powertools"
@@ -154374,7 +154592,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -154400,14 +154617,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-compiler-plugin",
                         "repository": "centos8-powertools"
@@ -154424,7 +154647,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -154450,14 +154672,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-compiler-plugin-javadoc",
                         "repository": "centos8-powertools"
@@ -154474,7 +154702,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -154500,14 +154727,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-dependency-analyzer",
                         "repository": "centos8-powertools"
@@ -154524,7 +154757,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -154550,14 +154782,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-dependency-analyzer-javadoc",
                         "repository": "centos8-powertools"
@@ -154574,7 +154812,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -154600,14 +154837,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-dependency-plugin",
                         "repository": "centos8-powertools"
@@ -154624,7 +154867,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -154650,14 +154892,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-dependency-plugin-javadoc",
                         "repository": "centos8-powertools"
@@ -154674,7 +154922,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -154700,14 +154947,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-dependency-tree",
                         "repository": "centos8-powertools"
@@ -154724,7 +154977,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -154750,14 +155002,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-dependency-tree-javadoc",
                         "repository": "centos8-powertools"
@@ -154840,7 +155098,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -154866,14 +155123,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-doxia",
                         "repository": "centos8-powertools"
@@ -154890,7 +155153,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -154916,14 +155178,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-doxia-core",
                         "repository": "centos8-powertools"
@@ -154940,7 +155208,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -154966,14 +155233,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-doxia-javadoc",
                         "repository": "centos8-powertools"
@@ -154990,7 +155263,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -155016,14 +155288,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-doxia-logging-api",
                         "repository": "centos8-powertools"
@@ -155040,7 +155318,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -155066,14 +155343,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-doxia-module-apt",
                         "repository": "centos8-powertools"
@@ -155090,7 +155373,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -155116,14 +155398,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-doxia-module-confluence",
                         "repository": "centos8-powertools"
@@ -155140,7 +155428,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -155166,14 +155453,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-doxia-module-docbook-simple",
                         "repository": "centos8-powertools"
@@ -155190,7 +155483,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -155216,14 +155508,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-doxia-module-fml",
                         "repository": "centos8-powertools"
@@ -155240,7 +155538,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -155266,14 +155563,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-doxia-module-latex",
                         "repository": "centos8-powertools"
@@ -155290,7 +155593,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -155316,14 +155618,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-doxia-module-rtf",
                         "repository": "centos8-powertools"
@@ -155340,7 +155648,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -155366,14 +155673,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-doxia-module-twiki",
                         "repository": "centos8-powertools"
@@ -155390,7 +155703,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -155416,14 +155728,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-doxia-module-xdoc",
                         "repository": "centos8-powertools"
@@ -155440,7 +155758,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -155466,14 +155783,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-doxia-module-xhtml",
                         "repository": "centos8-powertools"
@@ -155490,7 +155813,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -155516,14 +155838,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-doxia-modules",
                         "repository": "centos8-powertools"
@@ -155540,7 +155868,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -155566,14 +155893,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-doxia-sink-api",
                         "repository": "centos8-powertools"
@@ -155590,7 +155923,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -155616,14 +155948,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-doxia-test-docs",
                         "repository": "centos8-powertools"
@@ -155640,7 +155978,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -155666,14 +156003,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-doxia-tests",
                         "repository": "centos8-powertools"
@@ -155723,7 +156066,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -155749,14 +156091,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-doxia-sitetools",
                         "repository": "centos8-powertools"
@@ -155773,7 +156121,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -155799,14 +156146,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-doxia-sitetools-javadoc",
                         "repository": "centos8-powertools"
@@ -155823,7 +156176,6 @@
         {
             "action": 3,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -155849,14 +156201,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-doxia-sitetools",
                         "repository": "centos8-powertools"
@@ -155873,7 +156231,6 @@
         {
             "action": 3,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -155899,14 +156256,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-doxia-sitetools-javadoc",
                         "repository": "centos8-powertools"
@@ -155923,7 +156286,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -155949,14 +156311,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-enforcer",
                         "repository": "centos8-powertools"
@@ -155973,7 +156341,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -155999,14 +156366,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-enforcer-api",
                         "repository": "centos8-powertools"
@@ -156023,7 +156396,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -156049,14 +156421,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-enforcer-javadoc",
                         "repository": "centos8-powertools"
@@ -156073,7 +156451,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -156099,14 +156476,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-enforcer-plugin",
                         "repository": "centos8-powertools"
@@ -156123,7 +156506,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -156149,14 +156531,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-enforcer-rules",
                         "repository": "centos8-powertools"
@@ -156173,7 +156561,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -156199,14 +156586,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-file-management",
                         "repository": "centos8-powertools"
@@ -156223,7 +156616,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -156249,14 +156641,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-file-management-javadoc",
                         "repository": "centos8-powertools"
@@ -156273,7 +156671,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -156299,14 +156696,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-filtering",
                         "repository": "centos8-powertools"
@@ -156323,7 +156726,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -156349,14 +156751,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-filtering-javadoc",
                         "repository": "centos8-powertools"
@@ -156439,7 +156847,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -156465,14 +156872,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-install-plugin",
                         "repository": "centos8-powertools"
@@ -156489,7 +156902,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -156515,14 +156927,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-install-plugin-javadoc",
                         "repository": "centos8-powertools"
@@ -156539,7 +156957,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -156565,14 +156982,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-invoker",
                         "repository": "centos8-powertools"
@@ -156589,7 +157012,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -156615,14 +157037,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-invoker-javadoc",
                         "repository": "centos8-powertools"
@@ -156639,7 +157067,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -156665,14 +157092,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-invoker-plugin",
                         "repository": "centos8-powertools"
@@ -156689,7 +157122,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -156715,14 +157147,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-invoker-plugin-javadoc",
                         "repository": "centos8-powertools"
@@ -156739,7 +157177,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -156765,14 +157202,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-jar-plugin",
                         "repository": "centos8-powertools"
@@ -156789,7 +157232,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -156815,14 +157257,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-jar-plugin-javadoc",
                         "repository": "centos8-powertools"
@@ -157136,7 +157584,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -157162,14 +157609,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-parent",
                         "repository": "centos8-powertools"
@@ -157186,7 +157639,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -157212,14 +157664,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-plugin-build-helper",
                         "repository": "centos8-powertools"
@@ -157236,7 +157694,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -157262,14 +157719,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-plugin-build-helper-javadoc",
                         "repository": "centos8-powertools"
@@ -157286,7 +157749,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -157312,14 +157774,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-plugin-bundle",
                         "repository": "centos8-powertools"
@@ -157336,7 +157804,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -157362,14 +157829,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-plugin-bundle-javadoc",
                         "repository": "centos8-powertools"
@@ -157386,7 +157859,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -157412,14 +157884,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-plugin-testing",
                         "repository": "centos8-powertools"
@@ -157436,7 +157914,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -157462,14 +157939,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-plugin-testing-harness",
                         "repository": "centos8-powertools"
@@ -157486,7 +157969,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -157512,14 +157994,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-plugin-testing-javadoc",
                         "repository": "centos8-powertools"
@@ -157536,7 +158024,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -157562,14 +158049,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-plugin-testing-tools",
                         "repository": "centos8-powertools"
@@ -157586,7 +158079,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -157612,14 +158104,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-test-tools",
                         "repository": "centos8-powertools"
@@ -158784,7 +159282,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -158810,14 +159307,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-reporting-api-javadoc",
                         "repository": "centos8-powertools"
@@ -159547,7 +160050,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -159573,14 +160075,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-shared-incremental-javadoc",
                         "repository": "centos8-powertools"
@@ -159597,7 +160105,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -159623,14 +160130,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-shared-io",
                         "repository": "centos8-powertools"
@@ -159647,7 +160160,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -159673,14 +160185,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-shared-io-javadoc",
                         "repository": "centos8-powertools"
@@ -159813,7 +160331,6 @@
         {
             "action": 6,
             "architectures": [
-                "aarch64",
                 "ppc64le",
                 "s390x",
                 "x86_64"
@@ -159839,14 +160356,20 @@
             "modulestream_maps": [
                 {
                     "in_modulestream": null,
-                    "out_modulestream": null
+                    "out_modulestream": {
+                        "name": "javapackages-tools",
+                        "stream": "201801"
+                    }
                 }
             ],
             "out_packageset": {
                 "package": [
                     {
                         "modulestreams": [
-                            null
+                            {
+                                "name": "javapackages-tools",
+                                "stream": "201801"
+                            }
                         ],
                         "name": "maven-shared-utils-javadoc",
                         "repository": "centos8-powertools"
@@ -689598,12 +690121,145 @@
         {
             "action": 1,
             "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 19561,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "dyninst-testsuite",
+                        "repository": "centos10-crb"
+                    }
+                ],
+                "set_id": 26167
+            },
+            "initial_release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 1,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 19562,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "dyninst-testsuite",
+                        "repository": "centos9-crb"
+                    }
+                ],
+                "set_id": 26168
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 6,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 7,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "x86_64"
+            ],
+            "id": 19563,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "dyninst-testsuite",
+                        "repository": "centos10-crb"
+                    }
+                ],
+                "set_id": 26169
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 7,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 0,
+            "architectures": [
+                "aarch64",
+                "ppc64le",
+                "s390x",
+                "x86_64"
+            ],
+            "id": 19564,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "rpm-plugin-dbus-announce",
+                        "repository": "centos10-appstream"
+                    }
+                ],
+                "set_id": 26170
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 7,
+                "os_name": "CentOS"
+            },
+            "modulestream_maps": [],
+            "out_packageset": null,
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "CentOS"
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
                 "x86_64",
                 "aarch64",
                 "ppc64le",
                 "s390x"
             ],
-            "id": 19561,
+            "id": 19565,
             "in_packageset": {
                 "package": [
                     {
@@ -689614,7 +690270,7 @@
                         "repository": "base"
                     }
                 ],
-                "set_id": 26167
+                "set_id": 26171
             },
             "initial_release": {
                 "major_version": 7,
@@ -689637,7 +690293,7 @@
                 "ppc64le",
                 "s390x"
             ],
-            "id": 19562,
+            "id": 19566,
             "in_packageset": {
                 "package": [
                     {
@@ -689645,114 +690301,6 @@
                             null
                         ],
                         "name": "libssh2",
-                        "repository": "base"
-                    }
-                ],
-                "set_id": 26169
-            },
-            "initial_release": {
-                "major_version": 7,
-                "minor_version": 7,
-                "os_name": "CentOS",
-                "tag": null,
-                "z_stream": null
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "libssh",
-                        "repository": "centos8-baseos"
-                    }
-                ],
-                "set_id": 26168
-            },
-            "release": {
-                "major_version": 8,
-                "minor_version": 0,
-                "os_name": "CentOS",
-                "tag": null,
-                "z_stream": null
-            }
-        },
-        {
-            "action": 3,
-            "architectures": [
-                "x86_64",
-                "aarch64",
-                "ppc64le",
-                "s390x"
-            ],
-            "id": 19563,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "libssh2-devel",
-                        "repository": "base"
-                    }
-                ],
-                "set_id": 26171
-            },
-            "initial_release": {
-                "major_version": 7,
-                "minor_version": 7,
-                "os_name": "CentOS",
-                "tag": null,
-                "z_stream": null
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "libssh-devel",
-                        "repository": "centos8-baseos"
-                    }
-                ],
-                "set_id": 26170
-            },
-            "release": {
-                "major_version": 8,
-                "minor_version": 0,
-                "os_name": "CentOS",
-                "tag": null,
-                "z_stream": null
-            }
-        },
-        {
-            "action": 3,
-            "architectures": [
-                "x86_64",
-                "aarch64",
-                "ppc64le",
-                "s390x"
-            ],
-            "id": 19564,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "libssh2-docs",
                         "repository": "base"
                     }
                 ],
@@ -689777,7 +690325,7 @@
                         "modulestreams": [
                             null
                         ],
-                        "name": "libssh-docs",
+                        "name": "libssh",
                         "repository": "centos8-baseos"
                     }
                 ],
@@ -689792,93 +690340,7 @@
             }
         },
         {
-            "action": 1,
-            "architectures": [
-                "x86_64",
-                "aarch64",
-                "ppc64le",
-                "s390x"
-            ],
-            "id": 19565,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "ustr",
-                        "repository": "powertools"
-                    }
-                ],
-                "set_id": 26174
-            },
-            "initial_release": {
-                "major_version": 8,
-                "minor_version": 5,
-                "os_name": "CentOS",
-                "tag": null,
-                "z_stream": null
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": null,
-            "release": {
-                "major_version": 9,
-                "minor_version": 0,
-                "os_name": "CentOS",
-                "tag": null,
-                "z_stream": null
-            }
-        },
-        {
-            "action": 1,
-            "architectures": [
-                "x86_64",
-                "aarch64",
-                "ppc64le",
-                "s390x"
-            ],
-            "id": 19566,
-            "in_packageset": {
-                "package": [
-                    {
-                        "modulestreams": [
-                            null
-                        ],
-                        "name": "nautilus-sendto",
-                        "repository": "appstream"
-                    }
-                ],
-                "set_id": 26175
-            },
-            "initial_release": {
-                "major_version": 8,
-                "minor_version": 5,
-                "os_name": "CentOS",
-                "tag": null,
-                "z_stream": null
-            },
-            "modulestream_maps": [
-                {
-                    "in_modulestream": null,
-                    "out_modulestream": null
-                }
-            ],
-            "out_packageset": null,
-            "release": {
-                "major_version": 9,
-                "minor_version": 0,
-                "os_name": "CentOS",
-                "tag": null,
-                "z_stream": null
-            }
-        },
-        {
-            "action": 1,
+            "action": 3,
             "architectures": [
                 "x86_64",
                 "aarch64",
@@ -689892,15 +690354,15 @@
                         "modulestreams": [
                             null
                         ],
-                        "name": "libdmapsharing",
-                        "repository": "appstream"
+                        "name": "libssh2-devel",
+                        "repository": "base"
                     }
                 ],
-                "set_id": 26176
+                "set_id": 26175
             },
             "initial_release": {
-                "major_version": 8,
-                "minor_version": 5,
+                "major_version": 7,
+                "minor_version": 7,
                 "os_name": "CentOS",
                 "tag": null,
                 "z_stream": null
@@ -689911,9 +690373,20 @@
                     "out_modulestream": null
                 }
             ],
-            "out_packageset": null,
+            "out_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "libssh-devel",
+                        "repository": "centos8-baseos"
+                    }
+                ],
+                "set_id": 26174
+            },
             "release": {
-                "major_version": 9,
+                "major_version": 8,
                 "minor_version": 0,
                 "os_name": "CentOS",
                 "tag": null,
@@ -689921,7 +690394,7 @@
             }
         },
         {
-            "action": 1,
+            "action": 3,
             "architectures": [
                 "x86_64",
                 "aarch64",
@@ -689935,15 +690408,15 @@
                         "modulestreams": [
                             null
                         ],
-                        "name": "iptstate",
-                        "repository": "baseos"
+                        "name": "libssh2-docs",
+                        "repository": "base"
                     }
                 ],
                 "set_id": 26177
             },
             "initial_release": {
-                "major_version": 8,
-                "minor_version": 5,
+                "major_version": 7,
+                "minor_version": 7,
                 "os_name": "CentOS",
                 "tag": null,
                 "z_stream": null
@@ -689954,9 +690427,20 @@
                     "out_modulestream": null
                 }
             ],
-            "out_packageset": null,
+            "out_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "libssh-docs",
+                        "repository": "centos8-baseos"
+                    }
+                ],
+                "set_id": 26176
+            },
             "release": {
-                "major_version": 9,
+                "major_version": 8,
                 "minor_version": 0,
                 "os_name": "CentOS",
                 "tag": null,
@@ -689978,8 +690462,8 @@
                         "modulestreams": [
                             null
                         ],
-                        "name": "gupnp",
-                        "repository": "appstream"
+                        "name": "ustr",
+                        "repository": "powertools"
                     }
                 ],
                 "set_id": 26178
@@ -690021,7 +690505,7 @@
                         "modulestreams": [
                             null
                         ],
-                        "name": "libplist",
+                        "name": "nautilus-sendto",
                         "repository": "appstream"
                     }
                 ],
@@ -690064,8 +690548,8 @@
                         "modulestreams": [
                             null
                         ],
-                        "name": "jimtcl",
-                        "repository": "baseos"
+                        "name": "libdmapsharing",
+                        "repository": "appstream"
                     }
                 ],
                 "set_id": 26180
@@ -690107,7 +690591,7 @@
                         "modulestreams": [
                             null
                         ],
-                        "name": "libmodman",
+                        "name": "iptstate",
                         "repository": "baseos"
                     }
                 ],
@@ -690150,7 +690634,7 @@
                         "modulestreams": [
                             null
                         ],
-                        "name": "libimobiledevice",
+                        "name": "gupnp",
                         "repository": "appstream"
                     }
                 ],
@@ -690193,7 +690677,7 @@
                         "modulestreams": [
                             null
                         ],
-                        "name": "man-pages-overrides",
+                        "name": "libplist",
                         "repository": "appstream"
                     }
                 ],
@@ -690236,8 +690720,8 @@
                         "modulestreams": [
                             null
                         ],
-                        "name": "khmeros-fonts-common",
-                        "repository": "appstream"
+                        "name": "jimtcl",
+                        "repository": "baseos"
                     }
                 ],
                 "set_id": 26184
@@ -690279,8 +690763,8 @@
                         "modulestreams": [
                             null
                         ],
-                        "name": "gupnp-dlna",
-                        "repository": "appstream"
+                        "name": "libmodman",
+                        "repository": "baseos"
                     }
                 ],
                 "set_id": 26185
@@ -690322,7 +690806,7 @@
                         "modulestreams": [
                             null
                         ],
-                        "name": "gupnp-av",
+                        "name": "libimobiledevice",
                         "repository": "appstream"
                     }
                 ],
@@ -690365,7 +690849,7 @@
                         "modulestreams": [
                             null
                         ],
-                        "name": "lua-socket",
+                        "name": "man-pages-overrides",
                         "repository": "appstream"
                     }
                 ],
@@ -690408,7 +690892,7 @@
                         "modulestreams": [
                             null
                         ],
-                        "name": "usbmuxd",
+                        "name": "khmeros-fonts-common",
                         "repository": "appstream"
                     }
                 ],
@@ -690451,7 +690935,7 @@
                         "modulestreams": [
                             null
                         ],
-                        "name": "gssdp",
+                        "name": "gupnp-dlna",
                         "repository": "appstream"
                     }
                 ],
@@ -690494,11 +690978,183 @@
                         "modulestreams": [
                             null
                         ],
-                        "name": "libusbmuxd",
+                        "name": "gupnp-av",
                         "repository": "appstream"
                     }
                 ],
                 "set_id": 26190
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 5,
+                "os_name": "CentOS",
+                "tag": null,
+                "z_stream": null
+            },
+            "modulestream_maps": [
+                {
+                    "in_modulestream": null,
+                    "out_modulestream": null
+                }
+            ],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 0,
+                "os_name": "CentOS",
+                "tag": null,
+                "z_stream": null
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "x86_64",
+                "aarch64",
+                "ppc64le",
+                "s390x"
+            ],
+            "id": 19582,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "lua-socket",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 26191
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 5,
+                "os_name": "CentOS",
+                "tag": null,
+                "z_stream": null
+            },
+            "modulestream_maps": [
+                {
+                    "in_modulestream": null,
+                    "out_modulestream": null
+                }
+            ],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 0,
+                "os_name": "CentOS",
+                "tag": null,
+                "z_stream": null
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "x86_64",
+                "aarch64",
+                "ppc64le",
+                "s390x"
+            ],
+            "id": 19583,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "usbmuxd",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 26192
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 5,
+                "os_name": "CentOS",
+                "tag": null,
+                "z_stream": null
+            },
+            "modulestream_maps": [
+                {
+                    "in_modulestream": null,
+                    "out_modulestream": null
+                }
+            ],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 0,
+                "os_name": "CentOS",
+                "tag": null,
+                "z_stream": null
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "x86_64",
+                "aarch64",
+                "ppc64le",
+                "s390x"
+            ],
+            "id": 19584,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "gssdp",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 26193
+            },
+            "initial_release": {
+                "major_version": 8,
+                "minor_version": 5,
+                "os_name": "CentOS",
+                "tag": null,
+                "z_stream": null
+            },
+            "modulestream_maps": [
+                {
+                    "in_modulestream": null,
+                    "out_modulestream": null
+                }
+            ],
+            "out_packageset": null,
+            "release": {
+                "major_version": 9,
+                "minor_version": 0,
+                "os_name": "CentOS",
+                "tag": null,
+                "z_stream": null
+            }
+        },
+        {
+            "action": 1,
+            "architectures": [
+                "x86_64",
+                "aarch64",
+                "ppc64le",
+                "s390x"
+            ],
+            "id": 19585,
+            "in_packageset": {
+                "package": [
+                    {
+                        "modulestreams": [
+                            null
+                        ],
+                        "name": "libusbmuxd",
+                        "repository": "appstream"
+                    }
+                ],
+                "set_id": 26194
             },
             "initial_release": {
                 "major_version": 8,

--- a/files/centos/repomap.json.el10
+++ b/files/centos/repomap.json.el10
@@ -1,8 +1,8 @@
 {
-    "datetime": "2025011151130Z",
-    "version_format": "1.2.1",
+    "datetime": "202506241030Z",
+    "version_format": "1.3.0",
     "provided_data_streams": [
-        "3.0"
+        "4.0"
     ],
     "mapping": [
         {
@@ -62,6 +62,7 @@
                     "repoid": "baseos",
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "centos",
                     "arch": "x86_64",
                     "channel": "ga"
                 },
@@ -69,6 +70,7 @@
                     "repoid": "baseos",
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "centos",
                     "arch": "aarch64",
                     "channel": "ga"
                 },
@@ -76,6 +78,7 @@
                     "repoid": "baseos",
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "centos",
                     "arch": "ppc64le",
                     "channel": "ga"
                 },
@@ -83,6 +86,7 @@
                     "repoid": "baseos",
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "centos",
                     "arch": "s390x",
                     "channel": "ga"
                 }
@@ -94,6 +98,7 @@
                 {
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "centos",
                     "repoid": "appstream",
                     "arch": "x86_64",
                     "channel": "ga"
@@ -101,6 +106,7 @@
                 {
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "centos",
                     "repoid": "appstream",
                     "arch": "aarch64",
                     "channel": "ga"
@@ -108,6 +114,7 @@
                 {
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "centos",
                     "repoid": "appstream",
                     "arch": "ppc64le",
                     "channel": "ga"
@@ -115,6 +122,7 @@
                 {
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "centos",
                     "repoid": "appstream",
                     "arch": "s390x",
                     "channel": "ga"
@@ -128,6 +136,7 @@
                     "major_version": "9",
                     "repoid": "powertools",
                     "repo_type": "rpm",
+                    "distro": "centos",
                     "arch": "x86_64",
                     "channel": "ga"
                 },
@@ -135,6 +144,7 @@
                     "major_version": "9",
                     "repoid": "powertools",
                     "repo_type": "rpm",
+                    "distro": "centos",
                     "arch": "aarch64",
                     "channel": "ga"
                 },
@@ -142,6 +152,7 @@
                     "major_version": "9",
                     "repoid": "powertools",
                     "repo_type": "rpm",
+                    "distro": "centos",
                     "arch": "ppc64le",
                     "channel": "ga"
                 },
@@ -149,6 +160,7 @@
                     "major_version": "9",
                     "repoid": "powertools",
                     "repo_type": "rpm",
+                    "distro": "centos",
                     "arch": "s390x",
                     "channel": "ga"
                 }
@@ -160,6 +172,7 @@
                 {
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "centos",
                     "repoid": "ha",
                     "arch": "x86_64",
                     "channel": "ga"
@@ -167,6 +180,7 @@
                 {
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "centos",
                     "repoid": "ha",
                     "arch": "aarch64",
                     "channel": "ga"
@@ -174,6 +188,7 @@
                 {
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "centos",
                     "repoid": "ha",
                     "arch": "ppc64le",
                     "channel": "ga"
@@ -181,6 +196,7 @@
                 {
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "centos",
                     "repoid": "ha",
                     "arch": "s390x",
                     "channel": "ga"
@@ -193,6 +209,7 @@
                 {
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "centos",
                     "repoid": "extras",
                     "arch": "x86_64",
                     "channel": "ga"
@@ -200,6 +217,7 @@
                 {
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "centos",
                     "repoid": "extras",
                     "arch": "aarch64",
                     "channel": "ga"
@@ -207,6 +225,7 @@
                 {
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "centos",
                     "repoid": "extras",
                     "arch": "ppc64le",
                     "channel": "ga"
@@ -214,6 +233,7 @@
                 {
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "centos",
                     "repoid": "extras",
                     "arch": "s390x",
                     "channel": "ga"
@@ -226,6 +246,7 @@
                 {
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "centos",
                     "repoid": "rt",
                     "arch": "x86_64",
                     "channel": "ga"
@@ -238,6 +259,7 @@
                 {
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "centos",
                     "repoid": "nfv",
                     "arch": "x86_64",
                     "channel": "ga"
@@ -251,6 +273,7 @@
                     "repoid": "centos10-baseos",
                     "major_version": "10",
                     "repo_type": "rpm",
+                    "distro": "centos",
                     "arch": "x86_64",
                     "channel": "ga"
                 },
@@ -258,6 +281,7 @@
                     "repoid": "centos10-baseos",
                     "major_version": "10",
                     "repo_type": "rpm",
+                    "distro": "centos",
                     "arch": "aarch64",
                     "channel": "ga"
                 },
@@ -265,6 +289,7 @@
                     "repoid": "centos10-baseos",
                     "major_version": "10",
                     "repo_type": "rpm",
+                    "distro": "centos",
                     "arch": "ppc64le",
                     "channel": "ga"
                 },
@@ -272,6 +297,7 @@
                     "repoid": "centos10-baseos",
                     "major_version": "10",
                     "repo_type": "rpm",
+                    "distro": "centos",
                     "arch": "s390x",
                     "channel": "ga"
                 }
@@ -283,6 +309,7 @@
                 {
                     "major_version": "10",
                     "repo_type": "rpm",
+                    "distro": "centos",
                     "repoid": "centos10-appstream",
                     "arch": "x86_64",
                     "channel": "ga"
@@ -290,6 +317,7 @@
                 {
                     "major_version": "10",
                     "repo_type": "rpm",
+                    "distro": "centos",
                     "repoid": "centos10-appstream",
                     "arch": "aarch64",
                     "channel": "ga"
@@ -297,6 +325,7 @@
                 {
                     "major_version": "10",
                     "repo_type": "rpm",
+                    "distro": "centos",
                     "repoid": "centos10-appstream",
                     "arch": "ppc64le",
                     "channel": "ga"
@@ -304,6 +333,7 @@
                 {
                     "major_version": "10",
                     "repo_type": "rpm",
+                    "distro": "centos",
                     "repoid": "centos10-appstream",
                     "arch": "s390x",
                     "channel": "ga"
@@ -317,6 +347,7 @@
                     "major_version": "10",
                     "repoid": "centos10-crb",
                     "repo_type": "rpm",
+                    "distro": "centos",
                     "arch": "x86_64",
                     "channel": "ga"
                 },
@@ -324,6 +355,7 @@
                     "major_version": "10",
                     "repoid": "centos10-crb",
                     "repo_type": "rpm",
+                    "distro": "centos",
                     "arch": "aarch64",
                     "channel": "ga"
                 },
@@ -331,6 +363,7 @@
                     "major_version": "10",
                     "repoid": "centos10-crb",
                     "repo_type": "rpm",
+                    "distro": "centos",
                     "arch": "ppc64le",
                     "channel": "ga"
                 },
@@ -338,6 +371,7 @@
                     "major_version": "10",
                     "repoid": "centos10-crb",
                     "repo_type": "rpm",
+                    "distro": "centos",
                     "arch": "s390x",
                     "channel": "ga"
                 }
@@ -349,6 +383,7 @@
                 {
                     "major_version": "10",
                     "repo_type": "rpm",
+                    "distro": "centos",
                     "repoid": "centos10-ha",
                     "arch": "x86_64",
                     "channel": "ga"
@@ -356,6 +391,7 @@
                 {
                     "major_version": "10",
                     "repo_type": "rpm",
+                    "distro": "centos",
                     "repoid": "centos10-ha",
                     "arch": "aarch64",
                     "channel": "ga"
@@ -363,6 +399,7 @@
                 {
                     "major_version": "10",
                     "repo_type": "rpm",
+                    "distro": "centos",
                     "repoid": "centos10-ha",
                     "arch": "ppc64le",
                     "channel": "ga"
@@ -370,6 +407,7 @@
                 {
                     "major_version": "10",
                     "repo_type": "rpm",
+                    "distro": "centos",
                     "repoid": "centos10-ha",
                     "arch": "s390x",
                     "channel": "ga"
@@ -382,6 +420,7 @@
                 {
                     "major_version": "10",
                     "repo_type": "rpm",
+                    "distro": "centos",
                     "repoid": "centos10-extras",
                     "arch": "x86_64",
                     "channel": "ga"
@@ -389,6 +428,7 @@
                 {
                     "major_version": "10",
                     "repo_type": "rpm",
+                    "distro": "centos",
                     "repoid": "centos10-extras",
                     "arch": "aarch64",
                     "channel": "ga"
@@ -396,6 +436,7 @@
                 {
                     "major_version": "10",
                     "repo_type": "rpm",
+                    "distro": "centos",
                     "repoid": "centos10-extras",
                     "arch": "ppc64le",
                     "channel": "ga"
@@ -403,6 +444,7 @@
                 {
                     "major_version": "10",
                     "repo_type": "rpm",
+                    "distro": "centos",
                     "repoid": "centos10-extras",
                     "arch": "s390x",
                     "channel": "ga"
@@ -415,6 +457,7 @@
                 {
                     "major_version": "10",
                     "repo_type": "rpm",
+                    "distro": "centos",
                     "repoid": "centos10-rt",
                     "arch": "x86_64",
                     "channel": "ga"
@@ -427,6 +470,7 @@
                 {
                     "major_version": "10",
                     "repo_type": "rpm",
+                    "distro": "centos",
                     "repoid": "centos10-nfv",
                     "arch": "x86_64",
                     "channel": "ga"

--- a/files/centos/repomap.json.el8
+++ b/files/centos/repomap.json.el8
@@ -1,8 +1,8 @@
 {
-    "datetime": "202410111235Z",
-    "version_format": "1.2.1",
+    "datetime": "202506241030Z",
+    "version_format": "1.3.0",
     "provided_data_streams": [
-        "3.0"
+        "4.0"
     ],
     "mapping": [
         {
@@ -46,6 +46,7 @@
             "entries": [
                 {
                     "repo_type": "rpm",
+                    "distro": "centos",
                     "arch": "x86_64",
                     "major_version": "7",
                     "repoid": "base",
@@ -53,6 +54,7 @@
                 },
                 {
                     "repo_type": "rpm",
+                    "distro": "centos",
                     "arch": "aarch64",
                     "major_version": "7",
                     "repoid": "base",
@@ -60,6 +62,7 @@
                 },
                 {
                     "repo_type": "rpm",
+                    "distro": "centos",
                     "arch": "ppc64le",
                     "major_version": "7",
                     "repoid": "base",
@@ -72,6 +75,7 @@
             "entries": [
                 {
                     "repo_type": "rpm",
+                    "distro": "centos",
                     "repoid": "centos8-baseos",
                     "major_version": "8",
                     "arch": "x86_64",
@@ -79,6 +83,7 @@
                 },
                 {
                     "repo_type": "rpm",
+                    "distro": "centos",
                     "repoid": "centos8-baseos",
                     "major_version": "8",
                     "arch": "aarch64",
@@ -86,6 +91,7 @@
                 },
                 {
                     "repo_type": "rpm",
+                    "distro": "centos",
                     "repoid": "centos8-baseos",
                     "major_version": "8",
                     "arch": "ppc64le",
@@ -98,6 +104,7 @@
             "entries": [
                 {
                     "repo_type": "rpm",
+                    "distro": "centos",
                     "major_version": "8",
                     "arch": "x86_64",
                     "repoid": "centos8-appstream",
@@ -105,6 +112,7 @@
                 },
                 {
                     "repo_type": "rpm",
+                    "distro": "centos",
                     "major_version": "8",
                     "arch": "aarch64",
                     "repoid": "centos8-appstream",
@@ -112,6 +120,7 @@
                 },
                 {
                     "repo_type": "rpm",
+                    "distro": "centos",
                     "major_version": "8",
                     "arch": "ppc64le",
                     "repoid": "centos8-appstream",
@@ -125,6 +134,7 @@
                 {
                     "repoid": "centos8-powertools",
                     "repo_type": "rpm",
+                    "distro": "centos",
                     "major_version": "8",
                     "arch": "x86_64",
                     "channel": "ga"
@@ -132,6 +142,7 @@
                 {
                     "repoid": "centos8-powertools",
                     "repo_type": "rpm",
+                    "distro": "centos",
                     "major_version": "8",
                     "arch": "aarch64",
                     "channel": "ga"
@@ -139,6 +150,7 @@
                 {
                     "repoid": "centos8-powertools",
                     "repo_type": "rpm",
+                    "distro": "centos",
                     "major_version": "8",
                     "arch": "ppc64le",
                     "channel": "ga"
@@ -150,6 +162,7 @@
             "entries": [
                 {
                     "repo_type": "rpm",
+                    "distro": "centos",
                     "major_version": "8",
                     "arch": "x86_64",
                     "repoid": "centos8-ha",
@@ -157,6 +170,7 @@
                 },
                 {
                     "repo_type": "rpm",
+                    "distro": "centos",
                     "major_version": "8",
                     "arch": "aarch64",
                     "repoid": "centos8-ha",
@@ -164,6 +178,7 @@
                 },
                 {
                     "repo_type": "rpm",
+                    "distro": "centos",
                     "major_version": "8",
                     "arch": "ppc64le",
                     "repoid": "centos8-ha",
@@ -176,6 +191,7 @@
             "entries": [
                 {
                     "repo_type": "rpm",
+                    "distro": "centos",
                     "arch": "x86_64",
                     "major_version": "7",
                     "repoid": "updates",
@@ -183,6 +199,7 @@
                 },
                 {
                     "repo_type": "rpm",
+                    "distro": "centos",
                     "arch": "aarch64",
                     "major_version": "7",
                     "repoid": "updates",
@@ -190,6 +207,7 @@
                 },
                 {
                     "repo_type": "rpm",
+                    "distro": "centos",
                     "arch": "ppc64le",
                     "major_version": "7",
                     "repoid": "updates",
@@ -202,6 +220,7 @@
             "entries": [
                 {
                     "repo_type": "rpm",
+                    "distro": "centos",
                     "repoid": "extras",
                     "arch": "x86_64",
                     "major_version": "7",
@@ -209,6 +228,7 @@
                 },
                 {
                     "repo_type": "rpm",
+                    "distro": "centos",
                     "repoid": "extras",
                     "arch": "aarch64",
                     "major_version": "7",
@@ -216,6 +236,7 @@
                 },
                 {
                     "repo_type": "rpm",
+                    "distro": "centos",
                     "repoid": "extras",
                     "arch": "ppc64le",
                     "major_version": "7",
@@ -228,6 +249,7 @@
             "entries": [
                 {
                     "repo_type": "rpm",
+                    "distro": "centos",
                     "repoid": "centos8-extras",
                     "major_version": "8",
                     "arch": "x86_64",
@@ -235,6 +257,7 @@
                 },
                 {
                     "repo_type": "rpm",
+                    "distro": "centos",
                     "repoid": "centos8-extras",
                     "major_version": "8",
                     "arch": "aarch64",
@@ -242,6 +265,7 @@
                 },
                 {
                     "repo_type": "rpm",
+                    "distro": "centos",
                     "repoid": "centos8-extras",
                     "major_version": "8",
                     "arch": "ppc64le",
@@ -254,6 +278,7 @@
             "entries": [
                 {
                     "repo_type": "rpm",
+                    "distro": "centos",
                     "repoid": "centos8-rt",
                     "major_version": "8",
                     "arch": "x86_64",
@@ -266,6 +291,7 @@
             "entries": [
                 {
                     "repo_type": "rpm",
+                    "distro": "centos",
                     "repoid": "centos8-nfv",
                     "major_version": "8",
                     "arch": "x86_64",

--- a/files/centos/repomap.json.el9
+++ b/files/centos/repomap.json.el9
@@ -1,8 +1,8 @@
 {
-    "datetime": "2024101101250Z",
-    "version_format": "1.2.1",
+    "datetime": "202506241030Z",
+    "version_format": "1.3.0",
     "provided_data_streams": [
-        "3.0"
+        "4.0"
     ],
     "mapping": [
         {
@@ -62,6 +62,7 @@
                     "repoid": "baseos",
                     "major_version": "8",
                     "repo_type": "rpm",
+                    "distro": "centos",
                     "arch": "x86_64",
                     "channel": "ga"
                 },
@@ -69,6 +70,7 @@
                     "repoid": "baseos",
                     "major_version": "8",
                     "repo_type": "rpm",
+                    "distro": "centos",
                     "arch": "aarch64",
                     "channel": "ga"
                 },
@@ -76,6 +78,7 @@
                     "repoid": "baseos",
                     "major_version": "8",
                     "repo_type": "rpm",
+                    "distro": "centos",
                     "arch": "ppc64le",
                     "channel": "ga"
                 }
@@ -87,6 +90,7 @@
                 {
                     "major_version": "8",
                     "repo_type": "rpm",
+                    "distro": "centos",
                     "repoid": "appstream",
                     "arch": "x86_64",
                     "channel": "ga"
@@ -94,6 +98,7 @@
                 {
                     "major_version": "8",
                     "repo_type": "rpm",
+                    "distro": "centos",
                     "repoid": "appstream",
                     "arch": "aarch64",
                     "channel": "ga"
@@ -101,6 +106,7 @@
                 {
                     "major_version": "8",
                     "repo_type": "rpm",
+                    "distro": "centos",
                     "repoid": "appstream",
                     "arch": "ppc64le",
                     "channel": "ga"
@@ -114,6 +120,7 @@
                     "major_version": "8",
                     "repoid": "powertools",
                     "repo_type": "rpm",
+                    "distro": "centos",
                     "arch": "x86_64",
                     "channel": "ga"
                 },
@@ -121,6 +128,7 @@
                     "major_version": "8",
                     "repoid": "powertools",
                     "repo_type": "rpm",
+                    "distro": "centos",
                     "arch": "aarch64",
                     "channel": "ga"
                 },
@@ -128,6 +136,7 @@
                     "major_version": "8",
                     "repoid": "powertools",
                     "repo_type": "rpm",
+                    "distro": "centos",
                     "arch": "ppc64le",
                     "channel": "ga"
                 }
@@ -139,6 +148,7 @@
                 {
                     "major_version": "8",
                     "repo_type": "rpm",
+                    "distro": "centos",
                     "repoid": "ha",
                     "arch": "x86_64",
                     "channel": "ga"
@@ -146,6 +156,7 @@
                 {
                     "major_version": "8",
                     "repo_type": "rpm",
+                    "distro": "centos",
                     "repoid": "ha",
                     "arch": "aarch64",
                     "channel": "ga"
@@ -153,6 +164,7 @@
                 {
                     "major_version": "8",
                     "repo_type": "rpm",
+                    "distro": "centos",
                     "repoid": "ha",
                     "arch": "ppc64le",
                     "channel": "ga"
@@ -165,6 +177,7 @@
                 {
                     "major_version": "8",
                     "repo_type": "rpm",
+                    "distro": "centos",
                     "repoid": "extras",
                     "arch": "x86_64",
                     "channel": "ga"
@@ -172,6 +185,7 @@
                 {
                     "major_version": "8",
                     "repo_type": "rpm",
+                    "distro": "centos",
                     "repoid": "extras",
                     "arch": "aarch64",
                     "channel": "ga"
@@ -179,6 +193,7 @@
                 {
                     "major_version": "8",
                     "repo_type": "rpm",
+                    "distro": "centos",
                     "repoid": "extras",
                     "arch": "ppc64le",
                     "channel": "ga"
@@ -191,6 +206,7 @@
                 {
                     "major_version": "8",
                     "repo_type": "rpm",
+                    "distro": "centos",
                     "repoid": "rt",
                     "arch": "x86_64",
                     "channel": "ga"
@@ -203,6 +219,7 @@
                 {
                     "major_version": "8",
                     "repo_type": "rpm",
+                    "distro": "centos",
                     "repoid": "nfv",
                     "arch": "x86_64",
                     "channel": "ga"
@@ -216,6 +233,7 @@
                     "repoid": "centos9-baseos",
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "centos",
                     "arch": "x86_64",
                     "channel": "ga"
                 },
@@ -223,6 +241,7 @@
                     "repoid": "centos9-baseos",
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "centos",
                     "arch": "aarch64",
                     "channel": "ga"
                 },
@@ -230,6 +249,7 @@
                     "repoid": "centos9-baseos",
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "centos",
                     "arch": "ppc64le",
                     "channel": "ga"
                 }
@@ -241,6 +261,7 @@
                 {
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "centos",
                     "repoid": "centos9-appstream",
                     "arch": "x86_64",
                     "channel": "ga"
@@ -248,6 +269,7 @@
                 {
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "centos",
                     "repoid": "centos9-appstream",
                     "arch": "aarch64",
                     "channel": "ga"
@@ -255,6 +277,7 @@
                 {
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "centos",
                     "repoid": "centos9-appstream",
                     "arch": "ppc64le",
                     "channel": "ga"
@@ -268,6 +291,7 @@
                     "major_version": "9",
                     "repoid": "centos9-crb",
                     "repo_type": "rpm",
+                    "distro": "centos",
                     "arch": "x86_64",
                     "channel": "ga"
                 },
@@ -275,6 +299,7 @@
                     "major_version": "9",
                     "repoid": "centos9-crb",
                     "repo_type": "rpm",
+                    "distro": "centos",
                     "arch": "aarch64",
                     "channel": "ga"
                 },
@@ -282,6 +307,7 @@
                     "major_version": "9",
                     "repoid": "centos9-crb",
                     "repo_type": "rpm",
+                    "distro": "centos",
                     "arch": "ppc64le",
                     "channel": "ga"
                 }
@@ -293,6 +319,7 @@
                 {
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "centos",
                     "repoid": "centos9-ha",
                     "arch": "x86_64",
                     "channel": "ga"
@@ -300,6 +327,7 @@
                 {
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "centos",
                     "repoid": "centos9-ha",
                     "arch": "aarch64",
                     "channel": "ga"
@@ -307,6 +335,7 @@
                 {
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "centos",
                     "repoid": "centos9-ha",
                     "arch": "ppc64le",
                     "channel": "ga"
@@ -319,6 +348,7 @@
                 {
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "centos",
                     "repoid": "centos9-extras",
                     "arch": "x86_64",
                     "channel": "ga"
@@ -326,6 +356,7 @@
                 {
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "centos",
                     "repoid": "centos9-extras",
                     "arch": "aarch64",
                     "channel": "ga"
@@ -333,6 +364,7 @@
                 {
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "centos",
                     "repoid": "centos9-extras",
                     "arch": "ppc64le",
                     "channel": "ga"
@@ -345,6 +377,7 @@
                 {
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "centos",
                     "repoid": "centos9-rt",
                     "arch": "x86_64",
                     "channel": "ga"
@@ -357,6 +390,7 @@
                 {
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "centos",
                     "repoid": "centos9-nfv",
                     "arch": "x86_64",
                     "channel": "ga"

--- a/leapp-data.spec
+++ b/leapp-data.spec
@@ -1,9 +1,9 @@
-%global pes_events_build_date 20250505
+%global pes_events_build_date 20250624
 
 %define repositorydir %{_datadir}/leapp-repository/repositories
 
-%define dist_list almalinux almalinux-kitten centos oraclelinux rocky
-%define conflict_dists() %(for i in almalinux almalinux-kitten centos oraclelinux rocky; do if [ "${i}" != "%{dist_name}" ]; then echo -n "leapp-data-${i} "; fi; done)
+%define dist_list almalinux almalinux-kitten centos
+%define conflict_dists() %(for i in almalinux almalinux-kitten centos; do if [ "${i}" != "%{dist_name}" ]; then echo -n "leapp-data-${i} "; fi; done)
 
 %if 0%{?rhel} == 7
 %define supported_vendors epel imunify kernelcare mariadb nginx-stable nginx-mainline postgresql docker-ce imunify360-alt-php tuxcare
@@ -15,12 +15,6 @@
 %if %{dist_name} == "centos"
 %define gpg_key RPM-GPG-KEY-CentOS-Official
 %endif
-%if %{dist_name} == "oraclelinux"
-%define gpg_key RPM-GPG-KEY-oracle-ol8
-%endif
-%if %{dist_name} == "rocky"
-%define gpg_key RPM-GPG-KEY-Rocky-8
-%endif
 %endif
 %if 0%{?rhel} == 8
 %define supported_vendors epel kernelcare mariadb nginx-stable nginx-mainline postgresql docker-ce tuxcare
@@ -31,12 +25,6 @@
 %endif
 %if "%{dist_name}" == "centos"
 %define gpg_key RPM-GPG-KEY-CentOS-Official RPM-GPG-KEY-CentOS-SIG-Extras
-%endif
-%if "%{dist_name}" == "oraclelinux"
-%define gpg_key RPM-GPG-KEY-oracle-ol9
-%endif
-%if "%{dist_name}" == "rocky"
-%define gpg_key RPM-GPG-KEY-Rocky-9
 %endif
 %endif
 %if 0%{?rhel} == 9
@@ -58,8 +46,8 @@
 %bcond_without check
 
 Name:		leapp-data-%{dist_name}
-Version:	0.9
-Release:	4%{?dist}.%{pes_events_build_date}
+Version:	0.10
+Release:	1%{?dist}.%{pes_events_build_date}
 Summary:	data for migrating tool
 Group:		Applications/Databases
 License:	ASL 2.0
@@ -171,6 +159,14 @@ python3 tests/check_debranding.py %{buildroot}%{_sysconfdir}/leapp/files/pes-eve
 
 
 %changelog
+* Wed Jul 16 2025 Yuriy Kohut <ykohut@almalinux.org> - 0.10-1.20250624
+- Update all data into stream 4.0
+- Update all repomap files into new format version 1.3.0. Add 'distro' field
+- Rename Vendors' repositories mapping json files into templates and process them with generate_map_pes_files.sh
+- Update data to the upstream most recent state:
+ - PES data:
+  - pes-events.json: upstream state 2544f574969626bfe99cfd8aadd8eef36ecb2841
+- Bump the package version
 
 * Fri Jul 11 2025 Yuriy Kohut <ykohut@almalinux.org> - 0.9-4.20250505
 - New vendor, tuxcare

--- a/tools/device_driver_deprecation_data-update.sh
+++ b/tools/device_driver_deprecation_data-update.sh
@@ -9,10 +9,10 @@ dist_names="almalinux almalinux-kitten"
 parent_path=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )
 
 # Distros list to copy device driver deprecation data file for
-dists="centos oraclelinux rocky"
+dists="centos"
 
 # Data stream version, which is currently supported by ELevate
-provided_data_streams="3.3"
+provided_data_streams="4.0"
 
 # Date stamp to add to device driver deprecation data
 date_stamp=$(date -u '+%Y%m%d%H%M%S')

--- a/tools/generate_map_pes_files.sh
+++ b/tools/generate_map_pes_files.sh
@@ -11,13 +11,9 @@ major_ver=$2
 declare -A os_repos
 os_repos["almalinux7"]="almalinux8-appstream almalinux8-powertools almalinux8-baseos"
 os_repos["centos7"]="centos8-appstream centos8-powertools centos8-baseos"
-os_repos["oraclelinux7"]="ol8_appstream ol8_codeready_builder ol8-baseos"
-os_repos["rocky7"]="rocky8-appstream rocky8-powertools rocky8-baseos"
 
 os_repos["almalinux8"]="almalinux9-appstream almalinux9-crb almalinux9-baseos"
 os_repos["centos8"]="centos9-appstream centos9-crb centos9-baseos"
-os_repos["oraclelinux8"]="ol9_appstream ol9_codeready_builder ol9_baseos"
-os_repos["rocky8"]="rocky9-appstream rocky9-crb rocky9-baseos"
 
 os_repos["almalinux9"]="almalinux10-appstream almalinux10-crb almalinux10-baseos"
 # To generate data for leapp-data-almalinux-kitten package on AlmaLinux 9
@@ -28,8 +24,10 @@ declare -A os_name
 os_name["almalinux"]="AlmaLinux"
 os_name["almalinux-kitten"]="AlmaLinux"
 os_name["centos"]="CentOS"
-os_name["oraclelinux"]="OL"
-os_name["rocky"]="Rocky"
+
+# The 'distro' field in repomap files
+distro=$dist_name
+[[ $distro == almalinux-kitten* ]] && distro=almalinux
 
 case $major_ver in
     7)
@@ -47,21 +45,43 @@ esac
 epel_pes_file=vendors.d/epel_pes.json_template
 epel_map_file="vendors.d/epel_map.json_template.el${target_version}"
 microsoft_pes_file="vendors.d/microsoft_pes.json_template.el${target_version}"
+docker_ce_map_file="vendors.d/docker-ce_map.json_template.el${target_version}"
+imunify_map_file="vendors.d/imunify_map.json_template.el${target_version}"
+imunify360_alt_php_map_file="vendors.d/imunify360-alt-php_map.json_template.el${target_version}"
+kernelcare_map_file="vendors.d/kernelcare_map.json_template.el${target_version}"
+mariadb_map_file="vendors.d/mariadb_map.json_template.el${target_version}"
+microsoft_map_file="vendors.d/microsoft_map.json_template.el${target_version}"
+nginx_mainline_map_file="vendors.d/nginx-mainline_map.json_template.el${target_version}"
+nginx_stable_map_file="vendors.d/nginx-stable_map.json_template.el${target_version}"
+postgresql_map_file="vendors.d/postgresql_map.json_template.el${target_version}"
+tuxcare_map_file="vendors.d/tuxcare_map.json_template.el${target_version}"
 
 if [ -n "${os_repos[$dist_name$major_ver]}" ]; then
     IFS=' ' read -ra REPO <<< "${os_repos[$dist_name$major_ver]}"
-    for file in ${epel_map_file} ${epel_pes_file} ${microsoft_pes_file}; do
+    for file in ${epel_map_file} ${epel_pes_file} ${microsoft_pes_file} ${postgresql_map_file} ${nginx_stable_map_file} ${nginx_mainline_map_file} ${microsoft_map_file} ${mariadb_map_file} ${kernelcare_map_file} ${imunify360_alt_php_map_file} ${imunify_map_file} ${docker_ce_map_file}; do
         test -e "${file}" || continue
 
         sed -i "s/{appstream}/${REPO[0]}/g" "${file}"
         sed -i "s/{powertools}/${REPO[1]}/g" "${file}"
         sed -i "s/{baseos}/${REPO[2]}/g" "${file}"
         sed -i "s/{os_name}/${os_name[$dist_name]}/g" "${file}"
+        sed -i "s/{distro}/${distro}/g" "${file}"
     done
 
-    mv ${epel_pes_file} vendors.d/epel_pes.json
-    mv ${epel_map_file} vendors.d/epel_map.json
-    mv ${microsoft_pes_file} vendors.d/microsoft_pes.json || true
+    mv "${epel_pes_file}" vendors.d/epel_pes.json
+    mv "${epel_map_file}" vendors.d/epel_map.json
+    mv "${microsoft_pes_file}" vendors.d/microsoft_pes.json || true
+    mv "${microsoft_map_file}" vendors.d/microsoft_map.json || true
+    mv "${docker_ce_map_file}" vendors.d/docker-ce_map.json
+    mv "${imunify_map_file}" vendors.d/imunify_map.json || true
+    mv "${imunify360_alt_php_map_file}" vendors.d/imunify360-alt-php_map.json || true
+    mv "${kernelcare_map_file}" vendors.d/kernelcare_map.json || true
+    mv "${mariadb_map_file}" vendors.d/mariadb_map.json || true
+    mv "${nginx_mainline_map_file}" vendors.d/nginx_mainline_map.json || true
+    mv "${nginx_stable_map_file}" vendors.d/nginx-stable_map.json || true
+    mv "${postgresql_map_file}" vendors.d/postgresql_map.json
+    mv "${tuxcare_map_file}" vendors.d/tuxcare_map.json || true
+
 else
     echo "Unsupported OS"
     exit 1

--- a/tools/update_pes-events.py
+++ b/tools/update_pes-events.py
@@ -1,7 +1,7 @@
 import json
 import requests
 
-specific_commit = 'ffd6d8e456484630f99d98d5bff955914af02aa5'
+specific_commit = '2544f574969626bfe99cfd8aadd8eef36ecb2841'
 
 
 def download_pes_events(session, url):
@@ -130,7 +130,7 @@ def main():
         else:
             pes_events_url = 'https://raw.githubusercontent.com/oamg/leapp-repository/master/etc/leapp/files/pes-events.json'
 
-        for dist_name in ['almalinux', 'almalinux-kitten', 'oraclelinux', 'centos', 'rocky']:
+        for dist_name in ['almalinux', 'almalinux-kitten', 'centos']:
             print(f'Updating {dist_name}')
             pes_events_data = download_pes_events(session, pes_events_url)
             update_pes_events(dist_name, pes_events_data)

--- a/vendors.d/docker-ce_map.json_template.el10
+++ b/vendors.d/docker-ce_map.json_template.el10
@@ -1,6 +1,6 @@
 {
-    "datetime": "202412181645Z",
-    "version_format": "1.2.1",
+    "datetime": "202506241030Z",
+    "version_format": "1.3.0",
     "mapping": [
         {
             "source_major_version": "9",
@@ -36,21 +36,24 @@
                     "repoid": "docker-ce-stable",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "9",
                     "repoid": "docker-ce-stable",
                     "arch": "aarch64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "9",
                     "repoid": "docker-ce-stable",
                     "arch": "ppc64le",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 }
             ]
         },
@@ -62,21 +65,24 @@
                     "repoid": "docker-ce-test",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "9",
                     "repoid": "docker-ce-test",
                     "arch": "aarch64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "9",
                     "repoid": "docker-ce-test",
                     "arch": "ppc64le",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 }
             ]
         },
@@ -88,21 +94,24 @@
                     "repoid": "docker-ce-nightly",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "9",
                     "repoid": "docker-ce-nightly",
                     "arch": "aarch64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "9",
                     "repoid": "docker-ce-nightly",
                     "arch": "ppc64le",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 }
             ]
         },
@@ -114,14 +123,16 @@
                     "repoid": "el10-docker-ce-stable",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "10",
                     "repoid": "el10-docker-ce-stable",
                     "arch": "aarch64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 }
             ]
         },
@@ -133,22 +144,21 @@
                     "repoid": "el10-docker-ce-test",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "10",
                     "repoid": "el10-docker-ce-test",
                     "arch": "aarch64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 }
             ]
         }
     ],
     "provided_data_streams": [
-        "1.1",
-        "2.0",
-        "3.0",
-        "3.1"
+        "4.0"
     ]
 }

--- a/vendors.d/docker-ce_map.json_template.el8
+++ b/vendors.d/docker-ce_map.json_template.el8
@@ -1,6 +1,6 @@
 {
-    "datetime": "202410111720Z",
-    "version_format": "1.2.1",
+    "datetime": "202506241030Z",
+    "version_format": "1.3.0",
     "mapping": [
         {
             "source_major_version": "7",
@@ -36,21 +36,24 @@
                     "repoid": "docker-ce-stable",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "7",
                     "repoid": "docker-ce-stable",
                     "arch": "aarch64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "7",
                     "repoid": "docker-ce-stable",
                     "arch": "ppc64le",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 }
             ]
         },
@@ -62,21 +65,24 @@
                     "repoid": "docker-ce-test",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "7",
                     "repoid": "docker-ce-test",
                     "arch": "aarch64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "7",
                     "repoid": "docker-ce-test",
                     "arch": "ppc64le",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 }
             ]
         },
@@ -88,21 +94,24 @@
                     "repoid": "docker-ce-nightly",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "7",
                     "repoid": "docker-ce-nightly",
                     "arch": "aarch64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "7",
                     "repoid": "docker-ce-nightly",
                     "arch": "ppc64le",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 }
             ]
         },
@@ -114,21 +123,24 @@
                     "repoid": "el8-docker-ce-stable",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "8",
                     "repoid": "el8-docker-ce-stable",
                     "arch": "aarch64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "8",
                     "repoid": "el8-docker-ce-stable",
                     "arch": "ppc64le",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 }
             ]
         },
@@ -140,21 +152,24 @@
                     "repoid": "el8-docker-ce-test",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "8",
                     "repoid": "el8-docker-ce-test",
                     "arch": "aarch64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "8",
                     "repoid": "el8-docker-ce-test",
                     "arch": "ppc64le",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 }
             ]
         },
@@ -166,29 +181,29 @@
                     "repoid": "el8-docker-ce-nightly",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "8",
                     "repoid": "el8-docker-ce-nightly",
                     "arch": "aarch64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "8",
                     "repoid": "el8-docker-ce-nightly",
                     "arch": "ppc64le",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 }
             ]
         }
     ],
     "provided_data_streams": [
-        "1.1",
-        "2.0",
-        "3.0",
-        "3.1"
+        "4.0"
     ]
 }

--- a/vendors.d/docker-ce_map.json_template.el9
+++ b/vendors.d/docker-ce_map.json_template.el9
@@ -1,6 +1,6 @@
 {
-    "datetime": "202410111725Z",
-    "version_format": "1.2.1",
+    "datetime": "202506241030Z",
+    "version_format": "1.3.0",
     "mapping": [
         {
             "source_major_version": "8",
@@ -36,21 +36,24 @@
                     "repoid": "docker-ce-stable",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "8",
                     "repoid": "docker-ce-stable",
                     "arch": "aarch64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "8",
                     "repoid": "docker-ce-stable",
                     "arch": "ppc64le",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 }
             ]
         },
@@ -62,21 +65,24 @@
                     "repoid": "docker-ce-test",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "8",
                     "repoid": "docker-ce-test",
                     "arch": "aarch64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "8",
                     "repoid": "docker-ce-test",
                     "arch": "ppc64le",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 }
             ]
         },
@@ -88,21 +94,24 @@
                     "repoid": "docker-ce-nightly",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "8",
                     "repoid": "docker-ce-nightly",
                     "arch": "aarch64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "8",
                     "repoid": "docker-ce-nightly",
                     "arch": "ppc64le",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 }
             ]
         },
@@ -114,21 +123,24 @@
                     "repoid": "el9-docker-ce-stable",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "9",
                     "repoid": "el9-docker-ce-stable",
                     "arch": "aarch64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "9",
                     "repoid": "el9-docker-ce-stable",
                     "arch": "ppc64le",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 }
             ]
         },
@@ -140,21 +152,24 @@
                     "repoid": "el9-docker-ce-test",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "9",
                     "repoid": "el9-docker-ce-test",
                     "arch": "aarch64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "9",
                     "repoid": "el9-docker-ce-test",
                     "arch": "ppc64le",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 }
             ]
         },
@@ -166,29 +181,29 @@
                     "repoid": "el9-docker-ce-nightly",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "9",
                     "repoid": "el9-docker-ce-nightly",
                     "arch": "aarch64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "9",
                     "repoid": "el9-docker-ce-nightly",
                     "arch": "ppc64le",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 }
             ]
         }
     ],
     "provided_data_streams": [
-        "1.1",
-        "2.0",
-        "3.0",
-        "3.1"
+        "4.0"
     ]
 }

--- a/vendors.d/docker-ce_pes.json
+++ b/vendors.d/docker-ce_pes.json
@@ -2,9 +2,7 @@
     "legal_notice": "",
     "packageinfo": [],
     "provided_data_streams": [
-        "2.0",
-        "3.0",
-        "3.1"
+        "4.0"
     ],
-    "timestamp": "202408081321Z"
+    "timestamp": "202506241030Z"
 }

--- a/vendors.d/epel_map.json_template.el10
+++ b/vendors.d/epel_map.json_template.el10
@@ -1,6 +1,6 @@
 {
-    "datetime": "202412121200Z",
-    "version_format": "1.2.1",
+    "datetime": "202506241030Z",
+    "version_format": "1.3.0",
     "mapping": [
         {
             "source_major_version": "9",
@@ -42,28 +42,32 @@
                     "repoid": "epel",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "9",
                     "repoid": "epel",
                     "arch": "aarch64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "9",
                     "repoid": "epel",
                     "arch": "ppc64le",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "9",
                     "repoid": "epel",
                     "arch": "s390x",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 }
             ]
         },
@@ -75,28 +79,32 @@
                     "repoid": "el10-epel",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "10",
                     "repoid": "el10-epel",
                     "arch": "aarch64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "10",
                     "repoid": "el10-epel",
                     "arch": "ppc64le",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "10",
                     "repoid": "el10-epel",
                     "arch": "s390x",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 }
             ]
         },
@@ -108,28 +116,32 @@
                     "repoid": "{baseos}",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "10",
                     "repoid": "{baseos}",
                     "arch": "aarch64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "10",
                     "repoid": "{baseos}",
                     "arch": "ppc64le",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "10",
                     "repoid": "{baseos}",
                     "arch": "s390x",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 }
             ]
         },
@@ -141,28 +153,32 @@
                     "repoid": "{appstream}",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "10",
                     "repoid": "{appstream}",
                     "arch": "aarch64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "10",
                     "repoid": "{appstream}",
                     "arch": "ppc64le",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "10",
                     "repoid": "{appstream}",
                     "arch": "s390x",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 }
             ]
         },
@@ -174,36 +190,37 @@
                     "repoid": "{powertools}",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "10",
                     "repoid": "{powertools}",
                     "arch": "aarch64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "10",
                     "repoid": "{powertools}",
                     "arch": "ppc64le",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "10",
                     "repoid": "{powertools}",
                     "arch": "s390x",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 }
             ]
         }
     ],
     "provided_data_streams": [
-        "1.1",
-        "2.0",
-        "3.0",
-        "3.1"
+        "4.0"
     ]
 }

--- a/vendors.d/epel_map.json_template.el8
+++ b/vendors.d/epel_map.json_template.el8
@@ -1,6 +1,6 @@
 {
-    "datetime": "202410141150Z",
-    "version_format": "1.2.1",
+    "datetime": "202506241030Z",
+    "version_format": "1.3.0",
     "mapping": [
         {
             "source_major_version": "7",
@@ -48,21 +48,24 @@
                     "repoid": "epel",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "7",
                     "repoid": "epel",
                     "arch": "aarch64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "7",
                     "repoid": "epel",
                     "arch": "ppc64le",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 }
             ]
         },
@@ -74,28 +77,32 @@
                     "repoid": "el8-epel",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "8",
                     "repoid": "el8-epel",
                     "arch": "aarch64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "8",
                     "repoid": "el8-epel",
                     "arch": "ppc64le",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "8",
                     "repoid": "el8-epel",
                     "arch": "s390x",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 }
             ]
         },
@@ -107,21 +114,24 @@
                     "repoid": "base",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "7",
                     "repoid": "base",
                     "arch": "aarch64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "7",
                     "repoid": "base",
                     "arch": "ppc64le",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 }
             ]
         },
@@ -133,28 +143,32 @@
                     "repoid": "{appstream}",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "8",
                     "repoid": "{appstream}",
                     "arch": "aarch64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "8",
                     "repoid": "{appstream}",
                     "arch": "ppc64le",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "8",
                     "repoid": "{appstream}",
                     "arch": "s390x",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 }
             ]
         },
@@ -166,28 +180,32 @@
                     "repoid": "{powertools}",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "8",
                     "repoid": "{powertools}",
                     "arch": "aarch64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "8",
                     "repoid": "{powertools}",
                     "arch": "ppc64le",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "8",
                     "repoid": "{powertools}",
                     "arch": "s390x",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 }
             ]
         },
@@ -199,36 +217,37 @@
                     "repoid": "{baseos}",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "8",
                     "repoid": "{baseos}",
                     "arch": "aarch64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "8",
                     "repoid": "{baseos}",
                     "arch": "ppc64le",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "8",
                     "repoid": "{baseos}",
                     "arch": "s390x",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 }
             ]
         }
     ],
     "provided_data_streams": [
-        "1.1",
-        "2.0",
-        "3.0",
-        "3.1"
+        "4.0"
     ]
 }

--- a/vendors.d/epel_map.json_template.el9
+++ b/vendors.d/epel_map.json_template.el9
@@ -1,6 +1,6 @@
 {
-    "datetime": "202410141200Z",
-    "version_format": "1.2.1",
+    "datetime": "202506241030Z",
+    "version_format": "1.3.0",
     "mapping": [
         {
             "source_major_version": "8",
@@ -42,28 +42,32 @@
                     "repoid": "epel",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "8",
                     "repoid": "epel",
                     "arch": "aarch64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "8",
                     "repoid": "epel",
                     "arch": "ppc64le",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "8",
                     "repoid": "epel",
                     "arch": "s390x",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 }
             ]
         },
@@ -75,28 +79,32 @@
                     "repoid": "el9-epel",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "9",
                     "repoid": "el9-epel",
                     "arch": "aarch64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "9",
                     "repoid": "el9-epel",
                     "arch": "ppc64le",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "9",
                     "repoid": "el9-epel",
                     "arch": "s390x",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 }
             ]
         },
@@ -108,28 +116,32 @@
                     "repoid": "{baseos}",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "9",
                     "repoid": "{baseos}",
                     "arch": "aarch64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "9",
                     "repoid": "{baseos}",
                     "arch": "ppc64le",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "9",
                     "repoid": "{baseos}",
                     "arch": "s390x",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 }
             ]
         },
@@ -141,28 +153,32 @@
                     "repoid": "{appstream}",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "9",
                     "repoid": "{appstream}",
                     "arch": "aarch64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "9",
                     "repoid": "{appstream}",
                     "arch": "ppc64le",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "9",
                     "repoid": "{appstream}",
                     "arch": "s390x",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 }
             ]
         },
@@ -174,36 +190,37 @@
                     "repoid": "{powertools}",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "9",
                     "repoid": "{powertools}",
                     "arch": "aarch64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "9",
                     "repoid": "{powertools}",
                     "arch": "ppc64le",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "9",
                     "repoid": "{powertools}",
                     "arch": "s390x",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 }
             ]
         }
     ],
     "provided_data_streams": [
-        "1.1",
-        "2.0",
-        "3.0",
-        "3.1"
+        "4.0"
     ]
 }

--- a/vendors.d/epel_pes.json_template
+++ b/vendors.d/epel_pes.json_template
@@ -35333,7 +35333,7 @@
                         "repository": "el8-appstream"
                     }
                 ],
-                "set_id": 26221
+                "set_id": 36046
             },
             "release": {
                 "major_version": 8,
@@ -35358,7 +35358,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 26222
+                "set_id": 36047
             },
             "initial_release": {
                 "major_version": 7,
@@ -35374,7 +35374,7 @@
                         "repository": "el8-powertools"
                     }
                 ],
-                "set_id": 26223
+                "set_id": 36048
             },
             "release": {
                 "major_version": 8,
@@ -35399,7 +35399,7 @@
                         "repository": "epel"
                     }
                 ],
-                "set_id": 26224
+                "set_id": 36049
             },
             "initial_release": {
                 "major_version": 7,
@@ -252928,7 +252928,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 19605,
+            "id": 35773,
             "in_packageset": {
                 "package": [
                     {
@@ -252963,7 +252963,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 19606,
+            "id": 35774,
             "in_packageset": {
                 "package": [
                     {
@@ -252998,7 +252998,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 19607,
+            "id": 35775,
             "in_packageset": {
                 "package": [
                     {
@@ -253033,7 +253033,7 @@
                 "ppc64le"
             ],
             "description": "",
-            "id": 19608,
+            "id": 35776,
             "in_packageset": {
                 "package": [
                     {
@@ -353246,9 +353246,7 @@
         }
     ],
     "provided_data_streams": [
-        "2.0",
-        "3.0",
-        "3.1"
+        "4.0"
     ],
-    "timestamp": "202308241055Z"
+    "timestamp": "202506241030Z"
 }

--- a/vendors.d/imunify360-alt-php_map.json_template.el8
+++ b/vendors.d/imunify360-alt-php_map.json_template.el8
@@ -1,6 +1,6 @@
 {
-    "datetime": "202409180900Z",
-    "version_format": "1.2.1",
+    "datetime": "202506241030Z",
+    "version_format": "1.3.0",
     "mapping": [
         {
             "source_major_version": "7",
@@ -21,6 +21,7 @@
                     "repoid": "imunify360-alt-php",
                     "major_version": "7",
                     "repo_type": "rpm",
+                    "distro": "{distro}",
                     "arch": "x86_64",
                     "channel": "ga"
                 }
@@ -33,6 +34,7 @@
                     "repoid": "cloudlinux8-imunify360-alt-php",
                     "major_version": "8",
                     "repo_type": "rpm",
+                    "distro": "{distro}",
                     "arch": "x86_64",
                     "channel": "ga"
                 }

--- a/vendors.d/imunify360-alt-php_map.json_template.el9
+++ b/vendors.d/imunify360-alt-php_map.json_template.el9
@@ -1,6 +1,6 @@
 {
-    "datetime": "202409180900Z",
-    "version_format": "1.2.1",
+    "datetime": "202506241030Z",
+    "version_format": "1.3.0",
     "mapping": [
         {
             "source_major_version": "8",
@@ -21,6 +21,7 @@
                     "repoid": "imunify360-alt-php",
                     "major_version": "8",
                     "repo_type": "rpm",
+                    "distro": "{distro}",
                     "arch": "x86_64",
                     "channel": "ga"
                 }
@@ -33,6 +34,7 @@
                     "repoid": "cloudlinux9-imunify360-alt-php",
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "{distro}",
                     "arch": "x86_64",
                     "channel": "ga"
                 }

--- a/vendors.d/imunify360-alt-php_pes.json
+++ b/vendors.d/imunify360-alt-php_pes.json
@@ -3,9 +3,7 @@
     "packageinfo": [
     ],
     "provided_data_streams": [
-        "2.0",
-        "3.0",
-        "3.1"
+        "4.0"
     ],
-    "timestamp": "202409180900Z"
+    "timestamp": "202506241030Z"
 }

--- a/vendors.d/imunify_map.json_template.el8
+++ b/vendors.d/imunify_map.json_template.el8
@@ -1,6 +1,6 @@
 {
-    "datetime": "202204020934Z",
-    "version_format": "1.2.1",
+    "datetime": "202506241030Z",
+    "version_format": "1.3.0",
     "mapping": [
         {
             "source_major_version": "7",
@@ -33,6 +33,7 @@
                     "repoid": "imunify360",
                     "major_version": "7",
                     "repo_type": "rpm",
+                    "distro": "{distro}",
                     "arch": "x86_64",
                     "channel": "ga"
                 }
@@ -45,6 +46,7 @@
                     "repoid": "cloudlinux-imunify360",
                     "major_version": "7",
                     "repo_type": "rpm",
+                    "distro": "{distro}",
                     "arch": "x86_64",
                     "channel": "ga"
                 }
@@ -57,6 +59,7 @@
                     "repoid": "cloudlinux8-imunify360",
                     "major_version": "8",
                     "repo_type": "rpm",
+                    "distro": "{distro}",
                     "arch": "x86_64",
                     "channel": "ga"
                 }
@@ -69,6 +72,7 @@
                     "repoid": "imunify360-testing",
                     "major_version": "7",
                     "repo_type": "rpm",
+                    "distro": "{distro}",
                     "arch": "x86_64",
                     "channel": "beta"
                 }
@@ -81,6 +85,7 @@
                     "repoid": "cloudlinux-imunify360-testing",
                     "major_version": "7",
                     "repo_type": "rpm",
+                    "distro": "{distro}",
                     "arch": "x86_64",
                     "channel": "beta"
                 }
@@ -93,6 +98,7 @@
                     "repoid": "cloudlinux8-imunify360-testing",
                     "major_version": "8",
                     "repo_type": "rpm",
+                    "distro": "{distro}",
                     "arch": "x86_64",
                     "channel": "beta"
                 }

--- a/vendors.d/imunify_map.json_template.el9
+++ b/vendors.d/imunify_map.json_template.el9
@@ -1,6 +1,6 @@
 {
-    "datetime": "202204020934Z",
-    "version_format": "1.2.1",
+    "datetime": "202506241030Z",
+    "version_format": "1.3.0",
     "mapping": [
         {
             "source_major_version": "8",
@@ -33,6 +33,7 @@
                     "repoid": "imunify360",
                     "major_version": "8",
                     "repo_type": "rpm",
+                    "distro": "{distro}",
                     "arch": "x86_64",
                     "channel": "ga"
                 }
@@ -45,6 +46,7 @@
                     "repoid": "cloudlinux-imunify360",
                     "major_version": "8",
                     "repo_type": "rpm",
+                    "distro": "{distro}",
                     "arch": "x86_64",
                     "channel": "ga"
                 }
@@ -57,6 +59,7 @@
                     "repoid": "cloudlinux9-imunify360",
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "{distro}",
                     "arch": "x86_64",
                     "channel": "ga"
                 }
@@ -69,6 +72,7 @@
                     "repoid": "imunify360-testing",
                     "major_version": "8",
                     "repo_type": "rpm",
+                    "distro": "{distro}",
                     "arch": "x86_64",
                     "channel": "beta"
                 }
@@ -81,6 +85,7 @@
                     "repoid": "cloudlinux-imunify360-testing",
                     "major_version": "8",
                     "repo_type": "rpm",
+                    "distro": "{distro}",
                     "arch": "x86_64",
                     "channel": "beta"
                 }
@@ -93,6 +98,7 @@
                     "repoid": "cloudlinux9-imunify360-testing",
                     "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "{distro}",
                     "arch": "x86_64",
                     "channel": "beta"
                 }

--- a/vendors.d/imunify_pes.json
+++ b/vendors.d/imunify_pes.json
@@ -45,9 +45,7 @@
         }
     ],
     "provided_data_streams": [
-        "2.0",
-        "3.0",
-        "3.1"
+        "4.0"
     ],
-    "timestamp": "202409170900Z"
+    "timestamp": "202506241030Z"
 }

--- a/vendors.d/kernelcare_map.json_template.el8
+++ b/vendors.d/kernelcare_map.json_template.el8
@@ -1,15 +1,15 @@
 {
-    "datetime": "202204020934Z",
-    "version_format": "1.2.1",
+    "datetime": "202506241030Z",
+    "version_format": "1.3.0",
     "mapping": [
         {
-            "source_major_version": "8",
-            "target_major_version": "9",
+            "source_major_version": "7",
+            "target_major_version": "8",
             "entries": [
                 {
                     "source": "kernelcare",
                     "target": [
-                        "kernelcare-9"
+                        "kernelcare-8"
                     ]
                 }
             ]
@@ -21,34 +21,38 @@
             "entries": [
                 {
                     "repoid": "kernelcare",
-                    "major_version": "8",
+                    "major_version": "7",
                     "repo_type": "rpm",
+                    "distro": "{distro}",
                     "arch": "x86_64",
                     "channel": "ga"
                 },
                 {
                     "repoid": "kernelcare",
-                    "major_version": "8",
+                    "major_version": "7",
                     "repo_type": "rpm",
+                    "distro": "{distro}",
                     "arch": "aarch64",
                     "channel": "ga"
                 }
             ]
         },
         {
-            "pesid": "kernelcare-9",
+            "pesid": "kernelcare-8",
             "entries": [
                 {
-                    "repoid": "kernelcare-9",
-                    "major_version": "9",
+                    "repoid": "kernelcare-8",
+                    "major_version": "8",
                     "repo_type": "rpm",
+                    "distro": "{distro}",
                     "arch": "x86_64",
                     "channel": "ga"
                 },
                 {
-                    "repoid": "kernelcare-9",
-                    "major_version": "9",
+                    "repoid": "kernelcare-8",
+                    "major_version": "8",
                     "repo_type": "rpm",
+                    "distro": "{distro}",
                     "arch": "aarch64",
                     "channel": "ga"
                 }

--- a/vendors.d/kernelcare_map.json_template.el9
+++ b/vendors.d/kernelcare_map.json_template.el9
@@ -1,15 +1,15 @@
 {
-    "datetime": "202410111750Z",
-    "version_format": "1.2.1",
+    "datetime": "202506241030Z",
+    "version_format": "1.3.0",
     "mapping": [
         {
-            "source_major_version": "7",
-            "target_major_version": "8",
+            "source_major_version": "8",
+            "target_major_version": "9",
             "entries": [
                 {
                     "source": "kernelcare",
                     "target": [
-                        "kernelcare-8"
+                        "kernelcare-9"
                     ]
                 }
             ]
@@ -21,34 +21,38 @@
             "entries": [
                 {
                     "repoid": "kernelcare",
-                    "major_version": "7",
+                    "major_version": "8",
                     "repo_type": "rpm",
+                    "distro": "{distro}",
                     "arch": "x86_64",
                     "channel": "ga"
                 },
                 {
                     "repoid": "kernelcare",
-                    "major_version": "7",
+                    "major_version": "8",
                     "repo_type": "rpm",
+                    "distro": "{distro}",
                     "arch": "aarch64",
                     "channel": "ga"
                 }
             ]
         },
         {
-            "pesid": "kernelcare-8",
+            "pesid": "kernelcare-9",
             "entries": [
                 {
-                    "repoid": "kernelcare-8",
-                    "major_version": "8",
+                    "repoid": "kernelcare-9",
+                    "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "{distro}",
                     "arch": "x86_64",
                     "channel": "ga"
                 },
                 {
-                    "repoid": "kernelcare-8",
-                    "major_version": "8",
+                    "repoid": "kernelcare-9",
+                    "major_version": "9",
                     "repo_type": "rpm",
+                    "distro": "{distro}",
                     "arch": "aarch64",
                     "channel": "ga"
                 }

--- a/vendors.d/kernelcare_pes.json
+++ b/vendors.d/kernelcare_pes.json
@@ -2,9 +2,7 @@
     "legal_notice": "Copyright (c) 2022 CloudLinux Inc.",
     "packageinfo": [],
     "provided_data_streams": [
-        "2.0",
-        "3.0",
-        "3.1"
+        "4.0"
     ],
-    "timestamp": "202207130941Z"
+    "timestamp": "202506241030Z"
 }

--- a/vendors.d/mariadb_map.json_template.el8
+++ b/vendors.d/mariadb_map.json_template.el8
@@ -1,6 +1,6 @@
 {
-    "datetime": "202410111815Z",
-    "version_format": "1.2.1",
+    "datetime": "202506241030Z",
+    "version_format": "1.3.0",
     "mapping": [
         {
             "source_major_version": "7",
@@ -36,7 +36,8 @@
                     "repoid": "mariadb-main",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 }
             ]
         },
@@ -48,7 +49,8 @@
                     "repoid": "mariadb-maxscale",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 }
             ]
         },
@@ -60,7 +62,8 @@
                     "repoid": "mariadb-tools",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 }
             ]
         },
@@ -72,14 +75,16 @@
                     "repoid": "el8-mariadb-main",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "8",
                     "repoid": "el8-mariadb-main",
                     "arch": "aarch64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 }
             ]
         },
@@ -91,14 +96,16 @@
                     "repoid": "el8-mariadb-maxscale",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "8",
                     "repoid": "el8-mariadb-maxscale",
                     "arch": "aarch64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 }
             ]
         },
@@ -110,22 +117,21 @@
                     "repoid": "el8-mariadb-tools",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "8",
                     "repoid": "el8-mariadb-tools",
                     "arch": "aarch64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 }
             ]
         }
     ],
     "provided_data_streams": [
-        "1.1",
-        "2.0",
-        "3.0",
-        "3.1"
+        "4.0"
     ]
 }

--- a/vendors.d/mariadb_map.json_template.el9
+++ b/vendors.d/mariadb_map.json_template.el9
@@ -1,6 +1,6 @@
 {
-    "datetime": "202410111815Z",
-    "version_format": "1.2.1",
+    "datetime": "202506241030Z",
+    "version_format": "1.3.0",
     "mapping": [
         {
             "source_major_version": "8",
@@ -36,14 +36,16 @@
                     "repoid": "mariadb-main",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "8",
                     "repoid": "mariadb-main",
                     "arch": "aarch64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 }
             ]
         },
@@ -55,14 +57,16 @@
                     "repoid": "mariadb-maxscale",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "8",
                     "repoid": "mariadb-maxscale",
                     "arch": "aarch64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 }
             ]
         },
@@ -74,14 +78,16 @@
                     "repoid": "mariadb-tools",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "8",
                     "repoid": "mariadb-tools",
                     "arch": "aarch64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 }
             ]
         },
@@ -93,14 +99,16 @@
                     "repoid": "el9-mariadb-main",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "9",
                     "repoid": "el9-mariadb-main",
                     "arch": "aarch64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 }
             ]
         },
@@ -112,14 +120,16 @@
                     "repoid": "el9-mariadb-maxscale",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "9",
                     "repoid": "el9-mariadb-maxscale",
                     "arch": "aarch64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 }
             ]
         },
@@ -131,15 +141,13 @@
                     "repoid": "el9-mariadb-tools",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 }
             ]
         }
     ],
     "provided_data_streams": [
-        "1.1",
-        "2.0",
-        "3.0",
-        "3.1"
+        "4.0"
     ]
 }

--- a/vendors.d/mariadb_pes.json
+++ b/vendors.d/mariadb_pes.json
@@ -46,9 +46,7 @@
         }
     ],
     "provided_data_streams": [
-        "2.0",
-        "3.0",
-        "3.1"
+        "4.0"
     ],
-    "timestamp": "202308241055Z"
+    "timestamp": "202506241030Z"
 }

--- a/vendors.d/microsoft_map.json_template.el8
+++ b/vendors.d/microsoft_map.json_template.el8
@@ -1,6 +1,6 @@
 {
-    "datetime" : "202308301917Z",
-    "version_format" : "1.2.1",
+    "datetime" : "202506241030Z",
+    "version_format" : "1.3.0",
 
     "mapping" : [
         {
@@ -23,6 +23,7 @@
                     "repoid" : "packages-microsoft-com-prod",
                     "major_version" : "7",
                     "repo_type" : "rpm",
+                    "distro": "{distro}",
                     "arch" : "x86_64",
                     "channel" : "ga"
                 }
@@ -35,6 +36,7 @@
                     "repoid" : "packages-microsoft-com-prod-8",
                     "major_version" : "8",
                     "repo_type" : "rpm",
+                    "distro": "{distro}",
                     "arch" : "x86_64",
                     "channel" : "ga"
                 }

--- a/vendors.d/microsoft_map.json_template.el9
+++ b/vendors.d/microsoft_map.json_template.el9
@@ -1,6 +1,6 @@
 {
-    "datetime" : "202308301917Z",
-    "version_format" : "1.2.1",
+    "datetime" : "202506241030Z",
+    "version_format" : "1.3.0",
 
     "mapping" : [
         {
@@ -23,6 +23,7 @@
                     "repoid" : "packages-microsoft-com-prod",
                     "major_version" : "8",
                     "repo_type" : "rpm",
+                    "distro": "{distro}",
                     "arch" : "x86_64",
                     "channel" : "ga"
                 }
@@ -35,6 +36,7 @@
                     "repoid" : "packages-microsoft-com-prod-9",
                     "major_version" : "9",
                     "repo_type" : "rpm",
+                    "distro": "{distro}",
                     "arch" : "x86_64",
                     "channel" : "ga"
                 }

--- a/vendors.d/microsoft_pes.json_template.el8
+++ b/vendors.d/microsoft_pes.json_template.el8
@@ -1,5 +1,5 @@
 {
-    "timestamp": "202308301951Z",
+    "timestamp": "202506241030Z",
     "packageinfo": [
         {
             "id": 25872,
@@ -1438,9 +1438,7 @@
         }
     ],
     "provided_data_streams": [
-        "2.0",
-        "3.0",
-        "3.1"
+        "4.0"
     ],
-    "datetime": "202308301917Z"
+    "timestamp": "202506241030Z"
 }

--- a/vendors.d/microsoft_pes.json_template.el9
+++ b/vendors.d/microsoft_pes.json_template.el9
@@ -96,9 +96,7 @@
         }
     ],
     "provided_data_streams": [
-        "2.0",
-        "3.0",
-        "3.1"
+        "4.0"
     ],
-    "timestamp": "202308301951Z"
+    "timestamp": "202506241030Z"
 }

--- a/vendors.d/nginx-mainline_map.json_template.el8
+++ b/vendors.d/nginx-mainline_map.json_template.el8
@@ -1,10 +1,10 @@
 {
-    "datetime": "202410111830Z",
-    "version_format": "1.2.1",
+    "datetime": "202506241030Z",
+    "version_format": "1.3.0",
     "mapping": [
         {
-            "source_major_version": "8",
-            "target_major_version": "9",
+            "source_major_version": "7",
+            "target_major_version": "8",
             "entries": [
                 {
                     "source": "nginx-mainline",
@@ -20,25 +20,28 @@
             "pesid": "nginx-mainline",
             "entries": [
                 {
-                    "major_version": "8",
+                    "major_version": "7",
                     "repoid": "nginx-mainline",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
-                    "major_version": "8",
+                    "major_version": "7",
                     "repoid": "nginx-mainline",
                     "arch": "aarch64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
-                    "major_version": "8",
+                    "major_version": "7",
                     "repoid": "nginx-mainline",
-                    "arch": "s390x",
+                    "arch": "ppc64le",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 }
             ]
         },
@@ -46,33 +49,33 @@
             "pesid": "el8-nginx-mainline",
             "entries": [
                 {
-                    "major_version": "9",
+                    "major_version": "8",
                     "repoid": "el8-nginx-mainline",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
-                    "major_version": "9",
+                    "major_version": "8",
                     "repoid": "el8-nginx-mainline",
                     "arch": "aarch64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
-                    "major_version": "9",
+                    "major_version": "8",
                     "repoid": "el8-nginx-mainline",
                     "arch": "s390x",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 }
             ]
         }
     ],
     "provided_data_streams": [
-        "1.1",
-        "2.0",
-        "3.0",
-        "3.1"
+        "4.0"
     ]
 }

--- a/vendors.d/nginx-mainline_map.json_template.el9
+++ b/vendors.d/nginx-mainline_map.json_template.el9
@@ -1,10 +1,10 @@
 {
-    "datetime": "202410111825Z",
-    "version_format": "1.2.1",
+    "datetime": "202506241030Z",
+    "version_format": "1.3.0",
     "mapping": [
         {
-            "source_major_version": "7",
-            "target_major_version": "8",
+            "source_major_version": "8",
+            "target_major_version": "9",
             "entries": [
                 {
                     "source": "nginx-mainline",
@@ -20,25 +20,28 @@
             "pesid": "nginx-mainline",
             "entries": [
                 {
-                    "major_version": "7",
+                    "major_version": "8",
                     "repoid": "nginx-mainline",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
-                    "major_version": "7",
+                    "major_version": "8",
                     "repoid": "nginx-mainline",
                     "arch": "aarch64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
-                    "major_version": "7",
+                    "major_version": "8",
                     "repoid": "nginx-mainline",
-                    "arch": "ppc64le",
+                    "arch": "s390x",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 }
             ]
         },
@@ -46,33 +49,33 @@
             "pesid": "el8-nginx-mainline",
             "entries": [
                 {
-                    "major_version": "8",
+                    "major_version": "9",
                     "repoid": "el8-nginx-mainline",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
-                    "major_version": "8",
+                    "major_version": "9",
                     "repoid": "el8-nginx-mainline",
                     "arch": "aarch64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
-                    "major_version": "8",
+                    "major_version": "9",
                     "repoid": "el8-nginx-mainline",
                     "arch": "s390x",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 }
             ]
         }
     ],
     "provided_data_streams": [
-        "1.1",
-        "2.0",
-        "3.0",
-        "3.1"
+        "4.0"
     ]
 }

--- a/vendors.d/nginx-mainline_pes.json
+++ b/vendors.d/nginx-mainline_pes.json
@@ -2,9 +2,7 @@
     "legal_notice": "",
     "packageinfo": [],
     "provided_data_streams": [
-        "2.0",
-        "3.0",
-        "3.1"
+        "4.0"
     ],
-    "timestamp": "202308211027Z"
+    "timestamp": "202506241030Z"
 }

--- a/vendors.d/nginx-stable_map.json_template.el8
+++ b/vendors.d/nginx-stable_map.json_template.el8
@@ -1,15 +1,15 @@
 {
-    "datetime": "202410111835Z",
-    "version_format": "1.2.1",
+    "datetime": "202506241030Z",
+    "version_format": "1.3.0",
     "mapping": [
         {
-            "source_major_version": "8",
-            "target_major_version": "9",
+            "source_major_version": "7",
+            "target_major_version": "8",
             "entries": [
                 {
                     "source": "nginx-stable",
                     "target": [
-                        "el9-nginx-stable"
+                        "el8-nginx-stable"
                     ]
                 }
             ]
@@ -20,59 +20,62 @@
             "pesid": "nginx-stable",
             "entries": [
                 {
-                    "major_version": "8",
+                    "major_version": "7",
                     "repoid": "nginx-stable",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
-                    "major_version": "8",
+                    "major_version": "7",
                     "repoid": "nginx-stable",
                     "arch": "aarch64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
-                    "major_version": "8",
+                    "major_version": "7",
                     "repoid": "nginx-stable",
-                    "arch": "s390x",
+                    "arch": "ppc64le",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 }
             ]
         },
         {
-            "pesid": "el9-nginx-stable",
+            "pesid": "el8-nginx-stable",
             "entries": [
                 {
-                    "major_version": "9",
-                    "repoid": "el9-nginx-stable",
+                    "major_version": "8",
+                    "repoid": "el8-nginx-stable",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
-                    "major_version": "9",
-                    "repoid": "el9-nginx-stable",
+                    "major_version": "8",
+                    "repoid": "el8-nginx-stable",
                     "arch": "aarch64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
-                    "major_version": "9",
-                    "repoid": "el9-nginx-stable",
+                    "major_version": "8",
+                    "repoid": "el8-nginx-stable",
                     "arch": "s390x",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 }
             ]
         }
     ],
     "provided_data_streams": [
-        "1.1",
-        "2.0",
-        "3.0",
-        "3.1"
+        "4.0"
     ]
 }

--- a/vendors.d/nginx-stable_map.json_template.el9
+++ b/vendors.d/nginx-stable_map.json_template.el9
@@ -1,15 +1,15 @@
 {
-    "datetime": "202410111835Z",
-    "version_format": "1.2.1",
+    "datetime": "202506241030Z",
+    "version_format": "1.3.0",
     "mapping": [
         {
-            "source_major_version": "7",
-            "target_major_version": "8",
+            "source_major_version": "8",
+            "target_major_version": "9",
             "entries": [
                 {
                     "source": "nginx-stable",
                     "target": [
-                        "el8-nginx-stable"
+                        "el9-nginx-stable"
                     ]
                 }
             ]
@@ -20,59 +20,62 @@
             "pesid": "nginx-stable",
             "entries": [
                 {
-                    "major_version": "7",
+                    "major_version": "8",
                     "repoid": "nginx-stable",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
-                    "major_version": "7",
+                    "major_version": "8",
                     "repoid": "nginx-stable",
                     "arch": "aarch64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
-                    "major_version": "7",
+                    "major_version": "8",
                     "repoid": "nginx-stable",
-                    "arch": "ppc64le",
+                    "arch": "s390x",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 }
             ]
         },
         {
-            "pesid": "el8-nginx-stable",
+            "pesid": "el9-nginx-stable",
             "entries": [
                 {
-                    "major_version": "8",
-                    "repoid": "el8-nginx-stable",
+                    "major_version": "9",
+                    "repoid": "el9-nginx-stable",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
-                    "major_version": "8",
-                    "repoid": "el8-nginx-stable",
+                    "major_version": "9",
+                    "repoid": "el9-nginx-stable",
                     "arch": "aarch64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
-                    "major_version": "8",
-                    "repoid": "el8-nginx-stable",
+                    "major_version": "9",
+                    "repoid": "el9-nginx-stable",
                     "arch": "s390x",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 }
             ]
         }
     ],
     "provided_data_streams": [
-        "1.1",
-        "2.0",
-        "3.0",
-        "3.1"
+        "4.0"
     ]
 }

--- a/vendors.d/nginx-stable_pes.json
+++ b/vendors.d/nginx-stable_pes.json
@@ -2,9 +2,7 @@
     "legal_notice": "",
     "packageinfo": [],
     "provided_data_streams": [
-        "2.0",
-        "3.0",
-        "3.1"
+        "4.0"
     ],
-    "timestamp": "202308211027Z"
+    "timestamp": "202506241030Z"
 }

--- a/vendors.d/postgresql_map.json_template.el10
+++ b/vendors.d/postgresql_map.json_template.el10
@@ -1,6 +1,6 @@
 {
-    "datetime": "202505281525Z",
-    "version_format": "1.2.1",
+    "datetime": "202506241030Z",
+    "version_format": "1.3.0",
     "mapping": [
         {
             "source_major_version": "9",
@@ -59,14 +59,16 @@
                     "repoid": "pgdg-common",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "9",
                     "repoid": "pgdg-common",
                     "arch": "aarch64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 }
             ]
         },
@@ -78,14 +80,16 @@
                     "repoid": "pgdg17",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "9",
                     "repoid": "pgdg17",
                     "arch": "aarch64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 }
             ]
         },
@@ -97,14 +101,16 @@
                     "repoid": "pgdg16",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "9",
                     "repoid": "pgdg16",
                     "arch": "aarch64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 }
             ]
         },
@@ -116,14 +122,16 @@
                     "repoid": "pgdg15",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "9",
                     "repoid": "pgdg15",
                     "arch": "aarch64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 }
             ]
         },
@@ -135,14 +143,16 @@
                     "repoid": "pgdg14",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "9",
                     "repoid": "pgdg14",
                     "arch": "aarch64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 }
             ]
         },
@@ -154,14 +164,16 @@
                     "repoid": "pgdg13",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "9",
                     "repoid": "pgdg13",
                     "arch": "aarch64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 }
             ]
         },
@@ -173,14 +185,16 @@
                     "repoid": "el10-pgdg-common",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "10",
                     "repoid": "el10-pgdg-common",
                     "arch": "aarch64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 }
             ]
         },
@@ -192,14 +206,16 @@
                     "repoid": "el10-pgdg17",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "10",
                     "repoid": "el10-pgdg17",
                     "arch": "aarch64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 }
             ]
         },
@@ -211,14 +227,16 @@
                     "repoid": "el10-pgdg16",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "10",
                     "repoid": "el10-pgdg16",
                     "arch": "aarch64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 }
             ]
         },
@@ -230,14 +248,16 @@
                     "repoid": "el10-pgdg15",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "10",
                     "repoid": "el10-pgdg15",
                     "arch": "aarch64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 }
             ]
         },
@@ -249,14 +269,16 @@
                     "repoid": "el10-pgdg14",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "10",
                     "repoid": "el10-pgdg14",
                     "arch": "aarch64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 }
             ]
         },
@@ -268,14 +290,16 @@
                     "repoid": "el10-pgdg13",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "10",
                     "repoid": "el10-pgdg13",
                     "arch": "aarch64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 }
             ]
         },
@@ -287,22 +311,21 @@
                     "repoid": "el10-pgdg-rhel10-extras",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "10",
                     "repoid": "el10-pgdg-rhel10-extras",
                     "arch": "aarch64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 }
             ]
         }
     ],
     "provided_data_streams": [
-        "1.1",
-        "2.0",
-        "3.0",
-        "3.1"
+        "4.0"
     ]
 }

--- a/vendors.d/postgresql_map.json_template.el8
+++ b/vendors.d/postgresql_map.json_template.el8
@@ -1,6 +1,6 @@
 {
-    "datetime": "202410141100Z",
-    "version_format": "1.2.1",
+    "datetime": "202506241030Z",
+    "version_format": "1.3.0",
     "mapping": [
         {
             "source_major_version": "7",
@@ -64,21 +64,24 @@
                     "repoid": "pgdg-common",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "7",
                     "repoid": "pgdg-common",
                     "arch": "aarch64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "7",
                     "repoid": "pgdg-common",
                     "arch": "ppc64le",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 }
             ]
         },
@@ -90,21 +93,24 @@
                     "repoid": "pgdg15",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "7",
                     "repoid": "pgdg15",
                     "arch": "aarch64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "7",
                     "repoid": "pgdg15",
                     "arch": "ppc64le",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 }
             ]
         },
@@ -116,21 +122,24 @@
                     "repoid": "pgdg14",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "7",
                     "repoid": "pgdg14",
                     "arch": "aarch64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "7",
                     "repoid": "pgdg14",
                     "arch": "ppc64le",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 }
             ]
         },
@@ -142,21 +151,24 @@
                     "repoid": "pgdg13",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "7",
                     "repoid": "pgdg13",
                     "arch": "aarch64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "7",
                     "repoid": "pgdg13",
                     "arch": "ppc64le",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 }
             ]
         },
@@ -168,21 +180,24 @@
                     "repoid": "pgdg12",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "7",
                     "repoid": "pgdg12",
                     "arch": "aarch64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "7",
                     "repoid": "pgdg12",
                     "arch": "ppc64le",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 }
             ]
         },
@@ -194,21 +209,24 @@
                     "repoid": "pgdg11",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "7",
                     "repoid": "pgdg11",
                     "arch": "aarch64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "7",
                     "repoid": "pgdg11",
                     "arch": "ppc64le",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 }
             ]
         },
@@ -220,21 +238,24 @@
                     "repoid": "el8-pgdg-common",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "8",
                     "repoid": "el8-pgdg-common",
                     "arch": "aarch64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "8",
                     "repoid": "el8-pgdg-common",
                     "arch": "ppc64le",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 }
             ]
         },
@@ -246,21 +267,24 @@
                     "repoid": "el8-pgdg15",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "8",
                     "repoid": "el8-pgdg15",
                     "arch": "aarch64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "8",
                     "repoid": "el8-pgdg15",
                     "arch": "ppc64le",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 }
             ]
         },
@@ -272,21 +296,24 @@
                     "repoid": "el8-pgdg14",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "8",
                     "repoid": "el8-pgdg14",
                     "arch": "aarch64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "8",
                     "repoid": "el8-pgdg14",
                     "arch": "ppc64le",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 }
             ]
         },
@@ -298,21 +325,24 @@
                     "repoid": "el8-pgdg13",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "8",
                     "repoid": "el8-pgdg13",
                     "arch": "aarch64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "8",
                     "repoid": "el8-pgdg13",
                     "arch": "ppc64le",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 }
             ]
         },
@@ -324,21 +354,24 @@
                     "repoid": "el8-pgdg12",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "8",
                     "repoid": "el8-pgdg12",
                     "arch": "aarch64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "8",
                     "repoid": "el8-pgdg12",
                     "arch": "ppc64le",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 }
             ]
         },
@@ -350,21 +383,24 @@
                     "repoid": "el8-pgdg11",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "8",
                     "repoid": "el8-pgdg11",
                     "arch": "aarch64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "8",
                     "repoid": "el8-pgdg11",
                     "arch": "ppc64le",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 }
             ]
         },
@@ -376,21 +412,24 @@
                     "repoid": "el8-pgdg-centos8-sysupdates",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "8",
                     "repoid": "el8-pgdg-centos8-sysupdates",
                     "arch": "aarch64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "8",
                     "repoid": "el8-pgdg-centos8-sysupdates",
                     "arch": "ppc64le",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 }
             ]
         },
@@ -402,29 +441,29 @@
                     "repoid": "el8-pgdg-rhel8-extras",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "8",
                     "repoid": "el8-pgdg-rhel8-extras",
                     "arch": "aarch64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "8",
                     "repoid": "el8-pgdg-rhel8-extras",
                     "arch": "ppc64le",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 }
             ]
         }
     ],
     "provided_data_streams": [
-        "1.1",
-        "2.0",
-        "3.0",
-        "3.1"
+        "4.0"
     ]
 }

--- a/vendors.d/postgresql_map.json_template.el9
+++ b/vendors.d/postgresql_map.json_template.el9
@@ -1,6 +1,6 @@
 {
-    "datetime": "202410141110Z",
-    "version_format": "1.2.1",
+    "datetime": "202506241030Z",
+    "version_format": "1.3.0",
     "mapping": [
         {
             "source_major_version": "8",
@@ -80,21 +80,24 @@
                     "repoid": "pgdg-common",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "8",
                     "repoid": "pgdg-common",
                     "arch": "aarch64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "8",
                     "repoid": "pgdg-common",
                     "arch": "ppc64le",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 }
             ]
         },
@@ -106,14 +109,16 @@
                     "repoid": "pgdg17",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "8",
                     "repoid": "pgdg17",
                     "arch": "aarch64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 }
             ]
         },
@@ -125,21 +130,24 @@
                     "repoid": "pgdg16",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "8",
                     "repoid": "pgdg16",
                     "arch": "aarch64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "8",
                     "repoid": "pgdg16",
                     "arch": "ppc64le",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 }
             ]
         },
@@ -151,21 +159,24 @@
                     "repoid": "pgdg15",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "8",
                     "repoid": "pgdg15",
                     "arch": "aarch64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "8",
                     "repoid": "pgdg15",
                     "arch": "ppc64le",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 }
             ]
         },
@@ -177,21 +188,24 @@
                     "repoid": "pgdg14",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "8",
                     "repoid": "pgdg14",
                     "arch": "aarch64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "8",
                     "repoid": "pgdg14",
                     "arch": "ppc64le",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 }
             ]
         },
@@ -203,21 +217,24 @@
                     "repoid": "pgdg13",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "8",
                     "repoid": "pgdg13",
                     "arch": "aarch64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "8",
                     "repoid": "pgdg13",
                     "arch": "ppc64le",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 }
             ]
         },
@@ -229,21 +246,24 @@
                     "repoid": "pgdg12",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "8",
                     "repoid": "pgdg12",
                     "arch": "aarch64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "8",
                     "repoid": "pgdg12",
                     "arch": "ppc64le",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 }
             ]
         },
@@ -255,21 +275,24 @@
                     "repoid": "pgdg11",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "8",
                     "repoid": "pgdg11",
                     "arch": "aarch64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "8",
                     "repoid": "pgdg11",
                     "arch": "ppc64le",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 }
             ]
         },
@@ -281,14 +304,16 @@
                     "repoid": "el9-pgdg-common",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "9",
                     "repoid": "el9-pgdg-common",
                     "arch": "aarch64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 }
             ]
         },
@@ -300,14 +325,16 @@
                     "repoid": "el9-pgdg17",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "9",
                     "repoid": "el9-pgdg17",
                     "arch": "aarch64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 }
             ]
         },
@@ -319,14 +346,16 @@
                     "repoid": "el9-pgdg16",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "9",
                     "repoid": "el9-pgdg16",
                     "arch": "aarch64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 }
             ]
         },
@@ -338,14 +367,16 @@
                     "repoid": "el9-pgdg15",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "9",
                     "repoid": "el9-pgdg15",
                     "arch": "aarch64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 }
             ]
         },
@@ -357,14 +388,16 @@
                     "repoid": "el9-pgdg14",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "9",
                     "repoid": "el9-pgdg14",
                     "arch": "aarch64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 }
             ]
         },
@@ -376,14 +409,16 @@
                     "repoid": "el9-pgdg13",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "9",
                     "repoid": "el9-pgdg13",
                     "arch": "aarch64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 }
             ]
         },
@@ -395,14 +430,16 @@
                     "repoid": "el9-pgdg12",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "9",
                     "repoid": "el9-pgdg12",
                     "arch": "aarch64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 }
             ]
         },
@@ -414,14 +451,16 @@
                     "repoid": "el9-pgdg11",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "9",
                     "repoid": "el9-pgdg11",
                     "arch": "aarch64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 }
             ]
         },
@@ -433,7 +472,8 @@
                     "repoid": "el9-pgdg-rocky9-sysupdates",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 }
             ]
         },
@@ -445,22 +485,21 @@
                     "repoid": "el9-pgdg-rhel9-extras",
                     "arch": "x86_64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 },
                 {
                     "major_version": "9",
                     "repoid": "el9-pgdg-rhel9-extras",
                     "arch": "aarch64",
                     "channel": "ga",
-                    "repo_type": "rpm"
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 }
             ]
         }
     ],
     "provided_data_streams": [
-        "1.1",
-        "2.0",
-        "3.0",
-        "3.1"
+        "4.0"
     ]
 }

--- a/vendors.d/postgresql_pes.json
+++ b/vendors.d/postgresql_pes.json
@@ -2,9 +2,7 @@
     "legal_notice": "",
     "packageinfo": [],
     "provided_data_streams": [
-        "2.0",
-        "3.0",
-        "3.1"
+        "4.0"
     ],
-    "timestamp": "202306191746Z"
+    "timestamp": "202506241030Z"
 }

--- a/vendors.d/tuxcare_map.json_template.el10
+++ b/vendors.d/tuxcare_map.json_template.el10
@@ -1,6 +1,6 @@
 {
     "datetime": "2025071001300Z",
-    "version_format": "1.2.1",
+    "version_format": "1.3.0",
     "mapping": [
         {
             "source_major_version": "9",
@@ -22,7 +22,8 @@
                     "major_version": "9",
                     "repo_type": "rpm",
                     "arch": "x86_64",
-                    "channel": "ga"
+                    "channel": "ga",
+                    "distro": "{distro}"
                 }
             ]
         },
@@ -34,13 +35,14 @@
                     "major_version": "10",
                     "repo_type": "rpm",
                     "arch": "x86_64",
-                    "channel": "ga"
+                    "channel": "ga",
+                    "distro": "{distro}"
                 }
             ]
         }
 
     ],
     "provided_data_streams": [
-        "3.3"
+        "4.0"
     ]
 }

--- a/vendors.d/tuxcare_map.json_template.el8
+++ b/vendors.d/tuxcare_map.json_template.el8
@@ -1,6 +1,6 @@
 {
     "datetime": "2025071001300Z",
-    "version_format": "1.2.1",
+    "version_format": "1.3.0",
     "mapping": [
         {
             "source_major_version": "7",
@@ -22,7 +22,8 @@
                     "major_version": "7",
                     "repo_type": "rpm",
                     "arch": "x86_64",
-                    "channel": "ga"
+                    "channel": "ga",
+                    "distro": "{distro}"
                 }
             ]
         },
@@ -34,12 +35,13 @@
                     "major_version": "8",
                     "repo_type": "rpm",
                     "arch": "x86_64",
-                    "channel": "ga"
+                    "channel": "ga",
+                    "distro": "{distro}"
                 }
             ]
         }
     ],
     "provided_data_streams": [
-        "3.3"
+        "4.0"
     ]
 }

--- a/vendors.d/tuxcare_map.json_template.el9
+++ b/vendors.d/tuxcare_map.json_template.el9
@@ -1,6 +1,6 @@
 {
     "datetime": "2025071001300Z",
-    "version_format": "1.2.1",
+    "version_format": "1.3.0",
     "mapping": [
         {
             "source_major_version": "8",
@@ -22,7 +22,8 @@
                     "major_version": "8",
                     "repo_type": "rpm",
                     "arch": "x86_64",
-                    "channel": "ga"
+                    "channel": "ga",
+                    "distro": "{distro}"
                 }
             ]
         },
@@ -34,12 +35,13 @@
                     "major_version": "9",
                     "repo_type": "rpm",
                     "arch": "x86_64",
-                    "channel": "ga"
+                    "channel": "ga",
+                    "distro": "{distro}"
                 }
             ]
         }
     ],
     "provided_data_streams": [
-        "3.3"
+        "4.0"
     ]
 }

--- a/vendors.d/tuxcare_pes.json
+++ b/vendors.d/tuxcare_pes.json
@@ -2,7 +2,7 @@
     "legal_notice": "",
     "packageinfo": [],
     "provided_data_streams": [
-        "3.3"
+        "4.0"
     ],
     "timestamp": "202507101300Z"
 }


### PR DESCRIPTION
- Update all data into stream 4.0.

- Update all repomap files into new format version 1.3.0. Add `distro` field. The field's value in Kitten repomap files is `almalinux`.

- Rename Vendors' repositories mapping json files into templates and process them with `generate_map_pes_files.sh`.

- Update data to the upstream most recent version 0.22.0-4 ([2544f574969626bfe99cfd8aadd8eef36ecb2841](https://github.com/oamg/leapp-repository/commit/2544f574969626bfe99cfd8aadd8eef36ecb2841)).

- Bump the package version.