### PR TITLE
Update Vendor PostreSQL: add new version 18, switch version 13 to yum-archive.postgresql.org

### DIFF
--- a/.github/workflows/elevate.yml
+++ b/.github/workflows/elevate.yml
@@ -384,8 +384,9 @@ jobs:
           case ${source_release} in
             7)
               sudo dnf -y -q install epel-release
-              # TODO: switch "PostgreSQL 12 for RHEL / CentOS" repository into yum-archive.postgresql.org
+              # TODO: switch "PostgreSQL 12 for EL" and "PostgreSQL 13 for EL" repositories into yum-archive.postgresql.org
               sed -i 's#download.postgresql.org/pub/repos/yum/12/#yum-archive.postgresql.org/12/#g' /etc/yum.repos.d/pgdg-redhat-all.repo
+              sed -i 's#download.postgresql.org/pub/repos/yum/13/#yum-archive.postgresql.org/13/#g' /etc/yum.repos.d/pgdg-redhat-all.repo
               ;;
             8)
               sudo dnf -y -q module disable postgresql;;

--- a/leapp-data.spec
+++ b/leapp-data.spec
@@ -47,7 +47,7 @@
 
 Name:		leapp-data-%{dist_name}
 Version:	0.11
-Release:	5%{?dist}.%{pes_events_build_date}
+Release:	6%{?dist}.%{pes_events_build_date}
 Summary:	data for migrating tool
 Group:		Applications/Databases
 License:	ASL 2.0
@@ -159,6 +159,12 @@ python3 tests/check_debranding.py %{buildroot}%{_sysconfdir}/leapp/files/pes-eve
 
 
 %changelog
+* Wed Mar 11 2026 Yuriy Kohut <ykohut@almalinux.org> - 0.11-6.20251222
+- Vendor PostgreSQL:
+ - add "PostgreSQL 18 for EL" repositories, 8 to 9 and 9 to 10 upgrade paths
+ - include ppc64le architecture where it is available
+ - switch "PostgreSQL 13 for EL" repositories into yum-archive.postgresql.org
+
 * Wed Feb 11 2026 Yuriy Kohut <ykohut@almalinux.org> - 0.11-5.20251222
 - Vendor MariaDB:
  - change domain into mirror.mariadb.org and set path in baseurl for mariadb-main repository

--- a/vendors.d/postgresql.repo.el10
+++ b/vendors.d/postgresql.repo.el10
@@ -1,11 +1,11 @@
 #########################################################################
-# PGDG Red Hat Enterprise Linux / Rocky / AlmaLinux repositories.	#
+# PGDG EL repositories.	                                                #
 #########################################################################
 
-# PGDG Red Hat Enterprise Linux / Rocky / AlmaLinux stable common repository for all PostgreSQL versions
+# PGDG EL stable common repository for all PostgreSQL versions
 
 [el10-pgdg-common]
-name=PostgreSQL common RPMs for RHEL / Rocky / AlmaLinux 10 - $basearch
+name=PostgreSQL common RPMs for EL 10 - $basearch
 baseurl=https://download.postgresql.org/pub/repos/yum/common/redhat/rhel-10-$basearch
 enabled=1
 gpgcheck=1
@@ -15,45 +15,52 @@ gpgkey=file:///etc/leapp/files/vendors.d/rpm-gpg/postgresql.gpg
 # consul, haproxy, etc.
 
 [el10-pgdg-rhel10-extras]
-name=Extra packages to support some RPMs in the PostgreSQL RPM repo RHEL / Rocky / AlmaLinux 10 - $basearch
+name=Extra packages to support some RPMs in the PostgreSQL RPM repo EL 10 - $basearch
 baseurl=https://download.postgresql.org/pub/repos/yum/extras/redhat/rhel-10-$basearch
 enabled=0
 gpgcheck=1
 gpgkey=file:///etc/leapp/files/vendors.d/rpm-gpg/postgresql.gpg
 
