### PR TITLE
Vendor MariaDB fixes. EL7. Data stream 3.x.

### DIFF
--- a/.github/workflows/elevate.yml
+++ b/.github/workflows/elevate.yml
@@ -370,24 +370,21 @@ jobs:
         fi
 
         if [ "${vendor}" = "mariadb" ]; then
-          # MariaDB server requires some packages from EPEL on EL7
-          if [ "${source_release}" = "7" ]; then
-            cat << 'MARIADB'> /etc/yum.repos.d/mariadb.repo
+          # The https://r.mariadb.com/downloads/mariadb_repo_setup doesn't work anymore
+          cat << 'MARIADB'> /etc/yum.repos.d/mariadb.repo
         [mariadb-main]
         name = MariaDB
-        baseurl = https://rpm.mariadb.org/11.rolling/rhel/$releasever/$basearch
+        baseurl = https://mirror.mariadb.org/yum/12.rolling/rhel/$releasever/$basearch
         gpgkey= https://rpm.mariadb.org/RPM-GPG-KEY-MariaDB
         gpgcheck=1
+        module_hotfixes=1
         MARIADB
-
+          if [ "${source_release}" = "7" ]; then
+            # MariaDB server requires some packages from EPEL on EL7
             sudo dnf -y -q install epel-release
-          else
-            # Skip 'mariadb-maxscale' repository as it is broken for EL7
-            # --os-* options to install on EuroLinux
-            sudo curl -LsS https://r.mariadb.com/downloads/mariadb_repo_setup | sudo bash -s -- \
-              --skip-maxscale \
-              --os-version=${source_release} \
-              --os-type=rhel
+          elif [ "${source_release}" = "8" ]; then
+            # All matches were filtered out by modular filtering for argument: MariaDB-server
+            sudo dnf -y -q module disable mariadb
           fi
           sudo dnf -y install MariaDB-server
           res=$?

--- a/leapp-data.spec
+++ b/leapp-data.spec
@@ -52,7 +52,7 @@
 
 Name:		leapp-data-%{dist_name}
 Version:	0.6
-Release:	11%{?dist}.%{pes_events_build_date}
+Release:	12%{?dist}.%{pes_events_build_date}
 Summary:	data for migrating tool
 Group:		Applications/Databases
 License:	ASL 2.0
@@ -177,6 +177,10 @@ python3 tests/check_debranding.py %{buildroot}%{_sysconfdir}/leapp/files/pes-eve
 
 
 %changelog
+* Wed Feb 11 2026 Yuriy Kohut <ykohut@almalinux.org> - 0.6-12.20241127
+- Vendor MariaDB:
+ - set baseurl to https://mirror.mariadb.org/yum/11.rolling/rhel/$releasever/$basearch
+
 * Mon Jan 19 2026 Yuriy Kohut <ykohut@almalinux.org> - 0.6-11.20241127
 - Vendor PostgreSQL:
  - remove Supplementary ucommon RPMs (sysupdates) repositories

--- a/vendors.d/mariadb.repo.el8
+++ b/vendors.d/mariadb.repo.el8
@@ -1,6 +1,6 @@
 [el8-mariadb-main]
 name = MariaDB Server
-baseurl = https://dlm.mariadb.com/repo/mariadb-server/11/yum/rhel/8/$basearch
+baseurl = https://mirror.mariadb.org/yum/11.rolling/rhel/8/$basearch
 gpgkey = file:///etc/leapp/files/vendors.d/rpm-gpg/mariadb-Server-GPG-KEY
 gpgcheck = 1
 enabled = 1

--- a/vendors.d/mariadb.repo.el9
+++ b/vendors.d/mariadb.repo.el9
@@ -1,6 +1,6 @@
 [el9-mariadb-main]
 name = MariaDB Server
-baseurl = https://dlm.mariadb.com/repo/mariadb-server/11/yum/rhel/9/$basearch
+baseurl = https://mirror.mariadb.org/yum/11.rolling/rhel/9/$basearch
 gpgkey = file:///etc/leapp/files/vendors.d/rpm-gpg/mariadb-Server-GPG-KEY
 gpgcheck = 1
 enabled = 1


### PR DESCRIPTION
Set `baseurl` to `https://mirror.mariadb.org/yum/11.rolling/rhel/$releasever/$basearch`
CI: create MariaDB repository config (for all EL releases)