### PR TITLE
Correct vendor PostgreSQL repositories [Data stream 3.x, EL7 packages]

### DIFF
--- a/.github/workflows/elevate.yml
+++ b/.github/workflows/elevate.yml
@@ -398,6 +398,8 @@ jobs:
           case ${source_release} in
             7)
               sudo dnf -y -q install epel-release;;
+              # TODO: switch "PostgreSQL 12 for RHEL / CentOS" repository into yum-archive.postgresql.org
+              sed -i 's#download.postgresql.org/pub/repos/yum/12/#yum-archive.postgresql.org/12/#g' /etc/yum.repos.d/pgdg-redhat-all.repo
             8)
               sudo dnf -y -q module disable postgresql;;
           esac

--- a/leapp-data.spec
+++ b/leapp-data.spec
@@ -52,7 +52,7 @@
 
 Name:		leapp-data-%{dist_name}
 Version:	0.6
-Release:	10%{?dist}.%{pes_events_build_date}
+Release:	11%{?dist}.%{pes_events_build_date}
 Summary:	data for migrating tool
 Group:		Applications/Databases
 License:	ASL 2.0
@@ -177,6 +177,9 @@ python3 tests/check_debranding.py %{buildroot}%{_sysconfdir}/leapp/files/pes-eve
 
 
 %changelog
+* Fri Jan 16 2026 Yuriy Kohut <ykohut@almalinux.org> - 0.6-11.20241127
+- Vendor PostgreSQL: remove Supplementary ucommon RPMs (sysupdates) repositories
+
 * Wed Nov 26 2025 Yuriy Kohut <ykohut@almalinux.org> - 0.6-10.20241127
 - Vendor PostgreSQL: correct extras repository base url
 

--- a/leapp-data.spec
+++ b/leapp-data.spec
@@ -177,8 +177,10 @@ python3 tests/check_debranding.py %{buildroot}%{_sysconfdir}/leapp/files/pes-eve
 
 
 %changelog
-* Fri Jan 16 2026 Yuriy Kohut <ykohut@almalinux.org> - 0.6-11.20241127
-- Vendor PostgreSQL: remove Supplementary ucommon RPMs (sysupdates) repositories
+* Mon Jan 19 2026 Yuriy Kohut <ykohut@almalinux.org> - 0.6-11.20241127
+- Vendor PostgreSQL:
+ - remove Supplementary ucommon RPMs (sysupdates) repositories
+ - switch "PostgreSQL 12 for RHEL / CentOS" repositories into yum-archive.postgresql.org
 
 * Wed Nov 26 2025 Yuriy Kohut <ykohut@almalinux.org> - 0.6-10.20241127
 - Vendor PostgreSQL: correct extras repository base url

--- a/vendors.d/postgresql.repo.el8
+++ b/vendors.d/postgresql.repo.el8
@@ -55,7 +55,7 @@ module_hotfixes=true
 
 [el8-pgdg12]
 name=PostgreSQL 12 for RHEL / Rocky 8 - $basearch
-baseurl=https://download.postgresql.org/pub/repos/yum/12/redhat/rhel-8-$basearch
+baseurl=https://yum-archive.postgresql.org/12/redhat/rhel-8-$basearch
 enabled=1
 gpgcheck=1
 gpgkey=file:///etc/leapp/files/vendors.d/rpm-gpg/postgresql.gpg

--- a/vendors.d/postgresql.repo.el8
+++ b/vendors.d/postgresql.repo.el8
@@ -12,20 +12,6 @@ gpgcheck=1
 gpgkey=file:///etc/leapp/files/vendors.d/rpm-gpg/postgresql.gpg
 module_hotfixes=true
 
-
-# Red Hat recently breaks compatibility between 8.n and 8.n+1. PGDG repo is
-# affected with the LLVM packages. This is a band aid repo for the llvmjit users
-# whose installations cannot be updated.
-
-[el8-pgdg-centos8-sysupdates]
-name=PostgreSQL Supplementary ucommon RPMs for RHEL / Rocky 8 - $basearch
-baseurl=https://download.postgresql.org/pub/repos/yum/common/pgdg-centos8-sysupdates/redhat/rhel-8-$basearch
-enabled=0
-gpgcheck=1
-gpgkey=file:///etc/leapp/files/vendors.d/rpm-gpg/postgresql.gpg
-module_hotfixes=true
-
-
 # We provide extra package to support some RPMs in the PostgreSQL RPM repo, like
 # consul, haproxy, etc.
 

--- a/vendors.d/postgresql.repo.el9
+++ b/vendors.d/postgresql.repo.el9
@@ -11,17 +11,6 @@ enabled=1
 gpgcheck=1
 gpgkey=file:///etc/leapp/files/vendors.d/rpm-gpg/postgresql.gpg
 
-# Red Hat recently breaks compatibility between 8.n and 8.n+1. PGDG repo is
-# affected with the LLVM packages. This is a band aid repo for the llvmjit users
-# whose installations cannot be updated.
-
-[el9-pgdg-rocky9-sysupdates]
-name=PostgreSQL Supplementary ucommon RPMs for RHEL / Rocky / AlmaLinux 9 - $basearch
-baseurl=https://download.postgresql.org/pub/repos/yum/common/pgdg-rocky9-sysupdates/redhat/rhel-9-x86_64
-enabled=0
-gpgcheck=1
-gpgkey=file:///etc/leapp/files/vendors.d/rpm-gpg/postgresql.gpg
-
 # We provide extra package to support some RPMs in the PostgreSQL RPM repo, like
 # consul, haproxy, etc.
 