-# PGDG Red Hat Enterprise Linux / Rocky / AlmaLinux stable repositories:
+# PGDG EL stable repositories:
+
+[el10-pgdg18]
+name=PostgreSQL 18 for EL 10 - $basearch
+baseurl=https://download.postgresql.org/pub/repos/yum/18/redhat/rhel-10-$basearch
+enabled=1
+gpgcheck=1
+gpgkey=file:///etc/leapp/files/vendors.d/rpm-gpg/postgresql.gpg
 
 [el10-pgdg17]
-name=PostgreSQL 17 for RHEL / Rocky / AlmaLinux 10 - $basearch
+name=PostgreSQL 17 for EL 10 - $basearch
 baseurl=https://download.postgresql.org/pub/repos/yum/17/redhat/rhel-10-$basearch
 enabled=1
 gpgcheck=1
 gpgkey=file:///etc/leapp/files/vendors.d/rpm-gpg/postgresql.gpg
 
 [el10-pgdg16]
-name=PostgreSQL 16 for RHEL / Rocky / AlmaLinux 10 - $basearch
+name=PostgreSQL 16 for EL 10 - $basearch
 baseurl=https://download.postgresql.org/pub/repos/yum/16/redhat/rhel-10-$basearch
 enabled=1
 gpgcheck=1
 gpgkey=file:///etc/leapp/files/vendors.d/rpm-gpg/postgresql.gpg
 
 [el10-pgdg15]
-name=PostgreSQL 15 for RHEL / Rocky / AlmaLinux 10 - $basearch
+name=PostgreSQL 15 for EL 10 - $basearch
 baseurl=https://download.postgresql.org/pub/repos/yum/15/redhat/rhel-10-$basearch
 enabled=1
 gpgcheck=1
 gpgkey=file:///etc/leapp/files/vendors.d/rpm-gpg/postgresql.gpg
 
 [el10-pgdg14]
-name=PostgreSQL 14 for RHEL / Rocky / AlmaLinux 10 - $basearch
+name=PostgreSQL 14 for EL 10 - $basearch
 baseurl=https://download.postgresql.org/pub/repos/yum/14/redhat/rhel-10-$basearch
 enabled=1
 gpgcheck=1
 gpgkey=file:///etc/leapp/files/vendors.d/rpm-gpg/postgresql.gpg
 
 [el10-pgdg13]
-name=PostgreSQL 13 for RHEL / Rocky / AlmaLinux 10 - $basearch
-baseurl=https://download.postgresql.org/pub/repos/yum/13/redhat/rhel-10-$basearch
+name=PostgreSQL 13 for EL 10 - $basearch
+baseurl=https://yum-archive.postgresql.org/13/redhat/rhel-10-$basearch
 enabled=1
 gpgcheck=1
 gpgkey=file:///etc/leapp/files/vendors.d/rpm-gpg/postgresql.gpg

--- a/vendors.d/postgresql.repo.el8
+++ b/vendors.d/postgresql.repo.el8
@@ -1,11 +1,11 @@
 #######################################################
-# PGDG Red Hat Enterprise Linux / Rocky repositories  #
+# PGDG EL repositories                                #
 #######################################################
 
-# PGDG Red Hat Enterprise Linux / Rocky stable common repository for all PostgreSQL versions
+# PGDG EL stable common repository for all PostgreSQL versions
 
 [el8-pgdg-common]
-name=PostgreSQL common RPMs for RHEL / Rocky 8 - $basearch
+name=PostgreSQL common RPMs EL 8 - $basearch
 baseurl=https://download.postgresql.org/pub/repos/yum/common/redhat/rhel-8-$basearch
 enabled=1
 gpgcheck=1
@@ -16,7 +16,7 @@ module_hotfixes=true
 # consul, haproxy, etc.
 
 [el8-pgdg-rhel8-extras]
-name=Extra packages to support some RPMs in the PostgreSQL RPM repo RHEL / Rocky 8 - $basearch
+name=Extra packages to support some RPMs in the PostgreSQL RPM repo EL 8 - $basearch
 baseurl=https://download.postgresql.org/pub/repos/yum/extras/redhat/rhel-8-$basearch
 enabled=0
 gpgcheck=1
