### PR TITLE
Update Vendor PostreSQL: add new version 18, switch version 13 to yum-archive.postgresql.org

### DIFF
--- a/.github/workflows/elevate.yml
+++ b/.github/workflows/elevate.yml
@@ -395,8 +395,9 @@ jobs:
           case ${source_release} in
             7)
               sudo dnf -y -q install epel-release
-              # TODO: switch "PostgreSQL 12 for RHEL / CentOS" repository into yum-archive.postgresql.org
+              # TODO: switch "PostgreSQL 12 for EL" and "PostgreSQL 13 for EL" repositories into yum-archive.postgresql.org
               sed -i 's#download.postgresql.org/pub/repos/yum/12/#yum-archive.postgresql.org/12/#g' /etc/yum.repos.d/pgdg-redhat-all.repo
+              sed -i 's#download.postgresql.org/pub/repos/yum/13/#yum-archive.postgresql.org/13/#g' /etc/yum.repos.d/pgdg-redhat-all.repo
               ;;
             8)
               sudo dnf -y -q module disable postgresql;;

--- a/leapp-data.spec
+++ b/leapp-data.spec
@@ -52,7 +52,7 @@
 
 Name:		leapp-data-%{dist_name}
 Version:	0.6
-Release:	12%{?dist}.%{pes_events_build_date}
+Release:	13%{?dist}.%{pes_events_build_date}
 Summary:	data for migrating tool
 Group:		Applications/Databases
 License:	ASL 2.0
@@ -177,6 +177,12 @@ python3 tests/check_debranding.py %{buildroot}%{_sysconfdir}/leapp/files/pes-eve
 
 
 %changelog
+* Wed Mar 11 2026 Yuriy Kohut <ykohut@almalinux.org> - 0.6-13.20241127
+- Vendor PostgreSQL:
+ - add "PostgreSQL 18 for EL" repositories, 8 to 9 upgrade path
+ - include ppc64le architecture where it is available
+ - switch "PostgreSQL 13 for EL" repositories into yum-archive.postgresql.org
+
 * Wed Feb 11 2026 Yuriy Kohut <ykohut@almalinux.org> - 0.6-12.20241127
 - Vendor MariaDB:
  - set baseurl to https://mirror.mariadb.org/yum/11.rolling/rhel/$releasever/$basearch

--- a/vendors.d/postgresql.repo.el8
+++ b/vendors.d/postgresql.repo.el8
@@ -1,11 +1,11 @@
 #######################################################
-# PGDG Red Hat Enterprise Linux / Rocky repositories  #
+# PGDG EL repositories                                #
 #######################################################
 
-# PGDG Red Hat Enterprise Linux / Rocky stable common repository for all PostgreSQL versions
+# PGDG EL stable common repository for all PostgreSQL versions
 
 [el8-pgdg-common]
-name=PostgreSQL common RPMs for RHEL / Rocky 8 - $basearch
+name=PostgreSQL common RPMs EL 8 - $basearch
 baseurl=https://download.postgresql.org/pub/repos/yum/common/redhat/rhel-8-$basearch
 enabled=1
 gpgcheck=1
@@ -16,7 +16,7 @@ module_hotfixes=true
 # consul, haproxy, etc.
 
 [el8-pgdg-rhel8-extras]
-name=Extra packages to support some RPMs in the PostgreSQL RPM repo RHEL / Rocky 8 - $basearch
+name=Extra packages to support some RPMs in the PostgreSQL RPM repo EL 8 - $basearch
 baseurl=https://download.postgresql.org/pub/repos/yum/extras/redhat/rhel-8-$basearch
 enabled=0
 gpgcheck=1
@@ -24,10 +24,12 @@ gpgkey=file:///etc/leapp/files/vendors.d/rpm-gpg/postgresql.gpg
 module_hotfixes=true
 
 
-# PGDG Red Hat Enterprise Linux / Rocky stable repositories:
+# PGDG up to version 15 are available for EL 7,
+# so there is no reason to include newer PGDG yum configs for EL 8
+# PGDG EL stable repositories:
 
 [el8-pgdg15]
-name=PostgreSQL 15 for RHEL / Rocky 8 - $basearch
+name=PostgreSQL 15 EL 8 - $basearch
 baseurl=https://download.postgresql.org/pub/repos/yum/15/redhat/rhel-8-$basearch
 enabled=1
 gpgcheck=1
@@ -36,7 +38,7 @@ module_hotfixes=true
 
 
 [el8-pgdg14]
-name=PostgreSQL 14 for RHEL / Rocky 8 - $basearch
+name=PostgreSQL 14 EL 8 - $basearch
 baseurl=https://download.postgresql.org/pub/repos/yum/14/redhat/rhel-8-$basearch
 enabled=1
 gpgcheck=1
@@ -45,8 +47,8 @@ module_hotfixes=true
 
 
 [el8-pgdg13]
