### PR TITLE
feat(epel-altarch-x86_64_v2): add 9->10 PES and map data for epel-release->epel-release-almalinux-altarch upgrade

### DIFF
--- a/leapp-data.spec
+++ b/leapp-data.spec
@@ -19,7 +19,7 @@
 
 Name:       leapp-data
 Version:    0.12
-Release:    1%{?dist}.%{pes_events_build_date}
+Release:    2%{?dist}.%{pes_events_build_date}
 Summary:    Data for ELevate migration tool
 Group:      Applications/Databases
 License:    ASL 2.0
@@ -212,6 +212,9 @@ done)}
 
 
 %changelog
+* Mon Apr 20 2026 Yuriy Kohut <ykohut@almalinux.org> - 0.12-2.20251222
+- Vendor EPEL: add 9->10 (x86_64_v2) data for epel-release->epel-release-almalinux-altarch package upgrade
+
 * Tue Apr 14 2026 Yuriy Kohut <ykohut@almalinux.org> - 0.12-1.20251222
 - leapp-data-almalinux-x86_64_v2 and leapp-data-almalinux-kitten-x86_64_v2 new packages to upgrade AlmaLinux 9->10 x86_64 v2
 - Enable EPEL Vendor for AlmaLinux 9->10 x86_64_v2 upgrade

--- a/vendors.d/epel.repo.el10.almalinux-kitten-x86_64_v2
+++ b/vendors.d/epel.repo.el10.almalinux-kitten-x86_64_v2
@@ -1,4 +1,4 @@
-[el10-epel]
+[el10-epel-almalinux-altarch]
 name=Extra Packages for Enterprise Linux $releasever from AlmaLinux - x86_64_v2
 # mirrorlist=https://epel.mirrors.almalinux.org/mirrorlist/10/epel?arch=x86_64_v2
 baseurl=https://epel.repo.almalinux.org/10/x86_64_v2/

--- a/vendors.d/epel.repo.el10.almalinux-x86_64_v2
+++ b/vendors.d/epel.repo.el10.almalinux-x86_64_v2
@@ -1,4 +1,4 @@
-[el10-epel]
+[el10-epel-almalinux-altarch]
 name=Extra Packages for Enterprise Linux $releasever from AlmaLinux - x86_64_v2
 # mirrorlist=https://epel.mirrors.almalinux.org/mirrorlist/10z/epel?arch=x86_64_v2
 baseurl=https://epel.repo.almalinux.org/10z/x86_64_v2/

--- a/vendors.d/epel_map.json_template.el10
+++ b/vendors.d/epel_map.json_template.el10
@@ -15,6 +15,12 @@
                 {
                     "source": "epel",
                     "target": [
+                        "el10-epel-almalinux-altarch"
+                    ]
+                },
+                {
+                    "source": "epel",
+                    "target": [
                         "el10-baseos"
                     ]
                 },
@@ -102,6 +108,19 @@
                     "major_version": "10",
                     "repoid": "el10-epel",
                     "arch": "s390x",
+                    "channel": "ga",
+                    "repo_type": "rpm",
+                    "distro": "{distro}"
+                }
+            ]
+        },
+        {
+            "pesid": "el10-epel-almalinux-altarch",
+            "entries": [
+                {
+                    "major_version": "10",
+                    "repoid": "el10-epel-almalinux-altarch",
+                    "arch": "x86_64",
                     "channel": "ga",
                     "repo_type": "rpm",
                     "distro": "{distro}"

--- a/vendors.d/epel_pes.json_template
+++ b/vendors.d/epel_pes.json_template
@@ -353243,6 +353243,45 @@
                 "minor_version": 0,
                 "os_name": "{os_name}"
             }
+        },
+        {
+            "action": 3,
+            "architectures": [
+                "x86_64"
+            ],
+            "description": "",
+            "id": 36158,
+            "in_packageset": {
+                "package": [
+                    {
+                        "module_stream": null,
+                        "name": "epel-release",
+                        "repository": "extras"
+                    }
+                ],
+                "set_id": 36494
+            },
+            "initial_release": {
+                "major_version": 9,
+                "minor_version": 0,
+                "os_name": "{os_name}"
+            },
+            "is_approved": true,
+            "out_packageset": {
+                "package": [
+                    {
+                        "module_stream": null,
+                        "name": "epel-release-almalinux-altarch",
+                        "repository": "el10-epel-almalinux-altarch"
+                    }
+                ],
+                "set_id": 36495
+            },
+            "release": {
+                "major_version": 10,
+                "minor_version": 0,
+                "os_name": "{os_name}"
+            }
         }
     ],
     "provided_data_streams": [


### PR DESCRIPTION
Rename the el10 EPEL x86_64_v2 repo section to el10-epel-almalinux-altarch, map it from the source epel repo (x86_64 only), and add an action:3 PES entry so that epel-release from the extras repo is replaced by epel-release-almalinux-altarch from el10-epel-almalinux-altarch during the 9->10 x86_64_v2 upgrade.

Bump the package release.