@@ -24,10 +24,12 @@ gpgkey=file:///etc/leapp/files/vendors.d/rpm-gpg/postgresql.gpg
 module_hotfixes=true
 
 
-# PGDG Red Hat Enterprise Linux / Rocky stable repositories:
+# PGDG up to version 15 are available for EL 7,
+# so there is no reason to include newer PGDG yum configs for EL 8
+# PGDG EL stable repositories:
 
 [el8-pgdg15]
-name=PostgreSQL 15 for RHEL / Rocky 8 - $basearch
+name=PostgreSQL 15 EL 8 - $basearch
 baseurl=https://download.postgresql.org/pub/repos/yum/15/redhat/rhel-8-$basearch
 enabled=1
 gpgcheck=1
@@ -36,7 +38,7 @@ module_hotfixes=true
 
 
 [el8-pgdg14]
-name=PostgreSQL 14 for RHEL / Rocky 8 - $basearch
+name=PostgreSQL 14 EL 8 - $basearch
 baseurl=https://download.postgresql.org/pub/repos/yum/14/redhat/rhel-8-$basearch
 enabled=1
 gpgcheck=1
@@ -45,8 +47,8 @@ module_hotfixes=true
 
 
 [el8-pgdg13]
-name=PostgreSQL 13 for RHEL / Rocky 8 - $basearch
-baseurl=https://download.postgresql.org/pub/repos/yum/13/redhat/rhel-8-$basearch
+name=PostgreSQL 13 EL 8 - $basearch
+baseurl=https://yum-archive.postgresql.org/13/redhat/rhel-8-$basearch
 enabled=1
 gpgcheck=1
 gpgkey=file:///etc/leapp/files/vendors.d/rpm-gpg/postgresql.gpg
@@ -54,7 +56,7 @@ module_hotfixes=true
 
 
 [el8-pgdg12]
-name=PostgreSQL 12 for RHEL / Rocky 8 - $basearch
+name=PostgreSQL 12 EL 8 - $basearch
 baseurl=https://yum-archive.postgresql.org/12/redhat/rhel-8-$basearch
 enabled=1
 gpgcheck=1
@@ -63,7 +65,7 @@ module_hotfixes=true
 
 
 [el8-pgdg11]
-name=PostgreSQL 11 for RHEL / Rocky 8 - $basearch
+name=PostgreSQL 11 EL 8 - $basearch
 baseurl=https://yum-archive.postgresql.org/11/redhat/rhel-8-$basearch
 enabled=1
 gpgcheck=1

--- a/vendors.d/postgresql.repo.el9
+++ b/vendors.d/postgresql.repo.el9
@@ -1,11 +1,11 @@
 #######################################################
-# PGDG Red Hat Enterprise Linux / Rocky repositories  #
+# PGDG EL repositories  #
 #######################################################
 
-# PGDG Red Hat Enterprise Linux / Rocky stable common repository for all PostgreSQL versions
+# PGDG EL stable common repository for all PostgreSQL versions
 
 [el9-pgdg-common]
-name=PostgreSQL common RPMs for RHEL / Rocky / AlmaLinux 9 - $basearch
+name=PostgreSQL common RPMs for EL 9 - $basearch
 baseurl=https://download.postgresql.org/pub/repos/yum/common/redhat/rhel-9-$basearch
 enabled=1
 gpgcheck=1
@@ -15,58 +15,65 @@ gpgkey=file:///etc/leapp/files/vendors.d/rpm-gpg/postgresql.gpg
 # consul, haproxy, etc.
 
 [el9-pgdg-rhel9-extras]
-name=Extra packages to support some RPMs in the PostgreSQL RPM repo RHEL / Rocky / AlmaLinux 9 - $basearch
+name=Extra packages to support some RPMs in the PostgreSQL RPM repo EL 9 - $basearch
 baseurl=https://download.postgresql.org/pub/repos/yum/extras/redhat/rhel-9-$basearch
 enabled=0
 gpgcheck=1
 gpgkey=file:///etc/leapp/files/vendors.d/rpm-gpg/postgresql.gpg
 