-name=PostgreSQL 13 for RHEL / Rocky 8 - $basearch
-baseurl=https://download.postgresql.org/pub/repos/yum/13/redhat/rhel-8-$basearch
+name=PostgreSQL 13 EL 8 - $basearch
+baseurl=https://yum-archive.postgresql.org/13/redhat/rhel-8-$basearch
 enabled=1
 gpgcheck=1
 gpgkey=file:///etc/leapp/files/vendors.d/rpm-gpg/postgresql.gpg
@@ -54,7 +56,7 @@ module_hotfixes=true
 
 
 [el8-pgdg12]
-name=PostgreSQL 12 for RHEL / Rocky 8 - $basearch
+name=PostgreSQL 12 EL 8 - $basearch
 baseurl=https://yum-archive.postgresql.org/12/redhat/rhel-8-$basearch
 enabled=1
 gpgcheck=1
@@ -63,7 +65,7 @@ module_hotfixes=true
 
 
 [el8-pgdg11]
-name=PostgreSQL 11 for RHEL / Rocky 8 - $basearch
+name=PostgreSQL 11 EL 8 - $basearch
 baseurl=https://yum-archive.postgresql.org/11/redhat/rhel-8-$basearch
 enabled=1
 gpgcheck=1

--- a/vendors.d/postgresql.repo.el9
+++ b/vendors.d/postgresql.repo.el9
@@ -1,11 +1,11 @@
 #######################################################
-# PGDG Red Hat Enterprise Linux / Rocky repositories  #
+# PGDG EL repositories  #
 #######################################################
 
-# PGDG Red Hat Enterprise Linux / Rocky stable common repository for all PostgreSQL versions
+# PGDG EL stable common repository for all PostgreSQL versions
 
 [el9-pgdg-common]
-name=PostgreSQL common RPMs for RHEL / Rocky / AlmaLinux 9 - $basearch
+name=PostgreSQL common RPMs for EL 9 - $basearch
 baseurl=https://download.postgresql.org/pub/repos/yum/common/redhat/rhel-9-$basearch
 enabled=1
 gpgcheck=1
@@ -15,58 +15,65 @@ gpgkey=file:///etc/leapp/files/vendors.d/rpm-gpg/postgresql.gpg
 # consul, haproxy, etc.
 
 [el9-pgdg-rhel9-extras]
-name=Extra packages to support some RPMs in the PostgreSQL RPM repo RHEL / Rocky / AlmaLinux 9 - $basearch
+name=Extra packages to support some RPMs in the PostgreSQL RPM repo EL 9 - $basearch
 baseurl=https://download.postgresql.org/pub/repos/yum/extras/redhat/rhel-9-$basearch
 enabled=0
 gpgcheck=1
 gpgkey=file:///etc/leapp/files/vendors.d/rpm-gpg/postgresql.gpg
 
-# PGDG Red Hat Enterprise Linux / Rocky stable repositories:
+# PGDG EL stable repositories:
+
+[el9-pgdg18]
+name=PostgreSQL 18 for EL 9 - $basearch
+baseurl=https://download.postgresql.org/pub/repos/yum/18/redhat/rhel-9-$basearch
+enabled=1
+gpgcheck=1
+gpgkey=file:///etc/leapp/files/vendors.d/rpm-gpg/postgresql.gpg
 
 [el9-pgdg17]
-name=PostgreSQL 17 for RHEL / Rocky / AlmaLinux 9 - $basearch
+name=PostgreSQL 17 for EL 9 - $basearch
 baseurl=https://download.postgresql.org/pub/repos/yum/17/redhat/rhel-9-$basearch
 enabled=1
 gpgcheck=1
 gpgkey=file:///etc/leapp/files/vendors.d/rpm-gpg/postgresql.gpg
 
 [el9-pgdg16]
-name=PostgreSQL 16 for RHEL / Rocky / AlmaLinux 9 - $basearch
+name=PostgreSQL 16 for EL 9 - $basearch
 baseurl=https://download.postgresql.org/pub/repos/yum/16/redhat/rhel-9-$basearch
 enabled=1
 gpgcheck=1
 gpgkey=file:///etc/leapp/files/vendors.d/rpm-gpg/postgresql.gpg
 
 [el9-pgdg15]
-name=PostgreSQL 15 for RHEL / Rocky / AlmaLinux 9 - $basearch
+name=PostgreSQL 15 for EL 9 - $basearch
 baseurl=https://download.postgresql.org/pub/repos/yum/15/redhat/rhel-9-$basearch
 enabled=1
 gpgcheck=1
 gpgkey=file:///etc/leapp/files/vendors.d/rpm-gpg/postgresql.gpg
 
 [el9-pgdg14]
-name=PostgreSQL 14 for RHEL / Rocky / AlmaLinux 9 - $basearch
+name=PostgreSQL 14 for EL 9 - $basearch
 baseurl=https://download.postgresql.org/pub/repos/yum/14/redhat/rhel-9-$basearch
 enabled=1
 gpgcheck=1
 gpgkey=file:///etc/leapp/files/vendors.d/rpm-gpg/postgresql.gpg
 
 [el9-pgdg13]