--- a/vendors.d/postgresql.repo.el9
+++ b/vendors.d/postgresql.repo.el9
@@ -60,7 +60,7 @@ gpgkey=file:///etc/leapp/files/vendors.d/rpm-gpg/postgresql.gpg
 
 [el9-pgdg12]
 name=PostgreSQL 12 for RHEL / Rocky / AlmaLinux 9 - $basearch
-baseurl=https://download.postgresql.org/pub/repos/yum/12/redhat/rhel-9-$basearch
+baseurl=https://yum-archive.postgresql.org/12/redhat/rhel-9-$basearch
 enabled=1
 gpgcheck=1
 gpgkey=file:///etc/leapp/files/vendors.d/rpm-gpg/postgresql.gpg

--- a/vendors.d/postgresql_map.json.el8
+++ b/vendors.d/postgresql_map.json.el8
@@ -16,7 +16,6 @@
                     "source": "pgdg15",
                     "target": [
                         "el8-pgdg15",
-                        "el8-pgdg-centos8-sysupdates",
                         "el8-pgdg-rhel8-extras"
                     ]
                 },
@@ -24,7 +23,6 @@
                     "source": "pgdg14",
                     "target": [
                         "el8-pgdg14",
-                        "el8-pgdg-centos8-sysupdates",
                         "el8-pgdg-rhel8-extras"
                     ]
                 },
@@ -32,7 +30,6 @@
                     "source": "pgdg13",
                     "target": [
                         "el8-pgdg13",
-                        "el8-pgdg-centos8-sysupdates",
                         "el8-pgdg-rhel8-extras"
                     ]
                 },
@@ -40,7 +37,6 @@
                     "source": "pgdg12",
                     "target": [
                         "el8-pgdg12",
-                        "el8-pgdg-centos8-sysupdates",
                         "el8-pgdg-rhel8-extras"
                     ]
                 },
@@ -48,7 +44,6 @@
                     "source": "pgdg11",
                     "target": [
                         "el8-pgdg11",
-                        "el8-pgdg-centos8-sysupdates",
                         "el8-pgdg-rhel8-extras"
                     ]
                 }
@@ -362,32 +357,6 @@
                 {
                     "major_version": "8",
                     "repoid": "el8-pgdg11",
-                    "arch": "ppc64le",
-                    "channel": "ga",
-                    "repo_type": "rpm"
-                }
-            ]
-        },
-        {
-            "pesid": "el8-pgdg-centos8-sysupdates",
-            "entries": [
-                {
-                    "major_version": "8",
-                    "repoid": "el8-pgdg-centos8-sysupdates",
-                    "arch": "x86_64",
-                    "channel": "ga",
-                    "repo_type": "rpm"
-                },
-                {
-                    "major_version": "8",
-                    "repoid": "el8-pgdg-centos8-sysupdates",
-                    "arch": "aarch64",
-                    "channel": "ga",
-                    "repo_type": "rpm"
-                },
-                {
-                    "major_version": "8",
-                    "repoid": "el8-pgdg-centos8-sysupdates",
                     "arch": "ppc64le",
                     "channel": "ga",
                     "repo_type": "rpm"

--- a/vendors.d/postgresql_map.json.el9
+++ b/vendors.d/postgresql_map.json.el9
@@ -16,7 +16,6 @@
                     "source": "pgdg17",
                     "target": [
                         "el9-pgdg17",
-                        "el9-pgdg-rocky9-sysupdates",
                         "el9-pgdg-rhel9-extras"
                     ]
                 },
@@ -24,7 +23,6 @@
                     "source": "pgdg16",
                     "target": [
                         "el9-pgdg16",
-                        "el9-pgdg-rocky9-sysupdates",
                         "el9-pgdg-rhel9-extras"
                     ]
                 },
@@ -32,7 +30,6 @@
                     "source": "pgdg15",
                     "target": [
                         "el9-pgdg15",
-                        "el9-pgdg-rocky9-sysupdates",
                         "el9-pgdg-rhel9-extras"
                     ]
                 },
@@ -40,7 +37,6 @@
                     "source": "pgdg14",
                     "target": [
                         "el9-pgdg14",
-                        "el9-pgdg-rocky9-sysupdates",
                         "el9-pgdg-rhel9-extras"
                     ]
                 },
@@ -48,7 +44,6 @@
                     "source": "pgdg13",
                     "target": [
                         "el9-pgdg13",
-                        "el9-pgdg-rocky9-sysupdates",
                         "el9-pgdg-rhel9-extras"
                     ]
                 },
@@ -56,7 +51,6 @@
                     "source": "pgdg12",
                     "target": [
                         "el9-pgdg12",
-                        "el9-pgdg-rocky9-sysupdates",
                         "el9-pgdg-rhel9-extras"
                     ]
                 },
@@ -64,7 +58,6 @@
                     "source": "pgdg11",
                     "target": [
                         "el9-pgdg11",
-                        "el9-pgdg-rocky9-sysupdates",
                         "el9-pgdg-rhel9-extras"
                     ]
                 }
@@ -420,18 +413,6 @@
                     "major_version": "9",
                     "repoid": "el9-pgdg11",
                     "arch": "aarch64",
-                    "channel": "ga",
-                    "repo_type": "rpm"
-                }
-            ]
-        },
-        {
-            "pesid": "el9-pgdg-rocky9-sysupdates",
-            "entries": [
-                {
-                    "major_version": "9",
-                    "repoid": "el9-pgdg-rocky9-sysupdates",
-                    "arch": "x86_64",
                     "channel": "ga",
                     "repo_type": "rpm"
                 }


### PR DESCRIPTION
- remove "Supplementary ucommon RPMs" (sysupdates) repositories
- switch "PostgreSQL 12 for RHEL / CentOS" repositories into yum-archive.postgresql.org