-# PGDG Red Hat Enterprise Linux / Rocky stable repositories:
+# PGDG EL stable repositories:
+
+[el9-pgdg18]
+name=PostgreSQL 18 for EL 9 - $basearch
+baseurl=https://download.postgresql.org/pub/repos/yum/18/redhat/rhel-9-$basearch
+enabled=1
+gpgcheck=1
+gpgkey=file:///etc/leapp/files/vendors.d/rpm-gpg/postgresql.gpg
 
 [el9-pgdg17]
-name=PostgreSQL 17 for RHEL / Rocky / AlmaLinux 9 - $basearch
+name=PostgreSQL 17 for EL 9 - $basearch
 baseurl=https://download.postgresql.org/pub/repos/yum/17/redhat/rhel-9-$basearch
 enabled=1
 gpgcheck=1
 gpgkey=file:///etc/leapp/files/vendors.d/rpm-gpg/postgresql.gpg
 
 [el9-pgdg16]
-name=PostgreSQL 16 for RHEL / Rocky / AlmaLinux 9 - $basearch
+name=PostgreSQL 16 for EL 9 - $basearch
 baseurl=https://download.postgresql.org/pub/repos/yum/16/redhat/rhel-9-$basearch
 enabled=1
 gpgcheck=1
 gpgkey=file:///etc/leapp/files/vendors.d/rpm-gpg/postgresql.gpg
 
 [el9-pgdg15]
-name=PostgreSQL 15 for RHEL / Rocky / AlmaLinux 9 - $basearch
+name=PostgreSQL 15 for EL 9 - $basearch
 baseurl=https://download.postgresql.org/pub/repos/yum/15/redhat/rhel-9-$basearch
 enabled=1
 gpgcheck=1
 gpgkey=file:///etc/leapp/files/vendors.d/rpm-gpg/postgresql.gpg
 
 [el9-pgdg14]
-name=PostgreSQL 14 for RHEL / Rocky / AlmaLinux 9 - $basearch
+name=PostgreSQL 14 for EL 9 - $basearch
 baseurl=https://download.postgresql.org/pub/repos/yum/14/redhat/rhel-9-$basearch
 enabled=1
 gpgcheck=1
 gpgkey=file:///etc/leapp/files/vendors.d/rpm-gpg/postgresql.gpg
 
 [el9-pgdg13]
-name=PostgreSQL 13 for RHEL / Rocky / AlmaLinux 9 - $basearch
-baseurl=https://download.postgresql.org/pub/repos/yum/13/redhat/rhel-9-$basearch
+name=PostgreSQL 13 for EL 9 - $basearch
+baseurl=https://yum-archive.postgresql.org/13/redhat/rhel-9-$basearch
 enabled=1
 gpgcheck=1
 gpgkey=file:///etc/leapp/files/vendors.d/rpm-gpg/postgresql.gpg
 
 [el9-pgdg12]
-name=PostgreSQL 12 for RHEL / Rocky / AlmaLinux 9 - $basearch
+name=PostgreSQL 12 for EL 9 - $basearch
 baseurl=https://yum-archive.postgresql.org/12/redhat/rhel-9-$basearch
 enabled=1
 gpgcheck=1
 gpgkey=file:///etc/leapp/files/vendors.d/rpm-gpg/postgresql.gpg
 
 [el9-pgdg11]
-name=PostgreSQL 11 for RHEL / Rocky 9 - $basearch
+name=PostgreSQL 11 for EL 9 - $basearch
 baseurl=https://yum-archive.postgresql.org/11/redhat/rhel-9-$basearch
 enabled=1
 gpgcheck=1

