### PR TITLE
Vendor MariaDB fixes. EL8, EL9 and EL10. Data stream 4.0.

### DIFF
--- a/.github/workflows/elevate.yml
+++ b/.github/workflows/elevate.yml
@@ -359,24 +359,21 @@ jobs:
         fi
 
         if [ "${vendor}" = "mariadb" ]; then
-          # MariaDB server requires some packages from EPEL on EL7
-          if [ "${source_release}" = "7" ]; then
-            cat << 'MARIADB'> /etc/yum.repos.d/mariadb.repo
+          # The https://r.mariadb.com/downloads/mariadb_repo_setup doesn't work anymore
+          cat << 'MARIADB'> /etc/yum.repos.d/mariadb.repo
         [mariadb-main]
         name = MariaDB
-        baseurl = https://rpm.mariadb.org/11.rolling/rhel/$releasever/$basearch
+        baseurl = https://mirror.mariadb.org/yum/12.rolling/rhel/$releasever/$basearch
         gpgkey= https://rpm.mariadb.org/RPM-GPG-KEY-MariaDB
         gpgcheck=1
+        module_hotfixes=1
         MARIADB
-
+          if [ "${source_release}" = "7" ]; then
+            # MariaDB server requires some packages from EPEL on EL7
             sudo dnf -y -q install epel-release
-          else
-            # Skip 'mariadb-maxscale' repository as it is broken for EL7
-            # --os-* options to install on EuroLinux
-            sudo curl -LsS https://r.mariadb.com/downloads/mariadb_repo_setup | sudo bash -s -- \
-              --skip-maxscale \
-              --os-version=${source_release} \
-              --os-type=rhel
+          elif [ "${source_release}" = "8" ]; then
+            # All matches were filtered out by modular filtering for argument: MariaDB-server
+            sudo dnf -y -q module disable mariadb
           fi
           sudo dnf -y install MariaDB-server
           res=$?

--- a/leapp-data.spec
+++ b/leapp-data.spec
@@ -47,7 +47,7 @@
 
 Name:		leapp-data-%{dist_name}
 Version:	0.10
-Release:	9%{?dist}.%{pes_events_build_date}
+Release:	10%{?dist}.%{pes_events_build_date}
 Summary:	data for migrating tool
 Group:		Applications/Databases
 License:	ASL 2.0
@@ -159,6 +159,10 @@ python3 tests/check_debranding.py %{buildroot}%{_sysconfdir}/leapp/files/pes-eve
 
 
 %changelog
+* Wed Feb 11 2026 Yuriy Kohut <ykohut@almalinux.org> - 0.10-10.20250729
+- Vendor MariaDB:
+ - change domain into mirror.mariadb.org and set path in baseurl for mariadb-main repository
+
 * Mon Jan 19 2026 Yuriy Kohut <ykohut@almalinux.org> - 0.10-9.20250729
 - Vendor PostgreSQL:
  - remove Supplementary ucommon RPMs (sysupdates) repositories

--- a/vendors.d/mariadb.repo.el10
+++ b/vendors.d/mariadb.repo.el10
@@ -1,6 +1,6 @@
 [el10-mariadb-main]
 name = MariaDB Server
-baseurl = https://dlm.mariadb.com/repo/mariadb-server/12.rolling/yum/rhel/10/$basearch
+baseurl = https://mirror.mariadb.org/yum/12.rolling/rhel/10/$basearch
 gpgkey = file:///etc/leapp/files/vendors.d/rpm-gpg/mariadb-Server-GPG-KEY
 gpgcheck = 1
 enabled = 1

--- a/vendors.d/mariadb.repo.el8
+++ b/vendors.d/mariadb.repo.el8
@@ -1,6 +1,6 @@
 [el8-mariadb-main]
 name = MariaDB Server
-baseurl = https://dlm.mariadb.com/repo/mariadb-server/12.rolling/yum/rhel/8/$basearch
+baseurl = https://mirror.mariadb.org/yum/11.rolling/rhel/8/$basearch
 gpgkey = file:///etc/leapp/files/vendors.d/rpm-gpg/mariadb-Server-GPG-KEY
 gpgcheck = 1
 enabled = 1

--- a/vendors.d/mariadb.repo.el9
+++ b/vendors.d/mariadb.repo.el9
@@ -1,6 +1,6 @@
 [el9-mariadb-main]
 name = MariaDB Server
-baseurl = https://dlm.mariadb.com/repo/mariadb-server/12.rolling/yum/rhel/9/$basearch
+baseurl = https://mirror.mariadb.org/yum/12.rolling/rhel/9/$basearch
 gpgkey = file:///etc/leapp/files/vendors.d/rpm-gpg/mariadb-Server-GPG-KEY
 gpgcheck = 1
 enabled = 1


### PR DESCRIPTION
Change domain into `mirror.mariadb.org` and set path in `baseurl` for `mariadb-main` repository
CI: create MariaDB repository config (for all EL releases)