-name=PostgreSQL 13 for RHEL / Rocky / AlmaLinux 9 - $basearch
-baseurl=https://download.postgresql.org/pub/repos/yum/13/redhat/rhel-9-$basearch
+name=PostgreSQL 13 for EL 9 - $basearch
+baseurl=https://yum-archive.postgresql.org/13/redhat/rhel-9-$basearch
 enabled=1
 gpgcheck=1
 gpgkey=file:///etc/leapp/files/vendors.d/rpm-gpg/postgresql.gpg
 
 [el9-pgdg12]
-name=PostgreSQL 12 for RHEL / Rocky / AlmaLinux 9 - $basearch
+name=PostgreSQL 12 for EL 9 - $basearch
 baseurl=https://yum-archive.postgresql.org/12/redhat/rhel-9-$basearch
 enabled=1
 gpgcheck=1
 gpgkey=file:///etc/leapp/files/vendors.d/rpm-gpg/postgresql.gpg
 
 [el9-pgdg11]
-name=PostgreSQL 11 for RHEL / Rocky 9 - $basearch
+name=PostgreSQL 11 for EL 9 - $basearch
 baseurl=https://yum-archive.postgresql.org/11/redhat/rhel-9-$basearch
 enabled=1
 gpgcheck=1

--- a/vendors.d/postgresql_map.json.el9
+++ b/vendors.d/postgresql_map.json.el9
@@ -1,5 +1,5 @@
 {
-    "datetime": "202410141110Z",
+    "datetime": "202603111025Z",
     "version_format": "1.2.1",
     "mapping": [
         {
@@ -10,6 +10,13 @@
                     "source": "pgdg-common",
                     "target": [
                         "el9-pgdg-common"
+                    ]
+                },
+                {
+                    "source": "pgdg18",
+                    "target": [
+                        "el9-pgdg18",
+                        "el9-pgdg-rhel9-extras"
                     ]
                 },
                 {
@@ -92,6 +99,32 @@
             ]
         },
         {
+            "pesid": "pgdg18",
+            "entries": [
+                {
+                    "major_version": "8",
+                    "repoid": "pgdg18",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "pgdg18",
+                    "arch": "aarch64",
+                    "channel": "ga",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "pgdg18",
+                    "arch": "ppc64le",
+                    "channel": "ga",
+                    "repo_type": "rpm"
+                }
+            ]
+        },
+        {
             "pesid": "pgdg17",
             "entries": [
                 {
@@ -105,6 +138,13 @@
                     "major_version": "8",
                     "repoid": "pgdg17",
                     "arch": "aarch64",
+                    "channel": "ga",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "pgdg17",
+                    "arch": "ppc64le",
                     "channel": "ga",
                     "repo_type": "rpm"
                 }
@@ -286,6 +326,32 @@
             ]
         },
         {
+            "pesid": "el9-pgdg18",
+            "entries": [
+                {
+                    "major_version": "9",
+                    "repoid": "el9-pgdg18",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "el9-pgdg18",
+                    "arch": "aarch64",
+                    "channel": "ga",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "el9-pgdg18",
+                    "arch": "ppc64le",
+                    "channel": "ga",
+                    "repo_type": "rpm"
+                }
+            ]
+        },
+        {
             "pesid": "el9-pgdg17",
             "entries": [
                 {
@@ -299,6 +365,13 @@
                     "major_version": "9",
                     "repoid": "el9-pgdg17",
                     "arch": "aarch64",
+                    "channel": "ga",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "el9-pgdg17",
+                    "arch": "ppc64le",
                     "channel": "ga",
                     "repo_type": "rpm"
                 }
@@ -320,6 +393,13 @@
                     "arch": "aarch64",
                     "channel": "ga",
                     "repo_type": "rpm"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "el9-pgdg16",
+                    "arch": "ppc64le",
+                    "channel": "ga",
+                    "repo_type": "rpm"
                 }
             ]
         },
@@ -337,6 +417,13 @@
                     "major_version": "9",
                     "repoid": "el9-pgdg15",
                     "arch": "aarch64",
+                    "channel": "ga",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "el9-pgdg15",
+                    "arch": "ppc64le",
                     "channel": "ga",
                     "repo_type": "rpm"
                 }
@@ -358,6 +445,13 @@
                     "arch": "aarch64",
                     "channel": "ga",
                     "repo_type": "rpm"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "el9-pgdg14",
+                    "arch": "ppc64le",
+                    "channel": "ga",
+                    "repo_type": "rpm"
                 }
             ]
         },
@@ -375,6 +469,13 @@
                     "major_version": "9",
                     "repoid": "el9-pgdg13",
                     "arch": "aarch64",
+                    "channel": "ga",
+                    "repo_type": "rpm"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "el9-pgdg13",
+                    "arch": "ppc64le",
                     "channel": "ga",
                     "repo_type": "rpm"
                 }


### PR DESCRIPTION
Add "PostgreSQL 18 for EL" repositories, 8 to 9 upgrade path
Include ppc64le architecture where it is available
Switch "PostgreSQL 13 for EL" repositories into yum-archive.postgresql.org
CI: switch "PostgreSQL 13 for EL" repository into yum-archive.postgresql.org