--- a/vendors.d/postgresql_map.json_template.el10
+++ b/vendors.d/postgresql_map.json_template.el10
@@ -13,6 +13,13 @@
                     ]
                 },
                 {
+                    "source": "pgdg18",
+                    "target": [
+                        "el10-pgdg18",
+                        "el10-pgdg-rhel10-extras"
+                    ]
+                },
+                {
                     "source": "pgdg17",
                     "target": [
                         "el10-pgdg17",
@@ -73,6 +80,35 @@
             ]
         },
         {
+            "pesid": "pgdg18",
+            "entries": [
+                {
+                    "major_version": "9",
+                    "repoid": "pgdg18",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "pgdg18",
+                    "arch": "aarch64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "pgdg18",
+                    "arch": "ppc64le",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
+                }
+            ]
+        },
+        {
             "pesid": "pgdg17",
             "entries": [
                 {
@@ -87,6 +123,14 @@
                     "major_version": "9",
                     "repoid": "pgdg17",
                     "arch": "aarch64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "pgdg17",
+                    "arch": "ppc64le",
                     "channel": "ga",
                     "repo_type": "rpm",
                     "distro": "{distro}"
@@ -111,6 +155,14 @@
                     "channel": "ga",
                     "repo_type": "rpm",
                     "distro": "{distro}"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "pgdg16",
+                    "arch": "ppc64le",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 }
             ]
         },
@@ -129,6 +181,14 @@
                     "major_version": "9",
                     "repoid": "pgdg15",
                     "arch": "aarch64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "pgdg15",
+                    "arch": "ppc64le",
                     "channel": "ga",
                     "repo_type": "rpm",
                     "distro": "{distro}"
@@ -153,6 +213,14 @@
                     "channel": "ga",
                     "repo_type": "rpm",
                     "distro": "{distro}"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "pgdg14",
+                    "arch": "ppc64le",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 }
             ]
         },
@@ -171,6 +239,14 @@
                     "major_version": "9",
                     "repoid": "pgdg13",
                     "arch": "aarch64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "pgdg13",
+                    "arch": "ppc64le",
                     "channel": "ga",
                     "repo_type": "rpm",
                     "distro": "{distro}"
@@ -199,6 +275,35 @@
             ]
         },
         {
+            "pesid": "el10-pgdg18",
+            "entries": [
+                {
+                    "major_version": "10",
+                    "repoid": "el10-pgdg18",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
+                },
+                {
+                    "major_version": "10",
+                    "repoid": "el10-pgdg18",
+                    "arch": "aarch64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
+                },
+                {
+                    "major_version": "10",
+                    "repoid": "el10-pgdg18",
+                    "arch": "ppc64le",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
+                }
+            ]
+        },
+        {
             "pesid": "el10-pgdg17",
             "entries": [
                 {
@@ -213,6 +318,14 @@
                     "major_version": "10",
                     "repoid": "el10-pgdg17",
                     "arch": "aarch64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
+                },
+                {
+                    "major_version": "10",
+                    "repoid": "el10-pgdg17",
+                    "arch": "ppc64le",
                     "channel": "ga",
                     "repo_type": "rpm",
                     "distro": "{distro}"
@@ -237,6 +350,14 @@
                     "channel": "ga",
                     "repo_type": "rpm",
                     "distro": "{distro}"
+                },
+                {
+                    "major_version": "10",
+                    "repoid": "el10-pgdg16",
+                    "arch": "ppc64le",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 }
             ]
         },
@@ -255,6 +376,14 @@
                     "major_version": "10",
                     "repoid": "el10-pgdg15",
                     "arch": "aarch64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
+                },
+                {
+                    "major_version": "10",
+                    "repoid": "el10-pgdg15",
+                    "arch": "ppc64le",
                     "channel": "ga",
                     "repo_type": "rpm",
                     "distro": "{distro}"
@@ -279,6 +408,14 @@
                     "channel": "ga",
                     "repo_type": "rpm",
                     "distro": "{distro}"
+                },
+                {
+                    "major_version": "10",
+                    "repoid": "el10-pgdg14",
+                    "arch": "ppc64le",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 }
             ]
         },
@@ -297,6 +434,14 @@
                     "major_version": "10",
                     "repoid": "el10-pgdg13",
                     "arch": "aarch64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
