### PR TITLE
chore(ci): Mitigate 'Legacy network configuration found' inhibitor

### DIFF
--- a/.github/workflows/elevate.yml
+++ b/.github/workflows/elevate.yml
@@ -259,13 +259,15 @@ jobs:
             8)
               sed -i 's/\(PermitRootLogin yes\)/\1 # inhibited/g' /etc/ssh/sshd_config;
               sed -i s/^AllowZoneDrifting=.*/AllowZoneDrifting=no/ /etc/firewalld/firewalld.conf;
+              nmcli conn migrate
               leapp answer --section check_vdo.confirm=True;
               res=$?
               ;;
             9)
               # TODO: workaround for CentOS Stream 9 SHA1 deprecated signature
               [ ${{ env.source_distro }} = "centos" ] && rpm -e gpg-pubkey-8483c65d-5ccc5b19 || true
-              res=0
+              nmcli conn migrate
+              res=$?
               ;;
           esac
         fi


### PR DESCRIPTION
The reason is AlmaLinux Vagrant boxes now include cloud-init. It generates network configuration files in legacy "ifcfg" format. Converting of the configuration into NetworkManager native "keyfile" format is required.