+                },
+                {
+                    "major_version": "10",
+                    "repoid": "el10-pgdg13",
+                    "arch": "ppc64le",
                     "channel": "ga",
                     "repo_type": "rpm",
                     "distro": "{distro}"

--- a/vendors.d/postgresql_map.json_template.el9
+++ b/vendors.d/postgresql_map.json_template.el9
@@ -1,5 +1,5 @@
 {
-    "datetime": "202506241030Z",
+    "datetime": "202603111025Z",
     "version_format": "1.3.0",
     "mapping": [
         {
@@ -10,6 +10,13 @@
                     "source": "pgdg-common",
                     "target": [
                         "el9-pgdg-common"
+                    ]
+                },
+                {
+                    "source": "pgdg18",
+                    "target": [
+                        "el9-pgdg18",
+                        "el9-pgdg-rhel9-extras"
                     ]
                 },
                 {
@@ -95,6 +102,35 @@
             ]
         },
         {
+            "pesid": "pgdg18",
+            "entries": [
+                {
+                    "major_version": "8",
+                    "repoid": "pgdg18",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "pgdg18",
+                    "arch": "aarch64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "pgdg18",
+                    "arch": "ppc64le",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
+                }
+            ]
+        },
+        {
             "pesid": "pgdg17",
             "entries": [
                 {
@@ -109,6 +145,14 @@
                     "major_version": "8",
                     "repoid": "pgdg17",
                     "arch": "aarch64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
+                },
+                {
+                    "major_version": "8",
+                    "repoid": "pgdg17",
+                    "arch": "ppc64le",
                     "channel": "ga",
                     "repo_type": "rpm",
                     "distro": "{distro}"
@@ -311,6 +355,35 @@
             ]
         },
         {
+            "pesid": "el9-pgdg18",
+            "entries": [
+                {
+                    "major_version": "9",
+                    "repoid": "el9-pgdg18",
+                    "arch": "x86_64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "el9-pgdg18",
+                    "arch": "aarch64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "el9-pgdg18",
+                    "arch": "ppc64le",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
+                }
+            ]
+        },
+        {
             "pesid": "el9-pgdg17",
             "entries": [
                 {
@@ -325,6 +398,14 @@
                     "major_version": "9",
                     "repoid": "el9-pgdg17",
                     "arch": "aarch64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "el9-pgdg17",
+                    "arch": "ppc64le",
                     "channel": "ga",
                     "repo_type": "rpm",
                     "distro": "{distro}"
@@ -349,6 +430,14 @@
                     "channel": "ga",
                     "repo_type": "rpm",
                     "distro": "{distro}"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "el9-pgdg16",
+                    "arch": "ppc64le",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 }
             ]
         },
@@ -367,6 +456,14 @@
                     "major_version": "9",
                     "repoid": "el9-pgdg15",
                     "arch": "aarch64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "el9-pgdg15",
+                    "arch": "ppc64le",
                     "channel": "ga",
                     "repo_type": "rpm",
                     "distro": "{distro}"
@@ -391,6 +488,14 @@
                     "channel": "ga",
                     "repo_type": "rpm",
                     "distro": "{distro}"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "el9-pgdg14",
+                    "arch": "ppc64le",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
                 }
             ]
         },
@@ -409,6 +514,14 @@
                     "major_version": "9",
                     "repoid": "el9-pgdg13",
                     "arch": "aarch64",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
+                },
+                {
+                    "major_version": "9",
+                    "repoid": "el9-pgdg13",
+                    "arch": "ppc64le",
                     "channel": "ga",
                     "repo_type": "rpm",
                     "distro": "{distro}"


### PR DESCRIPTION
Add "PostgreSQL 18 for EL" repositories, 8 to 9 and 9 to 10 upgrade paths
Include ppc64le architecture where it is available
Switch "PostgreSQL 13 for EL" repositories into yum-archive.postgresql.org

CI: switch "PostgreSQL 13 for EL" repository into yum-archive.postgresql.org